### PR TITLE
add public jenkins url to comments

### DIFF
--- a/post-result.py
+++ b/post-result.py
@@ -3,15 +3,16 @@ import requests
 import os
 import subprocess
 import sys
+import argparse
 
 '''
 Usage:
 python post-result.py \
-https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
-http://rackhdci.lss.emc.com \
-http://rackhdci.lss.emc.com/job/on-core/851/ \
-'#851' \
-http://147.178.202.18/
+--github_pr_url https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
+--jenkins_url http://rackhdci.lss.emc.com \
+--build_url http://rackhdci.lss.emc.com/job/on-core/851/ \
+--build_name '#851' \
+--public_jenkins_url http://147.178.202.18/
 '''
 
 with open('${HOME}/.ghtoken', 'r') as file:
@@ -19,12 +20,38 @@ with open('${HOME}/.ghtoken', 'r') as file:
 
 HEADERS = {'Authorization': 'token %s' % TOKEN}
 
-GITHUB_PR_URL = sys.argv[1]
-JENKINS_URL = sys.argv[2]
-BUILD_URL = sys.argv[3]
-BUILD_NAME = sys.argv[4]
-PUBLIC_JENKINS_URL = sys.argv[5]
+GITHUB_PR_URL = ""
+JENKINS_URL = ""
+BUILD_URL = ""
+BUILD_NAME = ""
+PUBLIC_JENKINS_URL = ""
 FAIL_REPORTS = []
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--github_pr_url',
+                        required=True,
+                        help="The url of the pull request in github",
+                        action="store")
+    parser.add_argument('--jenkins_url',
+                        required=True,
+                        help="The url of the internal jenkins",
+                        action="store")
+    parser.add_argument('--build_url',
+                        required=True,
+                        help="the url of the build in jenkins",
+                        action="store")
+    parser.add_argument('--build_name',
+                        required=True,
+                        help="the name of the build in jenkins",
+                        action="store")
+    parser.add_argument('--public_jenkins_url',
+                        required=True,
+                        help="the url of the public jenkins",
+                        action="store")
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
 
 def get_build_data(build_url):
     '''
@@ -224,4 +251,12 @@ def main():
         post_comments_to_github(OUTPUT, GITHUB_PR_URL, HEADERS)
 
 if __name__ == "__main__":
+    # parse arguments
+    parsed_args = parse_args(sys.argv[1:])
+    GITHUB_PR_URL = parsed_args.github_pr_url
+    JENKINS_URL = parsed_args.jenkins_url
+    BUILD_URL = parsed_args.build_url
+    BUILD_NAME = parsed_args.build_name
+    PUBLIC_JENKINS_URL = parsed_args.public_jenkins_url
+
     main()

--- a/post-result.py
+++ b/post-result.py
@@ -10,7 +10,8 @@ python post-result.py \
 https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
 http://rackhdci.lss.emc.com \
 http://rackhdci.lss.emc.com/job/on-core/851/ \
-'#851'
+'#851' \
+http://147.178.202.18/
 '''
 
 with open('${HOME}/.ghtoken', 'r') as file:
@@ -22,6 +23,7 @@ GITHUB_PR_URL = sys.argv[1]
 JENKINS_URL = sys.argv[2]
 BUILD_URL = sys.argv[3]
 BUILD_NAME = sys.argv[4]
+PUBLIC_JENKINS_URL = sys.argv[5]
 FAIL_REPORTS = []
 
 def get_build_data(build_url):
@@ -86,7 +88,7 @@ def generate_failure_report(build_url, build_name):
     else:
         return None
 
