### PR TITLE
solve the issue that pm2 hangs at spawning PM2 Daemon

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # MONORAIL SERVER
     config.vm.define "dev" do |target|
         target.vm.box = "rackhd/rackhd"
-        target.vm.box_version = "0.15"
+        target.vm.box_version = "0.16"
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
@@ -64,10 +64,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.forward_agent = true
 
         target.vm.provision "shell", inline: <<-SHELL
+          timeout=0
+          maxto=30
+          waitForPM2Daemon() {
+            while [ ${timeout} != ${maxto} ]; do
+              ps aux | grep PM2 | grep Daemon
+              if [ $? = 0 ]; then 
+                break
+              fi
+              sleep 1
+              timeout=`expr ${timeout} + 1`
+            done
+            if [ ${timeout} == ${maxto} ]; then
+              echo "Timed out waiting for PM2 Daemon (duration=`expr $maxto \* 1`s)."
+              exit 1
+            fi
+          }
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
-          nf start > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          waitForPM2Daemon
+          pm2 start rackhd-pm2-config.yml
         SHELL
     end
 end

--- a/vagrant/Vagrantfile.in
+++ b/vagrant/Vagrantfile.in
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # MONORAIL SERVER
     config.vm.define "dev" do |target|
         target.vm.box = "rackhd/rackhd"
-        target.vm.box_version = "0.15"
+        target.vm.box_version = "0.16"
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
@@ -53,10 +53,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.forward_agent = true
 
         target.vm.provision "shell", inline: <<-SHELL
+          timeout=0
+          maxto=30
+          waitForPM2Daemon() {
+            while [ ${timeout} != ${maxto} ]; do
+              ps aux | grep PM2 | grep Daemon
+              if [ $? = 0 ]; then 
+                break
+              fi
+              sleep 1
+              timeout=`expr ${timeout} + 1`
+            done
+            if [ ${timeout} == ${maxto} ]; then
+              echo "Timed out waiting for PM2 Daemon (duration=`expr $maxto \* 1`s)."
+              exit 1
+            fi
+          }
           service isc-dhcp-server start
           service rsyslog stop
           echo manual | sudo tee /etc/init/rsyslog.override
-          nf start > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+          waitForPM2Daemon
+          pm2 start rackhd-pm2-config.yml
         SHELL
 
 


### PR DESCRIPTION
Pre-PR https://github.com/RackHD/on-build-config/pull/31 was reverted because of a PM2 issue:
* about 30% hangs at PM2  spawning.
see this jenkins build http://10.240.19.21/job/Release-Test/job/Release-Functional/2278/console

## root cause
Daemon process is the core process of PM2 , any PM2 cmds based on this Daemon.
So when run any PM2 cmds, it first checks existence of Daemon process, if not it will start Daemon and then run cmd, if yes it just run the cmds.
But there's no mutex lock on **check existence of Daemon process**.

So in previous Vagrantfile, pm2 was invoked like this
```
pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
pm2 start rackhd-pm2-config.yml
```
At the same time, ```pm2 logs``` and ```pm2 start``` both check existence of Daemon process and both believe there's no Daemon, so they all start PM2 Daemon, but there only can be one Daemon.
Then  ```pm2 logs``` succeeded and  ```pm2 start``` hangs at spawning PM2 Daemon.

## Solution
Add a function ```waitForPM2Daemon``` to fixed the issue. Though just ```sleep 5``` between  ```pm2 logs``` and ```pm2 start``` can fix this but that's not secure IMO.

@RackHD/corecommitters @panpan0000 @geoff-reid @amymullins 

F.Y.I Related PM2 issue https://github.com/Unitech/pm2/issues/2503