### PR TITLE
Edit Vagrantfile to adapt new version box: change foreman to pm2

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -67,8 +67,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
-          pm2 start rackhd.yml
           pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          pm2 start rackhd-pm2-config.yml
         SHELL
     end
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # MONORAIL SERVER
     config.vm.define "dev" do |target|
         target.vm.box = "rackhd/rackhd"
-        target.vm.box_version = "0.15"
+        target.vm.box_version = "0.16"
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
@@ -67,7 +67,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
-          nf start > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          pm2 start rackhd.yml
+          pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
         SHELL
     end
 end

--- a/vagrant/Vagrantfile.in
+++ b/vagrant/Vagrantfile.in
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # MONORAIL SERVER
     config.vm.define "dev" do |target|
         target.vm.box = "rackhd/rackhd"
-        target.vm.box_version = "0.15"
+        target.vm.box_version = "0.16"
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
@@ -56,7 +56,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
-          nf start > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          pm2 start rackhd.yml
+          pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
         SHELL
 
 

--- a/vagrant/Vagrantfile.in
+++ b/vagrant/Vagrantfile.in
@@ -56,8 +56,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
-          pm2 start rackhd.yml
           pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          pm2 start rackhd-pm2-config.yml
         SHELL
 
 


### PR DESCRIPTION
In new version box 0.16,  RackHD process manage has been changed to PM2 instead of Foreman.
This PR is for that change.

see GG https://groups.google.com/forum/#!topic/rackhd/UfyZ1v9Gdc4

But 0.16 is compatible for using foreman nf start, so this PR is not urgent to be merged.

Related PR:
* https://github.com/RackHD/RackHD/pull/478  edit packer script, change foreman to pm2.
* https://github.com/RackHD/RackHD/pull/479  edit RackHD readme 
* https://github.com/RackHD/docs/pull/357 edit docs
@panpan0000 