### PR TITLE
add sub builds information to comments to github

### DIFF
--- a/post-result.py
+++ b/post-result.py
@@ -7,7 +7,7 @@ import sys
 '''
 Usage:
 python post-result.py \
-https://api.github.com/repos/PengTian0/on-core/issues/${PullRequestId}/comments \
+https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
 http://rackhdci.lss.emc.com \
 http://rackhdci.lss.emc.com/job/on-core/851/ \
 '#851'

--- a/post-result.py
+++ b/post-result.py
@@ -4,32 +4,215 @@ import os
 import subprocess
 import sys
 
+'''
+Usage:
+python post-result.py \
+https://api.github.com/repos/PengTian0/on-core/issues/${PullRequestId}/comments \
+http://rackhdci.lss.emc.com \
+http://rackhdci.lss.emc.com/job/on-core/851/ \
+'#851'
+'''
+
 with open('${HOME}/.ghtoken', 'r') as file:
     TOKEN = file.read().strip('\n')
 
 HEADERS = {'Authorization': 'token %s' % TOKEN}
+
 GITHUB_PR_URL = sys.argv[1]
 JENKINS_URL = sys.argv[2]
-BUILD_NAME = sys.argv[3]
+BUILD_URL = sys.argv[3]
+BUILD_NAME = sys.argv[4]
+FAIL_REPORTS = []
 
-r = requests.get(JENKINS_URL)
-if r.status_code == 200:
+def get_build_data(build_url):
+    '''
+    get the json data of a build
+    :param build_url: the url of a build in jenkins
+    :return: json data of the build if succeed to get the json data
+             None if failed to get the json data
+    '''
+    r = requests.get(build_url + "/api/json?depth=2")
+    if is_error_response(r):
+        print "Failed to get api json of {0}".format(build_url)
+        print r.text
+        print r.status_code
+        return None
+    else:
+        data = r.json()
+        return data
+
+def get_test_report(build_url):
+    '''
+    get the test report of a build
+    :param build_url: the url of a build in jenkins
+    :return: json data of test report of the build if succeed to get the json data
+             None if failed to get the json data
+    '''
+    r = requests.get(build_url + "/testReport/api/json")
+    if is_error_response(r):
+        print "Failed to get testReport of {0}".format(build_url)
+        print r.text
+        print r.status_code
+        return None
+    else:
+        data = r.json()
+        return data     
+
+def generate_failure_report(build_url, build_name):
+    '''
+    get the test report and generate a report which contains the error log
+    :param build_url: the url of a build in jenkins
+    :param build_name: build name consist of job name and build number
+    :return: failure report if succeed to get the json data of test report 
+             None if failed to get the json data of test report
+    '''
+    data = get_test_report(build_url)
+    failure_report = "\n"
+    failure_report += "BUILD " + build_name + "  Error Logs:\n\n"
+    if data:
+        failCount = int(data.get('failCount'))
+        if failCount > 0:
+            for suite in data['suites']:
+                for case in suite['cases']:
+                    if case['errorDetails']:
+                        name = case['name']
+                        errorDetails = case['errorDetails']
+                        errorStackTrace = case['errorStackTrace']
+                        name = "Test Name: " + name + "\n"
+                        details = "Error Details: " + errorDetails + "\n"
+                        stack = "Stack Trace: " + errorStackTrace + "\n"
+                        failure_report += name + details + stack + "\n"
+        return failure_report
+    else:
+        return None
+
+def get_sub_builds(build_url, depth):
+    '''
+    get sub builds of a build
+    :param build_url: the url of a build in jenkins
+    :param depth: the depth of the nested sub build
+    :return: a list of string which contains the result , build number of the sub builds
+    '''
+    build_data = get_build_data(build_url)
+    outputs = []
+    if build_data:
+        if 'subBuilds' in build_data:
+            '''
+            get sub builds results
+            '''
+            for subBuild in build_data['subBuilds']:
+                output = ""
+                sub_build_name = subBuild['jobName'] + "  #" + str(subBuild['buildNumber'])
+                sub_build_result = subBuild['result']
+                sub_build_url = JENKINS_URL + "/" + subBuild['url']
+                for x in range(depth):
+                    output += "   "
+                output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
+
+                sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                if len(sub_outputs) >0 :
+                    for sub_output in sub_outputs:
+                        output += sub_output
+                outputs.append(output)
+                if sub_build_result != "SUCCESS":
+                    failure_report = generate_failure_report(sub_build_url, sub_build_name)
+                    FAIL_REPORTS.append(failure_report)
+
+        if 'actions' in build_data:
+            for action in build_data['actions']:
+                if 'triggeredBuilds' in action:
+                    '''
+                    get triggered builds results
+                    '''
+                    for subBuild in action['triggeredBuilds']:
+                        output = "\n"
+                        sub_build_name = subBuild['fullDisplayName']
+                        sub_build_result = subBuild['result']
+                        sub_build_url = subBuild['url']
+                        for x in range(depth):
+                            output += "   "
+                        output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
+                        sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                        if len(sub_outputs) > 0:
+                            for sub_output in sub_outputs:
+                                output += sub_output
+                        outputs.append(output)
+                        if sub_build_result != "SUCCESS":
+                            failure_report = generate_failure_report(sub_build_url, sub_build_name)
+                            FAIL_REPORTS.append(failure_report)
+    return outputs
+
+def is_error_response(res):
+    """
+    check the status code of http response
+    :param res: http response
+    :return: True if the status code less than 200 or larger than 206;
+             False if the status code is between 200 and 206
+    """
+    if res is None:
+        return True
+    if res.status_code < 200 or res.status_code > 299:
+        return True
+    return False
+
+def post_comments_to_github(comments, github_pr_url, headers):
+    '''
+    post comments to github Pull Request
+    :param comments: comments to be posted to Pull Request
+    '''
+    body = { "body" : comments }
+    r = requests.post(github_pr_url,headers=headers,data=json.dumps(body))
+    if is_error_response(r):
+        print "Failed to post comments to pull request {0}".format(github_pr_url)
+        print r.text
+        print r.status_code
+        sys.exit(1)
+    else:
+        print "Succeed to post comments to pull request {0}".format(github_pr_url)
+        return
+                
+def main():
     OUTPUT = '```\n'
-    OUTPUT += "*** BUILD " + BUILD_NAME + " ***\n"
-    data = r.json()
-    failCount = int(data.get('failCount'))
-    if failCount > 0:
-        for suite in data['suites']:
-            for case in suite['cases']:
-                if case['errorDetails']:
-                    name = case['name']
-                    errorDetails = case['errorDetails']
-                    errorStackTrace = case['errorStackTrace']
-                    name = "Test Name: " + name + "\n"
-                    details = "Error Details: " + errorDetails + "\n"
-                    stack = "Stack Trace: " + errorStackTrace + "\n"
-                    OUTPUT += name + details + stack + "\n"
-    OUTPUT += "```\n"
-    body = { "body" : OUTPUT }
-    r = requests.post(GITHUB_PR_URL,headers=HEADERS,data=json.dumps(body))
-    print r.status_code
+    job_name = BUILD_URL.split('/')[-3]
+    build_number = BUILD_URL.split('/')[-2]
+    
+    try:
+        build_data = get_build_data(BUILD_URL)
+        if build_data:
+            build_name = build_data['fullDisplayName']
+            build_result = build_data['result']
+            OUTPUT +=  "BUILD " + build_name + " : " + build_result + "\n"
+
+            sub_build_outputs = get_sub_builds(BUILD_URL, 1)
+            for sub_output in sub_build_outputs:
+                OUTPUT += sub_output
+
+            if build_result != "SUCCESS":
+                failure_report = generate_failure_report(BUILD_URL, build_name)
+                FAIL_REPORTS.append(failure_report)
+
+            if len(FAIL_REPORTS) > 0:
+                for fail_report in FAIL_REPORTS:
+                    OUTPUT += fail_report
+        else:
+            build_name = job_name + " #" + build_number   
+            failure_report = generate_failure_report(BUILD_URL, build_name)
+            FAIL_REPORTS.append(failure_report)
+
+            if len(FAIL_REPORTS) > 0:
+                for fail_report in FAIL_REPORTS:
+                    OUTPUT += fail_report
+            else:
+                OUTPUT += "*** BUILD " + build_name + " ***\n"
+    except Exception as e:
+        print e
+        sys.exit(1)
+    finally:
+        if OUTPUT == "```\n":
+            build_name = job_name + " #" + build_number
+            OUTPUT += "*** BUILD " + build_name + " ***\n"
+        OUTPUT += "```\n"
+        post_comments_to_github(OUTPUT, GITHUB_PR_URL, HEADERS)
+
+if __name__ == "__main__":
+    main()

--- a/post-result.py.in
+++ b/post-result.py.in
@@ -7,7 +7,7 @@ import sys
 '''
 Usage:
 python post-result.py \
