### PR TITLE
Use Customized config.json in Jenkins Test

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -37,7 +37,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           end
         end
         
-        if ENV['CONFIG_DIR']
+        if ENV['CONFIG_DIR'] # this ENV VAR defined in on-build-config repo's test.sh, pointing to vagrant/config/mongo/config.json in on-build-config repo.
+          target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['CONFIG_DIR']}", "/opt/monorail/"
           target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['CONFIG_DIR']}", "/opt/onrack/etc/"
           target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['CONFIG_DIR']}", "/home/vagrant/opt/monorail/"
         end


### PR DESCRIPTION
echoing @yyscamper   https://github.com/RackHD/RackHD/pull/400

sync customized config.json to /opt/monorail folder, as first priority config location.

But  I noticed below config(will be used for Jenkins Auto Test after this PR take effects)

https://raw.githubusercontent.com/RackHD/on-build-config/master/vagrant/config/mongo/config.json

**are different** with the one in vagrant box (by default) (you can vimdiff)

https://raw.githubusercontent.com/RackHD/RackHD/master/packer/ansible/roles/monorail/files/config.json

**Please someone confirm** if the first one config file suitable for Jenkins Test and no harm.

Left is default one. right is the jenkins cutomized one.

```

 "dhcpSubnetMask": "255.255.240.0"       VS  "dhcpSubnetMask": "255.255.252.0"
 "authEnabled": true,                    VS   "authEnabled": false
  "httpProxies"     "localPath": "/coreos"       VS  "httpProxies": "localPath": "/repo/"

```

the last line if my favorite :-) 
"minLogLevel": 2             VS        "minLogLevel": 0

@jlongever  @yyscamper  @heckj 
