### PR TITLE
fix: pre-deploy has been moved to unit-test so some post actions on s…

### DIFF
--- a/generate-sol-log.sh
+++ b/generate-sol-log.sh
@@ -13,7 +13,7 @@ bmc_account_list="${BMC_ACCOUNT_LIST}"
 handled_ip_list=""
 vnode_num=0
 timeout=0
-maxto=50
+maxto=20
 while [ ${timeout} != ${maxto} ]; do
     ip_list=`arp | awk '{print $1}' | xargs`
     echo "IP LIST: $ip_list"
@@ -47,7 +47,7 @@ while [ ${timeout} != ${maxto} ]; do
             fi  
         fi    
     done
-    #after more than 5*50 seconds all nodes are believed have got the IP by DHCP
+    #after more than 5*20 seconds all nodes are believed have got the IP by DHCP
     sleep 5
     timeout=`expr ${timeout} + 1`
 done

--- a/generate-sol-log.sh.in
+++ b/generate-sol-log.sh.in
@@ -13,7 +13,7 @@ bmc_account_list="${BMC_ACCOUNT_LIST}"
 handled_ip_list=""
 vnode_num=0
 timeout=0
-maxto=50
+maxto=20
 while [ ${timeout} != ${maxto} ]; do
     ip_list=`arp | awk '{print $1}' | xargs`
     echo "IP LIST: $ip_list"
@@ -47,7 +47,7 @@ while [ ${timeout} != ${maxto} ]; do
             fi  
         fi    
     done
-    #after more than 5*50 seconds all nodes are believed have got the IP by DHCP
+    #after more than 5*20 seconds all nodes are believed have got the IP by DHCP
     sleep 5
     timeout=`expr ${timeout} + 1`
 done

--- a/on-core/post-deploy.sh.in
+++ b/on-core/post-deploy.sh.in
@@ -8,3 +8,12 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
     sed -i 's|<file path="">|<file path="build/spec/helper.js">|' autotest-reports/$(basename "$filename" .xml).xml
   done
 fi
+
+
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-core/pre-deploy.sh.in
+++ b/on-core/pre-deploy.sh.in
@@ -8,11 +8,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/on-dhcp-proxy/post-deploy.sh.in
+++ b/on-dhcp-proxy/post-deploy.sh.in
@@ -9,3 +9,10 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-dhcp-proxy/pre-deploy.sh.in
+++ b/on-dhcp-proxy/pre-deploy.sh.in
@@ -8,11 +8,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/on-http/post-deploy.sh.in
+++ b/on-http/post-deploy.sh.in
@@ -9,3 +9,10 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-http/pre-deploy.sh.in
+++ b/on-http/pre-deploy.sh.in
@@ -8,11 +8,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/on-syslog/post-deploy.sh.in
+++ b/on-syslog/post-deploy.sh.in
@@ -9,3 +9,10 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-syslog/pre-deploy.sh.in
+++ b/on-syslog/pre-deploy.sh.in
@@ -8,11 +8,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/on-taskgraph/post-deploy.sh.in
+++ b/on-taskgraph/post-deploy.sh.in
@@ -9,3 +9,10 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-taskgraph/pre-deploy.sh.in
+++ b/on-taskgraph/pre-deploy.sh.in
@@ -8,11 +8,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/on-tasks/post-deploy.sh.in
+++ b/on-tasks/post-deploy.sh.in
@@ -9,3 +9,10 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-tasks/pre-deploy.sh.in
+++ b/on-tasks/pre-deploy.sh.in
@@ -9,11 +9,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/on-tftp/post-deploy.sh.in
+++ b/on-tftp/post-deploy.sh.in
@@ -9,3 +9,10 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/on-tftp/pre-deploy.sh.in
+++ b/on-tftp/pre-deploy.sh.in
@@ -8,11 +8,3 @@ cd $WORKSPACE
 
 mkdir -p xunit-reports
 cp build/test/TEST-all.xml xunit-reports
-
-#raw sol logs saved in WORKSPACE/build-deps
-#this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
-for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
-done

--- a/post-deploy.sh
+++ b/post-deploy.sh
@@ -1,2 +1,11 @@
 #!/bin/bash
 echo "Running post-deploy script"
+
+
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done

--- a/post-deploy.sh.in
+++ b/post-deploy.sh.in
@@ -1,2 +1,10 @@
 #!/bin/bash
 echo "Running post-deploy script"
+
+#raw sol logs saved in WORKSPACE/build-deps
+#this script convert them into html by ansi2html tool
+#and move them to 'build' folder for publishing
+cd $WORKSPACE/build-deps
+for file in `ls *sol.log.raw`; do
+    ansi2html < $file > $WORKSPACE/build/${file%.*}
+done


### PR DESCRIPTION
…ol log missing, now move the actions to post-deploy

move the sol.log post processing to post-deploy.

The pre-deploy used to run after smoke test so I add sol.log post processing to it.
But it was moved to unit-test several days ago, so now sol.log post processing missing.

post-deploy is a script never run and now it seems to be the best place to put sol.log post processing.

@panpan0000 @PengTian0 @RackHD/corecommitters 