-https://api.github.com/repos/PengTian0/on-core/issues/${PullRequestId}/comments \
+https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
 http://rackhdci.lss.emc.com \
 http://rackhdci.lss.emc.com/job/on-core/851/ \
 '#851'

--- a/post-result.py.in
+++ b/post-result.py.in
@@ -159,6 +159,10 @@ def post_comments_to_github(comments, github_pr_url, headers):
     '''
     post comments to github Pull Request
     :param comments: comments to be posted to Pull Request
+    :param github_pr_url: the url of the PR
+    :param headers: the request headers which usually contains the "Authorization" field
+    :return: exit with error code 1 if get bad response for the request
+             return null if get successful response
     '''
     body = { "body" : comments }
     r = requests.post(github_pr_url,headers=headers,data=json.dumps(body))

--- a/post-result.py.in
+++ b/post-result.py.in
@@ -4,32 +4,215 @@ import os
 import subprocess
 import sys
 
+'''
+Usage:
+python post-result.py \
+https://api.github.com/repos/PengTian0/on-core/issues/${PullRequestId}/comments \
+http://rackhdci.lss.emc.com \
+http://rackhdci.lss.emc.com/job/on-core/851/ \
+'#851'
+'''
+
 with open('${HOME}/.ghtoken', 'r') as file:
     TOKEN = file.read().strip('\n')
 
 HEADERS = {'Authorization': 'token %s' % TOKEN}
