### PR TITLE
Redirect SOL script output to file

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -121,7 +121,8 @@ vagrantHalt() {
 
 generateSolLog(){
   cd ${WORKSPACE}/RackHD/example
-  vagrant ssh -c 'cd /home/vagrant/src/build-config/; bash generate-sol-log.sh' &
+  vagrant ssh -c 'cd /home/vagrant/src/build-config/; \
+        bash generate-sol-log.sh' > ${WORKSPACE}/sol.log &
 }
 
 BASE_REPO_URL="${BASE_REPO_URL}"

--- a/test.sh.in
+++ b/test.sh.in
@@ -121,7 +121,8 @@ vagrantHalt() {
 
 generateSolLog(){
   cd ${WORKSPACE}/RackHD/example
-  vagrant ssh -c 'cd /home/vagrant/src/build-config/; bash generate-sol-log.sh' &
+  vagrant ssh -c 'cd /home/vagrant/src/build-config/; \
+        bash generate-sol-log.sh' > ${WORKSPACE}/sol.log &
 }
 
 BASE_REPO_URL="${BASE_REPO_URL}"


### PR DESCRIPTION
- Prevent SOL script from polluting Jenkins console with the below during test.  Redirect to file.  

```
13:22:27 --- 172.31.128.4 ping statistics ---
13:22:27 1 packets transmitted, 1 received, 0% packet loss, time 0ms
13:22:27 rtt min/avg/max/mdev = 0.721/0.721/0.721/0.000 ms
13:22:27 ipmi cmd: ipmitool -I lanplus -H 172.31.128.4 -U XXXXX -P XXXXX -R 1 -N 3 chassis power status
13:22:33 Error: Unable to establish IPMI v2 / RMCP+ session
13:22:33 PING 172.31.128.5 (172.31.128.5) 56(84) bytes of data.
13:22:33 64 bytes from 172.31.128.5: icmp_seq=1 ttl=64 time=0.654 ms
```