-def get_sub_builds(build_url, depth):
+def get_sub_builds(build_url, depth = 1):
     '''
     get sub builds of a build
     :param build_url: the url of a build in jenkins
@@ -105,11 +107,12 @@ def get_sub_builds(build_url, depth):
                 sub_build_name = subBuild['jobName'] + "  #" + str(subBuild['buildNumber'])
                 sub_build_result = subBuild['result']
                 sub_build_url = JENKINS_URL + "/" + subBuild['url']
+                public_sub_build_url = sub_build_url.replace(JENKINS_URL, PUBLIC_JENKINS_URL)
                 for x in range(depth):
                     output += "   "
-                output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
+                output += "- ** BUILD [" + sub_build_name + "](" + public_sub_build_url + "): " + sub_build_result + "\n"
 
-                sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                sub_outputs = get_sub_builds(sub_build_url, depth = depth+1)
                 if len(sub_outputs) >0 :
                     for sub_output in sub_outputs:
                         output += sub_output
@@ -129,10 +132,11 @@ def get_sub_builds(build_url, depth):
                         sub_build_name = subBuild['fullDisplayName']
                         sub_build_result = subBuild['result']
                         sub_build_url = subBuild['url']
+                        public_sub_build_url = sub_build_url.replace(JENKINS_URL, PUBLIC_JENKINS_URL)
                         for x in range(depth):
                             output += "   "
-                        output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
-                        sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                        output += "- ** BUILD " + sub_build_name + "](" + public_sub_build_url + "): " + sub_build_result + "\n"
+                        sub_outputs = get_sub_builds(sub_build_url, depth = depth+1)
                         if len(sub_outputs) > 0:
                             for sub_output in sub_outputs:
                                 output += sub_output
@@ -159,6 +163,10 @@ def post_comments_to_github(comments, github_pr_url, headers):
     '''
     post comments to github Pull Request
     :param comments: comments to be posted to Pull Request
+    :param github_pr_url: the url of the PR
+    :param headers: the request headers which usually contains the "Authorization" field
+    :return: exit with error code 1 if get bad response for the request
+             return null if get successful response
     '''
     body = { "body" : comments }
     r = requests.post(github_pr_url,headers=headers,data=json.dumps(body))
@@ -172,18 +180,19 @@ def post_comments_to_github(comments, github_pr_url, headers):
         return
                 
 def main():
-    OUTPUT = '```\n'
+    OUTPUT = ""
     job_name = BUILD_URL.split('/')[-3]
     build_number = BUILD_URL.split('/')[-2]
-    
+
+    public_build_url = BUILD_URL.replace(JENKINS_URL, PUBLIC_JENKINS_URL)
     try:
         build_data = get_build_data(BUILD_URL)
         if build_data:
             build_name = build_data['fullDisplayName']
             build_result = build_data['result']
-            OUTPUT +=  "BUILD " + build_name + " : " + build_result + "\n"
+            OUTPUT +=  "BUILD [" + build_name + "](" + public_build_url + ") : " + build_result + "\n"
 
-            sub_build_outputs = get_sub_builds(BUILD_URL, 1)
+            sub_build_outputs = get_sub_builds(BUILD_URL)
             for sub_output in sub_build_outputs:
                 OUTPUT += sub_output
 
@@ -201,17 +210,17 @@ def main():
 
             if len(FAIL_REPORTS) > 0:
                 for fail_report in FAIL_REPORTS:
+                    OUTPUT +=  "BUILD [" + build_name + "](" + public_build_url + ") :\n"
                     OUTPUT += fail_report
             else:
-                OUTPUT += "*** BUILD " + build_name + " ***\n"
+                OUTPUT += "*** BUILD [" + build_name + "](" + public_build_url + ") ***\n"
     except Exception as e:
         print e
         sys.exit(1)
     finally:
-        if OUTPUT == "```\n":
+        if OUTPUT == "":
             build_name = job_name + " #" + build_number
-            OUTPUT += "*** BUILD " + build_name + " ***\n"
-        OUTPUT += "```\n"
+            OUTPUT += "*** BUILD [" + build_name + "](" + public_build_url + ") ***\n"
         post_comments_to_github(OUTPUT, GITHUB_PR_URL, HEADERS)
 
 if __name__ == "__main__":

--- a/post-result.py.in
+++ b/post-result.py.in
@@ -3,15 +3,16 @@ import requests
 import os
 import subprocess
 import sys
+import argparse
 
 '''
 Usage:
 python post-result.py \