+
 GITHUB_PR_URL = sys.argv[1]
 JENKINS_URL = sys.argv[2]
-BUILD_NAME = sys.argv[3]
+BUILD_URL = sys.argv[3]
+BUILD_NAME = sys.argv[4]
+FAIL_REPORTS = []
 
-r = requests.get(JENKINS_URL)
-if r.status_code == 200:
+def get_build_data(build_url):
+    '''
+    get the json data of a build
+    :param build_url: the url of a build in jenkins
+    :return: json data of the build if succeed to get the json data
+             None if failed to get the json data
+    '''
+    r = requests.get(build_url + "/api/json?depth=2")
+    if is_error_response(r):
+        print "Failed to get api json of {0}".format(build_url)
+        print r.text
+        print r.status_code
+        return None
+    else:
+        data = r.json()
+        return data
+
+def get_test_report(build_url):
+    '''
+    get the test report of a build
+    :param build_url: the url of a build in jenkins
+    :return: json data of test report of the build if succeed to get the json data
+             None if failed to get the json data
+    '''
+    r = requests.get(build_url + "/testReport/api/json")
+    if is_error_response(r):
+        print "Failed to get testReport of {0}".format(build_url)
+        print r.text
+        print r.status_code
+        return None
+    else:
+        data = r.json()
+        return data     
+
+def generate_failure_report(build_url, build_name):
+    '''
+    get the test report and generate a report which contains the error log
+    :param build_url: the url of a build in jenkins
+    :param build_name: build name consist of job name and build number
+    :return: failure report if succeed to get the json data of test report 
+             None if failed to get the json data of test report
+    '''
+    data = get_test_report(build_url)
+    failure_report = "\n"
+    failure_report += "BUILD " + build_name + "  Error Logs:\n\n"
+    if data:
+        failCount = int(data.get('failCount'))
+        if failCount > 0:
+            for suite in data['suites']:
+                for case in suite['cases']:
+                    if case['errorDetails']:
+                        name = case['name']
+                        errorDetails = case['errorDetails']
+                        errorStackTrace = case['errorStackTrace']
+                        name = "Test Name: " + name + "\n"
+                        details = "Error Details: " + errorDetails + "\n"
+                        stack = "Stack Trace: " + errorStackTrace + "\n"
+                        failure_report += name + details + stack + "\n"
+        return failure_report
+    else:
+        return None
+
+def get_sub_builds(build_url, depth):
+    '''
+    get sub builds of a build
+    :param build_url: the url of a build in jenkins
+    :param depth: the depth of the nested sub build
+    :return: a list of string which contains the result , build number of the sub builds
+    '''
+    build_data = get_build_data(build_url)
+    outputs = []
+    if build_data:
+        if 'subBuilds' in build_data:
+            '''
+            get sub builds results
+            '''
+            for subBuild in build_data['subBuilds']:
+                output = ""
+                sub_build_name = subBuild['jobName'] + "  #" + str(subBuild['buildNumber'])
+                sub_build_result = subBuild['result']
+                sub_build_url = JENKINS_URL + "/" + subBuild['url']
+                for x in range(depth):
+                    output += "   "
+                output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
+
+                sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                if len(sub_outputs) >0 :
+                    for sub_output in sub_outputs:
+                        output += sub_output
+                outputs.append(output)
+                if sub_build_result != "SUCCESS":
+                    failure_report = generate_failure_report(sub_build_url, sub_build_name)
+                    FAIL_REPORTS.append(failure_report)
+
+        if 'actions' in build_data:
+            for action in build_data['actions']:
+                if 'triggeredBuilds' in action:
+                    '''
+                    get triggered builds results
+                    '''
+                    for subBuild in action['triggeredBuilds']:
+                        output = "\n"
+                        sub_build_name = subBuild['fullDisplayName']
+                        sub_build_result = subBuild['result']
+                        sub_build_url = subBuild['url']
+                        for x in range(depth):
+                            output += "   "
+                        output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
+                        sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                        if len(sub_outputs) > 0:
+                            for sub_output in sub_outputs:
+                                output += sub_output
+                        outputs.append(output)
+                        if sub_build_result != "SUCCESS":
+                            failure_report = generate_failure_report(sub_build_url, sub_build_name)
+                            FAIL_REPORTS.append(failure_report)
+    return outputs
+
+def is_error_response(res):
+    """
+    check the status code of http response
+    :param res: http response
+    :return: True if the status code less than 200 or larger than 206;
+             False if the status code is between 200 and 206
+    """
+    if res is None:
+        return True
+    if res.status_code < 200 or res.status_code > 299:
+        return True
+    return False
+
+def post_comments_to_github(comments, github_pr_url, headers):
+    '''
+    post comments to github Pull Request
+    :param comments: comments to be posted to Pull Request
+    '''
+    body = { "body" : comments }
+    r = requests.post(github_pr_url,headers=headers,data=json.dumps(body))
+    if is_error_response(r):
+        print "Failed to post comments to pull request {0}".format(github_pr_url)
+        print r.text
+        print r.status_code
+        sys.exit(1)
+    else:
+        print "Succeed to post comments to pull request {0}".format(github_pr_url)
+        return
+                
+def main():
     OUTPUT = '```\n'
