### PR TITLE
When unit-test script fail, make the shell return value not zero

### DIFF
--- a/unit-test.sh
+++ b/unit-test.sh
@@ -9,4 +9,3 @@ runUnitTest() {
    #cp -rf report.xml ${WORKSPACE}/xunit-reports/mocha-report.xml
 }
 runUnitTest
-exit 0

--- a/unit-test.sh.in
+++ b/unit-test.sh.in
@@ -9,4 +9,3 @@ runUnitTest() {
    #cp -rf report.xml ${WORKSPACE}/xunit-reports/mocha-report.xml
 }
 runUnitTest
-exit 0


### PR DESCRIPTION
@jlongever 

So far, when unit-test fails, the unit-test jenkins job still being green because of the "exit 0" in unit-tes.sh, which is confusing .
example: http://rackhdci.lss.emc.com/job/Templates/job/unit-tests/8509/console

the motivation/background:
 Paul.S told me an on-core PR fails:  http://rackhdci.lss.emc.com/job/on-core/833/
the direct  error message in  http://rackhdci.lss.emc.com/job/on-dhcp-proxy/926/         was:

```
+ ./pre-deploy.sh
Running pre-deploy script
./pre-deploy.sh: line 4: ./node_modules/.bin/istanbul: No such file or directory
```

but actually, that's because in unit-test job, error encounter as below( reason still under investigation), so npm install doesn't finish. if unit-test can fail out, then the downstream on-dhcp-proxy will not be triggered ,and more easy to debug

```

npm WARN excluding symbolic link chrome-extension/visualize -> ../visualize
npm ERR! Failed resolving git HEAD (https://github.com/RackHD/on-core.git) fatal: bad object 8232881895225ea48893418d9f0579e9da11aa2a
npm ERR! Failed resolving git HEAD (https://github.com/RackHD/on-core.git) 
npm ERR! Error: Command failed: fatal: bad object 8232881895225ea48893418d9f0579e9da11aa2a
npm ERR! 
npm ERR!     at ChildProcess.exithandler (child_process.js:637:15)
npm ERR!     at ChildProcess.EventEmitter.emit (events.js:98:17)
npm ERR!     at maybeClose (child_process.js:743:16)
npm ERR!     at Socket.<anonymous> (child_process.js:956:11)
npm ERR!     at Socket.EventEmitter.emit (events.js:95:17)
npm ERR!     at Pipe.close (net.js:466:12)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
```

@PengTian0  @changev 