-https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
-http://rackhdci.lss.emc.com \
-http://rackhdci.lss.emc.com/job/on-core/851/ \
-'#851' \
-http://147.178.202.18/
+--github_pr_url https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
+--jenkins_url http://rackhdci.lss.emc.com \
+--build_url http://rackhdci.lss.emc.com/job/on-core/851/ \
+--build_name '#851' \
+--public_jenkins_url http://147.178.202.18/
 '''
 
 with open('${HOME}/.ghtoken', 'r') as file:
@@ -19,12 +20,38 @@ with open('${HOME}/.ghtoken', 'r') as file:
 
 HEADERS = {'Authorization': 'token %s' % TOKEN}
 
-GITHUB_PR_URL = sys.argv[1]
-JENKINS_URL = sys.argv[2]
-BUILD_URL = sys.argv[3]
-BUILD_NAME = sys.argv[4]
-PUBLIC_JENKINS_URL = sys.argv[5]
+GITHUB_PR_URL = ""
+JENKINS_URL = ""
+BUILD_URL = ""
+BUILD_NAME = ""
+PUBLIC_JENKINS_URL = ""
 FAIL_REPORTS = []
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--github_pr_url',
+                        required=True,
+                        help="The url of the pull request in github",
+                        action="store")
+    parser.add_argument('--jenkins_url',
+                        required=True,
+                        help="The url of the internal jenkins",
+                        action="store")
+    parser.add_argument('--build_url',
+                        required=True,
+                        help="the url of the build in jenkins",
+                        action="store")
+    parser.add_argument('--build_name',
+                        required=True,
+                        help="the name of the build in jenkins",
+                        action="store")
+    parser.add_argument('--public_jenkins_url',
+                        required=True,
+                        help="the url of the public jenkins",
+                        action="store")
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
 
 def get_build_data(build_url):
     '''
@@ -224,4 +251,12 @@ def main():
         post_comments_to_github(OUTPUT, GITHUB_PR_URL, HEADERS)
 
 if __name__ == "__main__":
+    # parse arguments
+    parsed_args = parse_args(sys.argv[1:])
+    GITHUB_PR_URL = parsed_args.github_pr_url
+    JENKINS_URL = parsed_args.jenkins_url
+    BUILD_URL = parsed_args.build_url
+    BUILD_NAME = parsed_args.build_name
+    PUBLIC_JENKINS_URL = parsed_args.public_jenkins_url
+
     main()

--- a/post-result.py.in
+++ b/post-result.py.in
@@ -10,7 +10,8 @@ python post-result.py \
 https://api.github.com/repos/RackHD/on-core/issues/${PullRequestId}/comments \
 http://rackhdci.lss.emc.com \
 http://rackhdci.lss.emc.com/job/on-core/851/ \
-'#851'
+'#851' \
+http://147.178.202.18/
 '''
 
 with open('${HOME}/.ghtoken', 'r') as file:
@@ -22,6 +23,7 @@ GITHUB_PR_URL = sys.argv[1]
 JENKINS_URL = sys.argv[2]
 BUILD_URL = sys.argv[3]
 BUILD_NAME = sys.argv[4]
+PUBLIC_JENKINS_URL = sys.argv[5]
 FAIL_REPORTS = []
 
 def get_build_data(build_url):
@@ -86,7 +88,7 @@ def generate_failure_report(build_url, build_name):
     else:
         return None
 
-def get_sub_builds(build_url, depth):
+def get_sub_builds(build_url, depth = 1):
     '''
     get sub builds of a build
     :param build_url: the url of a build in jenkins
@@ -105,11 +107,12 @@ def get_sub_builds(build_url, depth):
                 sub_build_name = subBuild['jobName'] + "  #" + str(subBuild['buildNumber'])
                 sub_build_result = subBuild['result']
                 sub_build_url = JENKINS_URL + "/" + subBuild['url']
+                public_sub_build_url = sub_build_url.replace(JENKINS_URL, PUBLIC_JENKINS_URL)
                 for x in range(depth):
                     output += "   "
-                output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
+                output += "- ** BUILD [" + sub_build_name + "](" + public_sub_build_url + "): " + sub_build_result + "\n"
 