-    OUTPUT += "*** BUILD " + BUILD_NAME + " ***\n"
-    data = r.json()
-    failCount = int(data.get('failCount'))
-    if failCount > 0:
-        for suite in data['suites']:
-            for case in suite['cases']:
-                if case['errorDetails']:
-                    name = case['name']
-                    errorDetails = case['errorDetails']
-                    errorStackTrace = case['errorStackTrace']
-                    name = "Test Name: " + name + "\n"
-                    details = "Error Details: " + errorDetails + "\n"
-                    stack = "Stack Trace: " + errorStackTrace + "\n"
-                    OUTPUT += name + details + stack + "\n"
-    OUTPUT += "```\n"
-    body = { "body" : OUTPUT }
-    r = requests.post(GITHUB_PR_URL,headers=HEADERS,data=json.dumps(body))
-    print r.status_code
+    job_name = BUILD_URL.split('/')[-3]
+    build_number = BUILD_URL.split('/')[-2]
+    
+    try:
+        build_data = get_build_data(BUILD_URL)
+        if build_data:
+            build_name = build_data['fullDisplayName']
+            build_result = build_data['result']
+            OUTPUT +=  "BUILD " + build_name + " : " + build_result + "\n"
+
+            sub_build_outputs = get_sub_builds(BUILD_URL, 1)
+            for sub_output in sub_build_outputs:
+                OUTPUT += sub_output
+
+            if build_result != "SUCCESS":
+                failure_report = generate_failure_report(BUILD_URL, build_name)
+                FAIL_REPORTS.append(failure_report)
+
+            if len(FAIL_REPORTS) > 0:
+                for fail_report in FAIL_REPORTS:
+                    OUTPUT += fail_report
+        else:
+            build_name = job_name + " #" + build_number   
+            failure_report = generate_failure_report(BUILD_URL, build_name)
+            FAIL_REPORTS.append(failure_report)
+
+            if len(FAIL_REPORTS) > 0:
+                for fail_report in FAIL_REPORTS:
+                    OUTPUT += fail_report
+            else:
+                OUTPUT += "*** BUILD " + build_name + " ***\n"
+    except Exception as e:
+        print e
+        sys.exit(1)
+    finally:
+        if OUTPUT == "```\n":
+            build_name = job_name + " #" + build_number
+            OUTPUT += "*** BUILD " + build_name + " ***\n"
+        OUTPUT += "```\n"
+        post_comments_to_github(OUTPUT, GITHUB_PR_URL, HEADERS)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. If jenkins builds for PR failed and the failed builds is sub build,  jenkins won't post any comments to github.
2. If smoke test timeout, jenkins will fail the PR and only post the number of on-xxx.
   we have no idea why jenkins failed from the comments.

