### PR TITLE
collect download files from bintray

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,13 @@ dlHttpFiles() {
       dir=${WORKSPACE}/build-deps/on-http/static/http/common
   fi
   mkdir -p ${dir} && cd ${dir}
+  # pull down index from bintray repo and parse files from index
+  wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
+      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+  for i in `cat ./files`; do
+    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/${i}
+  done
+  # attempt to pull down user specified static files
   for i in ${HTTP_STATIC_FILES}; do
      wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/builds/${i}
   done
@@ -28,6 +35,13 @@ dlTftpFiles() {
       dir=${WORKSPACE}/build-deps/on-tftp/static/tftp
   fi
   mkdir -p ${dir} && cd ${dir}
+  # pull down index from bintray repo and parse files from index
+  wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/ && \
+      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+  for i in `cat ./files`; do
+    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/${i}
+  done
+  # attempt to pull down user specified static files
   for i in ${TFTP_STATIC_FILES}; do
     wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/ipxe/${i}
   done

--- a/test.sh.in
+++ b/test.sh.in
@@ -17,6 +17,13 @@ dlHttpFiles() {
       dir=${WORKSPACE}/build-deps/on-http/static/http/common
   fi
   mkdir -p ${dir} && cd ${dir}
+  # pull down index from bintray repo and parse files from index
+  wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
+      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+  for i in `cat ./files`; do
+    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/${i}
+  done
+  # attempt to pull down user specified static files
   for i in ${HTTP_STATIC_FILES}; do
      wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/builds/${i}
   done
@@ -28,6 +35,13 @@ dlTftpFiles() {
       dir=${WORKSPACE}/build-deps/on-tftp/static/tftp
   fi
   mkdir -p ${dir} && cd ${dir}
+  # pull down index from bintray repo and parse files from index
+  wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/ && \
+      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+  for i in `cat ./files`; do
+    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/${i}
+  done
+  # attempt to pull down user specified static files
   for i in ${TFTP_STATIC_FILES}; do
     wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/ipxe/${i}
   done


### PR DESCRIPTION
@RackHD/corecommitters Changing Jenkins to parse the bintray file list.  The optional HTTP_STATIC_FILES build parameter will remain but default to empty. 
