### PR TITLE
clean mongo before nf start

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -57,6 +57,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
+          until echo "db.dropDatabase()" | mongo pxe
+          do
+            sleep 5
+            echo "Try again to clean mongodb"
+          done
           nf start > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
         SHELL
 


### PR DESCRIPTION
The mongodb of rackhd virtualbox v0.15 is not clean, and this leads to several problems, for example:
- In collection **graphobjects** we found

```
{ "_id" : ObjectId("579a43646c4cbbe4026ca14a"), "injectableName" : "Graph.Service.Poller" }
{ "_id" : ObjectId("57d91edb075306fd610d8cf5"), "injectableName" : "Graph.Service.Poller" }
```

So RackHD errors occurs when vagrant just up and vnode is poweroff, these error logs make vagrant.log confusing.
- In collection **profiles**, `error.ipxe` can be found, but this file has been removed from repo on-http.
  so error occurs in `api/1.1/profiles/library` 

I thinks it's necessary to clean mongo before nf start.

**This issue can be fixed in next virtualbox update, and then this code block can be removed.**

@RackHD/corecommitters @jlongever @panpan0000 @PengTian0 