The PR will post comments which contain the status of current build and sub builds.

```
BUILD Maglev-BRI-Test » test-stability » on-core #20 : ABORTED
  - ** BUILD build-config-setup  #62: SUCCESS
  - ** BUILD unit-tests  #58: SUCCESS
  - ** BUILD smoke-test  #23: ABORTED

   - ** BUILD Maglev-BRI-Test » test-stability » on-taskgraph #34: SUCCESS
    - ** BUILD build-config-setup  #63: SUCCESS
    - ** BUILD unit-tests  #59: SUCCESS
```

If builds for unit test and smoke test generate report, the PR will also post comments which contain failed test cases.

```
BUILD on-tftp #714 : UNSTABLE
  - ** BUILD build-config-setup  #89110: SUCCESS
  - ** BUILD unit-tests  #8929: SUCCESS
  - ** BUILD smoke-test  #3168: SUCCESS

BUILD on-tftp #714  Error Logs:

Test Name: test_get_sessions
Error Details: (500)
Reason: Internal Server Error
HTTP response headers: HTTPHeaderDict({'Content-Length': '154', 'X-Content-Type-Options': 'nosniff', 'X-Powered-By': 'Express', 'Connection': 'keep-alive', 'Date': 'Tue, 30 Aug 2016 23:27:09 GMT', 'Access-Control-Allow-Origin': '*', 'Content-Type': 'text/html; charset=utf-8'})
HTTP response body: Error: EPROTO: protocol error, stat &#39;/home/vagrant/src/on-http/static/http/redfish/v1/SessionService/Sessions&#39;<br> &nbsp; &nbsp;at Error (native)


Stack Trace: Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/usr/lib/python2.7/unittest/case.py", line 1043, in runTest
    self._testFunc()
  File "/tmp/.venv/local/lib/python2.7/site-packages/proboscis/case.py", line 296, in testng_method_mistake_capture_func
    compatability.capture_type_error(s_func)
  File "/tmp/.venv/local/lib/python2.7/site-packages/proboscis/compatability/exceptions_2_6.py", line 27, in capture_type_error
    func()
  File "/tmp/.venv/local/lib/python2.7/site-packages/proboscis/case.py", line 350, in func
    func(test_case.state.get_state())
  File "/home/jenkins/workspace/on-tftp/RackHD/test/tests/api/redfish_1_0/session_service_tests.py", line 69, in test_get_sessions
    redfish().get_sessions()
  File "/tmp/.venv/local/lib/python2.7/site-packages/on_http_redfish_1_0/apis/redfishv_api.py", line 2601, in get_sessions
    callback=params.get('callback'))
  File "/tmp/.venv/local/lib/python2.7/site-packages/on_http_redfish_1_0/api_client.py", line 322, in call_api
    response_type, auth_settings, callback)
  File "/tmp/.venv/local/lib/python2.7/site-packages/on_http_redfish_1_0/api_client.py", line 149, in __call_api
    post_params=post_params, body=body)
  File "/tmp/.venv/local/lib/python2.7/site-packages/on_http_redfish_1_0/api_client.py", line 342, in request
    headers=headers)
  File "/tmp/.venv/local/lib/python2.7/site-packages/on_http_redfish_1_0/rest.py", line 184, in GET
    query_params=query_params)
  File "/tmp/.venv/local/lib/python2.7/site-packages/on_http_redfish_1_0/rest.py", line 177, in request
    raise ApiException(http_resp=r)
ApiException: (500)
Reason: Internal Server Error
HTTP response headers: HTTPHeaderDict({'Content-Length': '154', 'X-Content-Type-Options': 'nosniff', 'X-Powered-By': 'Express', 'Connection': 'keep-alive', 'Date': 'Tue, 30 Aug 2016 23:27:09 GMT', 'Access-Control-Allow-Origin': '*', 'Content-Type': 'text/html; charset=utf-8'})
HTTP response body: Error: EPROTO: protocol error, stat &#39;/home/vagrant/src/on-http/static/http/redfish/v1/SessionService/Sessions&#39;<br> &nbsp; &nbsp;at Error (native)
```