-                sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                sub_outputs = get_sub_builds(sub_build_url, depth = depth+1)
                 if len(sub_outputs) >0 :
                     for sub_output in sub_outputs:
                         output += sub_output
@@ -129,10 +132,11 @@ def get_sub_builds(build_url, depth):
                         sub_build_name = subBuild['fullDisplayName']
                         sub_build_result = subBuild['result']
                         sub_build_url = subBuild['url']
+                        public_sub_build_url = sub_build_url.replace(JENKINS_URL, PUBLIC_JENKINS_URL)
                         for x in range(depth):
                             output += "   "
-                        output += "- ** BUILD " + sub_build_name + ": " + sub_build_result + "\n"
-                        sub_outputs = get_sub_builds(sub_build_url, depth+1)
+                        output += "- ** BUILD " + sub_build_name + "](" + public_sub_build_url + "): " + sub_build_result + "\n"
+                        sub_outputs = get_sub_builds(sub_build_url, depth = depth+1)
                         if len(sub_outputs) > 0:
                             for sub_output in sub_outputs:
                                 output += sub_output
@@ -176,18 +180,19 @@ def post_comments_to_github(comments, github_pr_url, headers):
         return
                 
 def main():
-    OUTPUT = '```\n'
+    OUTPUT = ""
     job_name = BUILD_URL.split('/')[-3]
     build_number = BUILD_URL.split('/')[-2]
-    
+
+    public_build_url = BUILD_URL.replace(JENKINS_URL, PUBLIC_JENKINS_URL)
     try:
         build_data = get_build_data(BUILD_URL)
         if build_data:
             build_name = build_data['fullDisplayName']
             build_result = build_data['result']
-            OUTPUT +=  "BUILD " + build_name + " : " + build_result + "\n"
+            OUTPUT +=  "BUILD [" + build_name + "](" + public_build_url + ") : " + build_result + "\n"
 
-            sub_build_outputs = get_sub_builds(BUILD_URL, 1)
+            sub_build_outputs = get_sub_builds(BUILD_URL)
             for sub_output in sub_build_outputs:
                 OUTPUT += sub_output
 
@@ -205,17 +210,17 @@ def main():
 
             if len(FAIL_REPORTS) > 0:
                 for fail_report in FAIL_REPORTS:
+                    OUTPUT +=  "BUILD [" + build_name + "](" + public_build_url + ") :\n"
                     OUTPUT += fail_report
             else:
-                OUTPUT += "*** BUILD " + build_name + " ***\n"
+                OUTPUT += "*** BUILD [" + build_name + "](" + public_build_url + ") ***\n"
     except Exception as e:
         print e
         sys.exit(1)
     finally:
-        if OUTPUT == "```\n":
+        if OUTPUT == "":
             build_name = job_name + " #" + build_number
-            OUTPUT += "*** BUILD " + build_name + " ***\n"
-        OUTPUT += "```\n"
+            OUTPUT += "*** BUILD [" + build_name + "](" + public_build_url + ") ***\n"
         post_comments_to_github(OUTPUT, GITHUB_PR_URL, HEADERS)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add url to jenkins in cloud to the comments which is posted by jenkins after testing for PR.

Looks like:

BUILD [on-core #874](http://147.178.202.18/job/on-core/874/) : UNSTABLE
- *\* BUILD [build-config-setup  #101225](http://147.178.202.18/job/Templates/job/build-config-setup/101225/): SUCCESS
- *\* BUILD [unit-tests  #9343](http://147.178.202.18/job/Templates/job/unit-tests/9343/): SUCCESS
- *\* BUILD [smoke-tests  #3405](http://147.178.202.18/job/Templates/job/smoke-test/3405/): UNSTABLE
- *\* BUILD [on-taskgraph #1525](http://147.178.202.18/job/on-taskgraph/1525/): SUCCESS
  - *\* BUILD [build-config-setup  #101227](http://147.178.202.18/job/Templates/job/build-config-setup/101227/): SUCCESS
  - *\* BUILD [unit-tests  #9344](http://147.178.202.18/job/Templates/job/unit-tests/9344/): SUCCESS
