### PR TITLE
move build-release-tools from on-tools repo to this repo

### DIFF
--- a/build-release-tools/HWIMO-BUILD
+++ b/build-release-tools/HWIMO-BUILD
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# HWIMO-BUILD
+#
+# Sets up the virtual environment for the scripts in question
+# Runs the specified command, passing down all command line arguments
+#
+
+# Specify full error checking
+set -e
+
+function cleanup {
+  set +e
+  trap '' EXIT SIGINT
+
+  echo "Cleaning up ${TMPDIR}"
+  if [ -n "${TMPDIR}" ]
+  then
+    rm -r ${TMPDIR}
+  fi
+}
+
+trap cleanup SIGINT EXIT
+
+BASEDIR=$(dirname "$0")
+
+# Create a virtual environment to use for the
+# packaging, testing and document generation.
+# We need to disable "set -e" here.  sourcing
+# virtualenv files causes early exits
+
+if [ ! -d $BASEDIR/env/hwimobuild -o $BASEDIR/requirements.txt -nt $BASEDIR/env/hwimobuild ]
+then
+  echo -n "Creating virtual environment... " > $BASEDIR/environment.log
+  set +e
+  (cd $BASEDIR; ./mkenv.sh hwimobuild) > $BASEDIR/environment.log 2>&1
+  if [ $? != 0 ]
+  then
+    echo "found problems:"
+    if [ -f $BASEDIR/environment.log ]
+    then
+      cat $BASEDIR/environment.log
+    else
+      echo "No log file available"
+    fi
+    exit 1
+  fi
+  echo 'done!' > $BASEDIR/environment.log
+fi
+
+source $BASEDIR/env/hwimobuild/bin/activate
+set -e
+
+if [ -d $BASEDIR/lib ]
+then
+  export PYTHONPATH="$(cd $BASEDIR/lib; pwd)"
+fi
+
+exec "$@"

--- a/build-release-tools/application/generate_manifest.py
+++ b/build-release-tools/application/generate_manifest.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# Copyright 2016, DELLEMC, Inc.
+
+"""
+The script generate a new manifest for a new branch according to another manifest.
+For example, 
+new branch: release/branch-1.2.3
+date: 2016-12-15 00:00:00
+The generated new manifest: branch-1.2.3-20161215
+
+usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/generate_manifest.py \
+--branch master \
+--date "$date" \
+--timezone "+0800" \
+--builddir b \
+--force \
+--git-credential https://github.com,GITHUB \
+--jobs 8
+
+The required parameters: 
+branch: The branch name of each repository in manifest file.
+date: The commit of each repository are last commit before the date.
+      The valid date: current (the commit of each repository are the lastest commit")
+                      yesterday (the commit of each repository are the last commit of yesterday")
+                      date string, such as: 2016-12-01 00:00:00 (the commit of each repository are the last commit before the date")
+
+timezone: The Time Zone for the date, such as: +0800, -0800, -0500
+git-credential: Git credentials for CI services.
+builddir: The directory for checked repositories.
+
+The optional parameters:
+force: If true, overwrite the destination manifest file even it already exists.
+jobs: number of parallel jobs to run. The number is related to the compute architecture, multi-core processors...
+"""
+import os
+import sys
+import argparse
+from dateutil.parser import parse
+from datetime import datetime,timedelta
+
+try:
+    import common
+    from ManifestGenerator import *
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+def parse_command_line(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--branch",
+                        required=True,
+                        help="The branch of repositories in new manifest",
+                        action="store")
+
+    parser.add_argument("--date",
+                         default="current",
+                         required=True,
+                         help="Generate a new manifest with commit before the date, such as: current, yesterday, 2016-12-13 00:00:00",
+                         action="store")
+
+    parser.add_argument("--timezone",
+                         default="+0800",
+                         required=True,
+                         help="The time zone for parameter date",
+                         action="store")
+
+    parser.add_argument("--builddir",
+                        required=True,
+                        help="destination for checked out repositories",
+                        action="store")
+
+    parser.add_argument("--git-credential",
+                        required=True,
+                        help="Git credential for CI services",
+                        action="append")
+
+    parser.add_argument("--force",
+                        help="use destination manifest file, even if it exists",
+                        action="store_true")
+    parser.add_argument("--jobs",
+                        default=1,
+                        help="Number of parallel jobs to run",
+                        type=int)
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+def convert_date(date_str):
+    try:
+        if date_str == "yesterday":
+            utc_now = datetime.utcnow()
+            utc_yesterday = utc_now + timedelta(days=-1)
+            date = utc_yesterday.strftime('%Y%m%d 23:59:59')
+            dt = parse(date)
+            return dt
+        else:
+            dt = parse(date_str)
+            return dt
+    except Exception, e:
+        raise ValueError(e)
+
+def main():
+    try:
+        # parse arguments
+        args = parse_command_line(sys.argv[1:])
+        slice_branch = args.branch.split("/")[-1]
+        if args.date == "current":
+            utc_now = datetime.utcnow()
+            day_str = utc_now.strftime("%Y%m%d")
+            dest_manifest = "{branch}-{day}".format(branch=slice_branch, day=day_str)
+            generator = ManifestGenerator(dest_manifest, args.branch, args.builddir, args.git_credential, jobs=args.jobs, force=args.force)
+        else:
+            dt = convert_date(args.date)
+            day_str = dt.strftime("%Y%m%d")
+            dest_manifest = "{branch}-{day}".format(branch=slice_branch, day=day_str)
+            date_str = "{0} {1}".format(dt.strftime("%Y-%m-%d %H:%M:%S"), args.timezone)
+            generator = SpecifyDayManifestGenerator(dest_manifest, args.branch, date_str, args.builddir, args.git_credential, jobs=args.jobs, force=args.force)
+            
+        generator.update_manifest()
+        generator.generate_manifest()
+    except Exception, e:
+        print "Failed to generate new manifest for {0} due to \n{1}\nExiting now".format(args.branch, e)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/build-release-tools/application/get_downstream_jobs.py
+++ b/build-release-tools/application/get_downstream_jobs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# Copyright 2016, DELLEMC, Inc.
+
+'''
+The script get name and build number of all the downstream jobs of a jenkins job.
+Usage:
+python get_downstream_jobs.py \
+--jenkins-url http://rackhdci.lss.emc.com \
+--build-url http://rackhdci.lss.emc.com/job/on-core/851/ \
+--parameter-file downstream-files
+
+The required parameters:
+jenkins-url: the URL of jenkins server
+build-url: the build URL of the job, such as http://rackhdci.lss.emc.com/job/on-core/851/.
+
+The optional parameters: 
+parameter-file: The file with parameters. The file will be passed to downstream jobs.
+'''
+
+import json
+import requests
+import os
+import sys
+import argparse
+import re
+
+try:
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--jenkins-url',
+                        required=True,
+                        help="The url of the internal jenkins",
+                        action="store")
+    parser.add_argument('--build-url',
+                        required=True,
+                        help="the url of the build in jenkins",
+                        action="store")
+    parser.add_argument('--parameter-file',
+                        help="The jenkins parameter file that will be used for Jenkins job",
+                        action='store',
+                        default="downstream_parameters")
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+def get_build_data(build_url):
+    '''
+    get the json data of a build
+    :param build_url: the url of a build in jenkins
+    :return: json data of the build if succeed to get the json data
+             None if failed to get the json data
+    '''
+    r = requests.get(build_url + "/api/json")
+    if is_error_response(r):
+        print "Failed to get api json of {0}".format(build_url)
+        print r.status_code
+        return None
+    else:
+        data = r.json()
+        return data
+
+def get_sub_builds(build_url, jenkins_url):
+    '''
+    get sub builds of a build
+    :param build_url: the url of a build in jenkins
+    :return: a dictionary which contains key, value: build name= build number of the sub builds
+    '''
+    build_data = get_build_data(build_url)
+    builds = {}
+    if build_data:
+        if 'subBuilds' in build_data:
+            for subBuild in build_data['subBuilds']:
+                sub_job_name = subBuild['jobName'] 
+                sub_build_number = subBuild['buildNumber']
+                sub_build_url = jenkins_url + "/" + subBuild['url']
+                builds[sub_job_name] = sub_build_number
+                sub_builds = get_sub_builds(sub_build_url, jenkins_url)
+                builds.update(sub_builds)
+
+    return builds
+
+def is_error_response(res):
+    """
+    check the status code of http response
+    :param res: http response
+    :return: True if the status code less than 200 or larger than 299;
+             False if the status code is between 200 and 299
+    """
+    if res is None:
+        return True
+    if res.status_code < 200 or res.status_code > 299:
+        return True
+    return False
+
+def main():
+    args = parse_args(sys.argv[1:])
+    try:
+        sub_builds = get_sub_builds(args.build_url, args.jenkins_url)
+        
+        # Replace the special character of job name with _
+        # Because these parameters are going to used as linux environment variables 
+        # whose variable name may permit some characters which are allowed in jenkins job name,
+        # such as: white space, -, ..
+        parameters = {}
+        for key, value in sub_builds.items():
+            job_name = re.sub(r'[\W_]+', '_', key)
+            parameters[job_name] = value
+        common.write_parameters(args.parameter_file, parameters)
+    except Exception as e:
+        print e
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+

--- a/build-release-tools/application/make_debian_packages.py
+++ b/build-release-tools/application/make_debian_packages.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+# Copyright 2016, DELLEMC, Inc.
+
+"""
+This is a command line program that makes a rackhd release to bintray.
+This program build debian packages for repositories 
+which checked out based on the given manifest file.
+
+Usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/make_debian_packages.py \
+--build-directory b/ \
+--manifest-file rackhd-devel \
+--git-credential https://github.com,GITHUB \
+--jobs 8 \
+--is-official-release true\
+--parameter-file downstream-files \
+--force \
+--sudo-credential SUDO_CREDS
+
+The required parameters:
+build-directory: A directory where all the repositories are cloned to. 
+manifest-file: The path of manifest file. 
+git-credential: Git URL and credential for CI services: <URL>,<Credentials>
+
+The optional parameters:
+is-official-release: Whether this release is official. The default value is False
+parameter-file: The file with parameters. The file will be passed to downstream jobs.
+force: Use destination directory, even if it exists.
+sudo-credential: The environment variable name of sudo credentials.
+                 For example: SUDO_CRED=username:password
+jobs: Number of parallel jobs(build debian packages) to run.
+      The number is related to the compute architecture, multi-core processors..
+force:
+"""
+
+import argparse
+import os
+import sys
+import json
+
+try:
+    from reprove import ManifestActions
+    from manifest import Manifest
+    from update_dependencies import RackhdDebianControlUpdater
+    from version_generator import VersionGenerator
+    from DebianBuilder import DebianBuilder
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--build-directory',
+                        required=True,
+                        help="Top level directory that stores all the cloned repositories.",
+                        action='store')
+
+    parser.add_argument('--manifest-file',
+                        required=True,
+                        help="The file path of manifest",
+                        action='store')
+
+    parser.add_argument('--parameter-file',
+                        help="The jenkins parameter file that will used for succeeding Jenkins job",
+                        action='store',
+                        default="downstream_parameters")
+
+    parser.add_argument('--git-credential',
+                        required=True,
+                        help="Git URL and credential for CI services: <URL>,<Credentials>",
+                        action='append',
+                        default=None)
+
+    parser.add_argument('--sudo-credential',
+                        help="username:password pair for sudo user",
+                        action='store',
+                        default=None)
+
+    parser.add_argument('--jobs',
+                        help="Number of build jobs to run in parallel",
+                        default=-1,
+                        type=int,
+                        action="store")
+
+    parser.add_argument('--is-official-release',
+                        default="false",
+                        help="Whether this release is official",
+                        action="store")
+
+    parser.add_argument('--force',
+                        help="Overwrite a directory even if it exists",
+                        action="store_true")
+
+    parsed_args = parser.parse_args(args)
+    parsed_args.is_official_release = common.str2bool(parsed_args.is_official_release)
+    return parsed_args
+
+def update_rackhd_control(top_level_dir, is_official_release):
+    """
+    Update the rackhd/debian/control with the version of on-xxx.deb under $top_level_dir.
+    :param top_level_dir: Top level directory that stores all the
+                          cloned repositories.
+    :param is_official_release: If true, this release is official release
+    :return: None
+    """
+    updater = RackhdDebianControlUpdater(top_level_dir, is_official_release)
+    updater.update_RackHD_control()
+
+def generate_version_file(repo_dir, is_official_release):
+    """
+    Generate the version file for rackhd repository
+    :param repo_dir: The directory of rackhd repository
+    :param is_official_release: If true, this release is official release
+    :return: True if succeed to compute version and write it into version file.
+             Otherwise, False.
+    """
+    try:
+        version_generator = VersionGenerator(repo_dir)
+        version = version_generator.generate_package_version(is_official_release)
+        if version != None:
+            params = {}
+            params['PKG_VERSION'] = version
+            repo_name = os.path.basename(repo_dir)
+            version_file = "{0}.version".format(repo_name)
+            version_path = os.path.join(repo_dir, version_file)
+            common.write_parameters(version_path, params)
+            return True
+    except Exception, e:
+        raise RuntimeError("Failed to generate version file for {0} \ndue to {1}".format(repo_dir, e))
+
+def run_build_scripts(top_level_dir, repos, jobs=1, sudo_creds=None):
+    """
+    Go into the directory provided and run all the building scripts.
+    :param top_level_dir: Top level directory that stores all the
+                          cloned repositories.
+    :param repos: A list of repositories to be build
+    :param jobs: Number of parallel jobs(build debian packages) to run.
+    :param sudo_creds: the environment variable name of sudo credentials.
+                       for example: SUDO_CRED=username:password
+    :return:
+        exit on failures
+        None on success.
+    """
+    try:
+        builder = DebianBuilder(top_level_dir, repos, jobs=jobs, sudo_creds=sudo_creds)
+        builder.blind_build_all()
+        builder.print_summary_report()
+        builder.print_detailed_report()
+        result = builder.get_build_result()
+        if result:
+            print "Debian building is finished successfully."
+        else:
+            #builder.print_detailed_report()
+            print "Error found during debian building. cannot continue."
+            sys.exit(2)
+    except Exception, e:
+        sys.exit(1)
+
+def get_build_repos(directory):
+    """
+    :param directory: Directory that stores all the cloned repositories.
+    :return: a list which contains the name of repositories under the directory
+    """
+    repos = []
+    for filename in os.listdir(directory):
+        repos.append(filename)
+    return repos
+
+def checkout_repos(manifest, builddir, force, git_credential, jobs):
+    try:
+        manifest_actions = ManifestActions(manifest, builddir, force=force, git_credentials=git_credential, jobs=jobs, actions=["checkout", "packagerefs"])
+        manifest_actions.execute_actions()
+    except Exception, e:
+        print "Failed to checkout repositories according to manifest file {0} \ndue to {1}. Exiting now...".format(manifest, e)
+        sys.exit(1)
+
+def build_debian_packages(build_directory, jobs, is_official_release, sudo_creds):
+    """
+    Build debian packages
+    """
+    try:
+        repos = get_build_repos(build_directory)
+        for repo in repos:
+            repo_dir = os.path.join(build_directory, repo)
+            generate_version_file(repo_dir, is_official_release)
+
+        # Build Debian packages of repositories except RackHD
+        repos.remove("RackHD")
+        # Run HWIMO-BUILD script under each repository to build debian packages
+        run_build_scripts(build_directory, repos, jobs=jobs, sudo_creds=sudo_creds)
+
+        # If on-xxx.deb build successfully, build Debian packages of RackHD
+        repos = ["RackHD"]
+        # Update the debian/control of rackhd to depends on specified version of component of raqkhd
+        update_rackhd_control(build_directory, is_official_release)
+        # Run HWIMO-BUILD script under each repository to build debian packages
+        run_build_scripts(build_directory, repos, sudo_creds=sudo_creds)
+
+    except Exception, e:
+        print "Failed to build debian packages under {0} \ndue to {1}, Exiting now".format(build_directory, e)
+        sys.exit(1)
+
+def write_downstream_parameter_file(build_directory, manifest_file, is_official_release, parameter_file):
+    try:
+        params = {}
+
+        # Add rackhd version to downstream parameters
+        rackhd_repo_dir = os.path.join(build_directory, "RackHD")
+        version_generator = VersionGenerator(rackhd_repo_dir)
+        rackhd_version = version_generator.generate_package_version(is_official_release)
+        if rackhd_version != None:
+            params['RACKHD_VERSION'] = rackhd_version
+        else:
+            raise RuntimeError("Version of {0} is None. Maybe the repository doesn't contain debian directory ".format(rackhd_repo_dir))
+
+        # Add the commit of repository RackHD/RackHD to downstream parameters
+        manifest = Manifest(manifest_file)
+        # commit of repository RackHD/RackHD
+        rackhd_commit = ''
+        for repo in manifest.repositories:
+            repository = repo['repository'].lower()
+            if repository.endswith('rackhd') or repository.endswith('rackhd.git'):
+                rackhd_commit = repo['commit-id']
+
+        if rackhd_commit != '':
+            params['RACKHD_COMMIT'] = rackhd_commit
+        else:
+            raise RuntimeError("commit-id of RackHD is None. Please check the manifest {0}".format(manifest_file))
+            
+        # Write downstream parameters to downstream parameter file.
+        common.write_parameters(parameter_file, params)
+    except Exception, e:
+        raise RuntimeError("Failed to write downstream parameter file \ndue to {0}".format(e))
+
+def main():
+    """
+    Build all the debians.
+    Exit on encountering any error.
+    """
+    args = parse_args(sys.argv[1:])
+    checkout_repos(args.manifest_file, args.build_directory, args.force, args.git_credential, args.jobs)
+    build_debian_packages(args.build_directory, args.jobs, args.is_official_release, args.sudo_credential)
+    write_downstream_parameter_file(args.build_directory, args.manifest_file, args.is_official_release, args.parameter_file)
+
+if __name__ == '__main__':
+    main()

--- a/build-release-tools/application/release_debian_packages.py
+++ b/build-release-tools/application/release_debian_packages.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+# Copyright 2016, EMC, Inc.
+"""
+This is a command line program that upload a rackhd release to bintray.
+
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/release_debian_packages.py --build-directory b/ \
+--bintray-credential BINTRAY \
+--bintray-subject rackhd \
+--bintray-repo debian \
+--bintray-component main \
+--bintray-distribution trusty \
+--bintray-architecture amd64 \
+--debian-depth 3
+
+The required parameters:
+build-directory: A directory where all the repositories are cloned to. 
+bintray-credential: The environment variable name of bintray credential.
+                    For example: BINTRAY_CREDS=username:api_key
+bintray-subject: The Bintray subject, which is either a user or an organization
+bintray-repo: The Bintary repository name
+
+The optional parameters:
+component: The uploaded component of package, default: main
+distribution: The uploaded distribution of package, default: trusty
+architecture: The uploaded architecture of package, default: amd64
+debian-depth: The depth in top level directory that you want this program look into to find debians.
+"""
+import argparse
+import os
+import sys
+
+try:
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+push_exe_script = "pushToBintray.sh"
+
+class Bintray(object):
+    """
+    A module of bintray
+    """
+    def __init__(self, creds, subject, repo, push_executable, **kwargs):
+        self._username, self._api_key = common.parse_credential_variable(creds)
+        self._subject = subject
+        self._repo = repo
+        self._push_executable = push_executable
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    @property
+    def component(self):
+        return self._component
+
+    @component.setter
+    def component(self, component):
+        self._component = component
+
+    @property
+    def distribution(self):
+        return self._distribution
+
+    @distribution.setter
+    def distribution(self, distribution):
+        self._distribution = distribution
+
+    @property
+    def architecture(self):
+        return self._architecture
+
+    @architecture.setter
+    def architecture(self, architecture):
+        self._architecture = architecture
+
+    def upload_a_file(self, package, version, file_path):
+        """
+        Upload a debian file to bintray.
+        """
+        cmd_args = [self._push_executable]
+        cmd_args += ["--user", self._username]
+        cmd_args += ["--api_key", self._api_key]
+        cmd_args += ["--subject", self._subject]
+        cmd_args += ["--repo", self._repo]
+        cmd_args += ["--package", package]
+        cmd_args += ["--version", version]
+        cmd_args += ["--file_path", file_path]
+
+        if self._component:
+            cmd_args += ["--component", self._component]
+        if self._distribution:
+            cmd_args += ["--distribution", self._distribution]
+        if self._architecture:
+            cmd_args += ["--architecture", self._architecture]
+
+        cmd_args += ["--package", package]
+        cmd_args += ["--version", version]
+        cmd_args += ["--file_path", file_path]
+
+        try:
+            common.run_command(cmd_args)
+        except Exception, ex:
+            raise RuntimeError("Failed to upload file {0} due to {1}".format(file_path, ex))
+        return True
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--build-directory',
+                        required=True,
+                        help="Top level directory that stores all the cloned repositories.",
+                        action='store')
+
+    parser.add_argument('--debian-depth',
+                        help="The depth in top level directory that you want"
+                             " this program look into to find debians.",
+                        default=3,
+                        type=int,
+                        action='store')
+
+    parser.add_argument('--bintray-credential',
+                        required=True,
+                        help="bintray credential for CI services: <Credentials>",
+                        action='store')
+
+    parser.add_argument('--bintray-subject',
+                        required=True,
+                        help="the Bintray subject, which is either a user or an organization",
+                        action='store')
+
+    parser.add_argument('--bintray-repo',
+                        required=True,
+                        help="the Bintary repository name",
+                        action='store')
+
+    parser.add_argument('--bintray-component',
+                        help="such as: main",
+                        action='store',
+                        default='main')
+
+    parser.add_argument('--bintray-distribution',
+                        help="such as: trusty, xenial",
+                        action='store',
+                        default='trusty')
+
+    parser.add_argument('--bintray-architecture',
+                        help="such as: amd64, i386",
+                        action='store',
+                        default='amd64')
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+def get_push_executable():
+    repo_dir = os.path.dirname(sys.path[0])
+    for subdir, dirs, files in os.walk(repo_dir):
+        for file in files:
+            if file == push_exe_script:
+                return os.path.join(subdir, file)
+    return None
+
+def upload_debs(build_directory, debian_depth, bintray):
+    """
+    The function will walk through all sub-folder under $build_directory, and for every *.deb found:
+        1. retrieve its version and package name
+        2. upload to bintray with this version
+
+    :param build_directory: The directory where all the build repositories are cloned.
+    :param debian_depth: integer for level of directories to look into
+                         the repository directory to look for debians
+    :param bintray: An instance of Bintray.
+    """
+    return_dict_detail = {}
+    debian_files = common.find_specify_type_files(build_directory, ".deb", depth=debian_depth)
+    if len(debian_files) == 0:
+        return_dict_detail[build_directory] = "No debians found under {dir}".format(dir=build_directory)
+
+    for file_itr in debian_files:
+        version = common.get_debian_version(file_itr)
+        package = common.get_debian_package(file_itr)
+        upload_result = bintray.upload_a_file(package, version, file_itr)
+        if upload_result:
+            return_dict_detail[package] = "{package} upload successfully".format(package=file_itr)
+        else:
+            raise RuntimeError("Upload Failure at {repo}.\nDetails:{file}: Fail"
+                               .format(repo=package, file=file_itr))
+
+    return return_dict_detail
+
+def main():
+    """
+    Upload all the debian packages under top level dir to bintray.
+    Exit on encountering any error.
+    :return:
+    """
+    args = parse_args(sys.argv[1:])
+    try:
+        push_script_path = get_push_executable()
+        bintray = Bintray(args.bintray_credential, args.bintray_subject, args.bintray_repo, push_script_path, component=args.bintray_component, distribution=args.bintray_distribution, architecture=args.bintray_architecture)
+
+        return_dict_detail = upload_debs(args.build_directory, args.debian_depth, bintray)
+        for key, value in return_dict_detail.items():
+            print "{key}: {value}".format(key=key, value=value)
+    except Exception, e:
+        print e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/build-release-tools/application/release_to_atlas.py
+++ b/build-release-tools/application/release_to_atlas.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+# Copyright 2016, EMC, Inc.
+
+"""
+This is a command line program that upload vagrant.boxs to atlas.
+
+usage:
+    ./on-tools/manifest-build-tools/HWIMO-BUILD \
+    on-tools/manifest-build-tools/application/release_to_atlas.py \
+    --build-directory b/RackHD/packer \
+    --atlas-url https://atlas.hashicorp.com/api/v1 \
+    --atlas-username rackhd \
+    --atlas-name rackhd \
+    --atlas-token ****** \
+    --atlas-version 1.2.3 \
+    --is-release true
+
+The required parameters:
+    build-directory: A directory where box files laid in.
+    atlas-token: atlas access token.
+
+The optional parameters:
+    provider: The provider of vagrant box, virtualbox, vmware_fusion .etc, default: virtualbox
+    atlas-url: Base URL for Atlas, default: https://atlas.hashicorp.com/api/v1
+    atlas-username: The account name of atlas, default: rackhd
+    atlas-name: The box name under a specific account of atlas, default: rackhd
+    atlas-version: The box version in atlas, default: version number when is_release
+                   0.month.day when is ci_builds.
+"""
+
+import sys
+import argparse
+import requests
+import subprocess
+
+try:
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class Atlas(object):
+    """
+    A simple class of atlas.
+    An instance of 'class Atlas' represents a box in Atlas.
+        default: rackhd/rackhd in official Atlas server.
+    """
+    def __init__(self, atlas_url, atlas_username, atlas_name, atlas_token):
+        self.atlas_url = atlas_url or "https://atlas.hashicorp.com/api/v1"
+
+        self.atlas_username = atlas_username or "rackhd"
+        self.atlas_name = atlas_name or "rackhd"
+        self.box = "/".join(["box", self.atlas_username, self.atlas_name])
+
+        self.atlas_token = atlas_token
+
+        self.session = requests.Session()
+        self.session.headers.update({'X-Atlas-Token': self.atlas_token})
+
+    def upload_handler(self, atlas_version, provider, box_file):
+        """
+        Upload a box file to atlas.
+        See https://vagrantcloud.com/help/vagrant/boxes/create for more details
+        """
+        if not self.version_exist(atlas_version):
+            self.create_version(atlas_version)
+
+        if not self.provider_exist(atlas_version, provider):
+            self.create_provider(atlas_version, provider)
+
+        self.upload_box(atlas_version, provider, box_file)
+
+    def create_version(self, atlas_version):
+        """
+        Create box version
+        """
+        create_version_url = self.generate_url("create_version")
+        version_data = {'version[version]': atlas_version}
+        print create_version_url
+        resp = self.session.post(create_version_url, data=version_data)
+        if resp.ok:
+            print "Create box version {0} successfully.".format(atlas_version)
+        else:
+            print "Failed to create box version.\n {0}".format(resp.text)
+            sys.exit(1)
+
+    def create_provider(self, atlas_version, provider):
+        """
+        Create box provider of a specific version
+        """
+        create_provider_url = self.generate_url("create_provider", atlas_version)
+        provider_data = {'provider[name]': provider}
+        resp = self.session.post(create_provider_url, data=provider_data)
+        if resp.ok:
+            print "Create box provider {0} of version {1} successfully.".format(provider, atlas_version)
+        else:
+            print "Failed to create box provider.\n {0}".format(resp.text)
+            sys.exit(1)
+
+    def upload_box(self, atlas_version, provider, box_file):
+        """
+        Upload one box to a specific version/provider
+        """
+        upload_box_url = self.generate_url("upload_box", atlas_version, provider)
+        resp = self.session.get(upload_box_url)
+        if resp.ok:
+            upload_path = resp.json()["upload_path"]
+            cmd = "curl -X PUT --upload-file " +  box_file  + " " +  upload_path
+            p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            retval = p.wait()
+            if retval == 0 :
+                print "Upload box {0} to version/{1}/provider/{2} successfully!".format(box_file, atlas_version, provider)
+            else:
+                print "Failed to Upload box {0} to version/{1}/provider/{2}!\n {3}".format(box_file, atlas_version, provider,retval)
+                sys.exit(1)
+
+    def version_exist(self, atlas_version):
+        """
+        Check if box version exists
+        """
+        check_version_url = self.generate_url("check_version", atlas_version)
+        resp = self.session.get(check_version_url)
+        if resp.ok:
+            print "Box version {0} already exists.".format(atlas_version)
+            return True
+        print "Box version {0} doesn't' exist, will be created soon.".format(atlas_version)
+        return False
+
+    def provider_exist(self, atlas_version, provider):
+        """
+        Check if box provider exists.
+        NOTICE: provider depends on a specific box version.
+        """
+        if not self.version_exist(atlas_version):
+            print "Box version {0} doesn't' exist, please create version before check provider.".format(atlas_version)
+            return False
+        check_provider_url = self.generate_url("check_provider", atlas_version, provider)
+        resp = self.session.get(check_provider_url)
+        if resp.ok:
+            print "{0} provider of version {1} already exists!".format(provider, atlas_version)
+            return True
+        print "{0} provider of version {1} doesn't' exist, will be created soon".format(provider, atlas_version)
+        return False
+
+    def generate_url(self, purpose, atlas_version=None, provider=None):
+        """
+        Tool method, Generate all possible urls according to purpose
+        """
+        purpose_handler = {
+            "check_version": lambda atlas_version, provider: "/".join([self.atlas_url, self.box, "version/{0}".format(atlas_version)]),
+            "create_version": lambda atlas_version, provider: "/".join([self.atlas_url, self.box, "versions"]),
+            "check_provider": lambda atlas_version, provider: "/".join([self.atlas_url, self.box, "version/{0}/provider/{1}".format(atlas_version, provider)]),
+            "create_provider": lambda atlas_version, provider: "/".join([self.atlas_url, self.box, "version/{0}/providers".format(atlas_version)]),
+            "upload_box": lambda atlas_version, provider: "/".join([self.atlas_url, self.box, "version/{0}/provider/{1}".format(atlas_version, provider), "upload"])
+        }
+        return purpose_handler[purpose](atlas_version, provider)
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--build-directory',
+                        required=True,
+                        help="A directory where box files laid in",
+                        action='store')
+
+    parser.add_argument('--atlas-url',
+                        help="Base URL for Atlas, default: https://atlas.hashicorp.com/api/v1",
+                        action='store')
+
+    parser.add_argument('--atlas-username',
+                        help="The account name of atlas, default: rackhd",
+                        action='store')
+
+    parser.add_argument('--atlas-name',
+                        help="The repo name under a specific account of atlas, default: rackhd",
+                        action='store')
+
+    parser.add_argument('--atlas-token',
+                        required=True,
+                        help="atlas access token",
+                        action='store')
+
+    parser.add_argument('--atlas-version',
+                        help="set box version in atlas",
+                        action='store')
+
+    parser.add_argument('--is-release',
+                        help="if this is a step of rlease build",
+                        default=False,
+                        action='store')
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+def upload_boxs(build_directory, atlas, is_release, atlas_version):
+    """
+    The function will walk through all sub-folder under $build_directory, and for every *.box found:
+        1. retrieve its version
+        2. upload to atlas with this version
+    NOTICE:
+        1. Box version is calculated from box file name.
+        2. Box provider is hardcoded and default to virtualbox currently.
+           If need to upload boxs of multi-provider, there should be a way
+           to pass the provider information to this script.
+    """
+
+    box_files = common.find_specify_type_files(build_directory, ".box", depth=1)
+    if len(box_files) == 0:
+        print "No box found under {0}".format(build_directory)
+
+    for full_file_path in box_files:
+        if not atlas_version:
+            if is_release:
+                # Box file name is like "rackhd-ubuntu-14.04-1.2.3.box" when release.
+                # Extract 1.2.3 only
+                atlas_version = "-".join(full_file_path.split('/')[-1:][0].strip(".box").split('-')[4])
+            else:
+                from datetime import datetime
+                datatime_now_md = datetime.utcnow().strftime("0.%m.%d")
+                atlas_version = datatime_now_md
+        atlas.upload_handler(atlas_version, "virtualbox", full_file_path)
+
+def main():
+    """
+    Upload all the vagrant boxs to Atlas.
+    """
+    try:
+        args = parse_args(sys.argv[1:])
+        is_release = False
+        if args.is_release == "true" or args.is_release == "True":
+            is_release = True
+        atlas = Atlas(args.atlas_url, args.atlas_username, args.atlas_name, args.atlas_token)
+        upload_boxs(args.build_directory, atlas, is_release, args.atlas_version)
+    except Exception, e:
+        print e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/build-release-tools/application/reprove.py
+++ b/build-release-tools/application/reprove.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python
+# see http://stackoverflow.com/questions/1783405/checkout-remote-git-branch
+# and http://stackoverflow.com/questions/791959/download-a-specific-tag-with-git
+
+# check out a set of repositories to match the manifest file
+
+# Copyright 2015, EMC, Inc.
+
+"""
+usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/reprove.py \
+--manifest manifest-files/rackhd-devel \
+--builddir d \
+--force \
+--git-credential https://github.com,GITHUB \
+--jobs 8 \
+--branch-name "branch/release-1.5.1 \
+checkout \
+branch
+
+The required parameters:
+manifest: the path of manifest file.
+builddir: the destination for checked out repositories.
+git-credential: url, credentials pair for the access to github repos.
+                For example: https://github.com,GITHUB
+                GITHUB is an environment variable: 
+                GITHUB=username:password
+action: the supported action, includes checkout branch.
+        "checkout": it  will clone all the repositories in a manifest file;
+                    if "branch" in a repository dictionary, the action will check out to the branch.
+                    if "commit-id" in a repository dictionary, the action will reset to the commit 
+        "branch": it will create a new branch for all the repositories under builddir
+                  and update the package.json to point to the new branch.
+                  For example:
+                  - git+https://github.com/RackHD/on-core.git
+                  + git+https://github.com/RackHD/on-core.git#branch/release-1.2.3
+
+The optional parameters:
+force: use destination directory, even if it exists
+jobs: number of parallel jobs to run. The number is related to the compute architecture, multi-core processors...
+branch-name: the name of new branch.
+             If action contains "branch", the parameter is required.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import config
+
+from urlparse import urlparse, urlunsplit
+from RepositoryOperator import RepoOperator
+from manifest import Manifest
+from common import *
+
+class ManifestActions(object):
+    
+    """
+    valid actions:
+    checkout: check out a set of repositories to match the manifest file
+    """
+    valid_actions = ['checkout', 'branch', 'packagerefs']
+
+    def __init__(self, manifest_path, builddir, force=False, git_credentials=None, jobs=1, actions=[], branch_name=None):
+        """
+        __force - Overwrite a directory if it exists
+        __git_credential - url, credentials pair for the access to github repos
+        __manifest - Repository manifest contents
+        __builddir - Destination for checked out repositories
+        __jobs - Number of parallel jobs to run
+        __actions -Supported actions
+        :return:
+        """
+        self._force = force
+        self._git_credentials = git_credentials
+        self._builddir = builddir
+        self._manifest = None
+        self.handle_manifest(manifest_path)
+        self._jobs = jobs
+        self.actions = []
+        for action in actions:
+            self.add_action(action)
+
+        self._branch_name = branch_name
+       
+        self.repo_operator = RepoOperator(self._git_credentials)
+
+    def set_force(self, force):
+        """
+        Standard setter for force
+        :param force: if true, overwrite a directory if it exists
+        :return: None
+        """
+        self._force = force
+
+    def get_force(self):
+        """
+        Standard getter for force
+        :return: force
+        """
+        return self._force
+
+    
+    def set_branch_name(self, branch):
+        """
+        Standard setter for branch_name
+        :param force: if true, overwrite a directory if it exists
+        :return: None
+        """
+        self._branch_name = branch
+
+    def get_branch_name(self):
+        """
+        Standard getter for branch_name
+        :return: force
+        """
+        return self._branch_name
+
+    def set_git_credentials(self, git_credential):
+        """
+        Standard setter for git_credentials
+        :param git_credential: url, credentials pair for the access to github repos
+        :return: None
+        """
+        self._git_credentials = git_credential
+        self.repo_operator.setup_gitbit(credentials=self._git_credentials)    
+
+    def get_manifest(self):
+        """
+        Standard getter for manifest
+        :return: an instance of Manifest
+        """
+        return self._manifest
+
+    def add_action(self, action):
+        """
+        Add action to actions
+        :param action: a string, just like: checkout
+        :return: None
+        """
+        if action not in self.valid_actions:
+            print "Unknown action '{0}' requested".format(action)
+            print "Valid actions are:"
+            for op in self.valid_actions:
+                print "  {0}".format(op)
+            sys.exit(1)
+        else:
+            if action == "branch" and self._git_credentials == None:
+                print "Must Specify git_credentials when try to create branch"
+                sys.exit(1)
+            self.actions.append(action)
+
+    def set_jobs(self, jobs):
+        """
+        Standard setter for jobs
+        :param jobs: number of parallel jobs to run
+        :return: None
+        """
+        self._jobs = jobs
+        if self._jobs < 1:
+            print "--jobs value must be an integer >=1"
+            sys.exit(1)
+
+    def handle_manifest(self, manifest_path):
+        """
+        initial manifest and validate it
+        :param manifest_path: the path of manifest file
+        :return: None
+        """
+        try:
+            self._manifest = Manifest(manifest_path)
+            self._manifest.validate_manifest()
+        except KeyError as error:
+            print "Failed to create a Manifest instance for the manifest file {0} \nERROR:\n{1}"\
+                  .format(manifest_path, error.message)
+            sys.exit(1)
+         
+        for repo in self._manifest.repositories:
+            repo['directory-name'] = self.directory_for_repo(repo)
+
+    def check_builddir(self):
+        """
+        Checks the given builddir name and force flag. 
+        Deletes exists directory if one already exists and --force is set
+        :return: None
+        """
+        if os.path.exists(self._builddir):
+            if self._force:
+                shutil.rmtree(self._builddir)
+                print "Removing existing data at {0}".format(self._builddir)
+            else:
+                print "Unwilling to overwrite destination builddir of {0}".format(self._builddir)
+                sys.exit(1)
+
+        os.makedirs(self._builddir)
+
+    def get_repositories(self):
+        """
+        Issues checkout commands to dictionaries within a provided manifest
+        :return: None
+        """
+        repo_list = self._manifest.repositories
+        try:
+            self.repo_operator.clone_repo_list(repo_list, self._builddir, jobs=self._jobs)
+        except RuntimeError as error:
+            print "Exiting due to error: {0}".format(error)
+            sys.exit(1)
+            
+    def directory_for_repo(self, repo):
+        """
+        Get the directory of a repository
+        :param repo: a dictionary
+        :return: the directary of repository
+        """
+        if 'checked-out-directory-name' in repo:
+            repo_directory = repo['checked-out-directory-name']
+        else:
+            if 'repository' in repo:
+                repo_url = repo['repository']
+                repo_directory = strip_suffix(os.path.basename(repo_url), ".git")
+            else:
+                raise ValueError("no way to find basename")
+
+        repo_directory = os.path.join(self._builddir, repo_directory)
+        return repo_directory
+
+    def execute_actions(self):
+        """
+        start to execute actions
+        :return: None
+        """
+        # Start to check out a set of repositories within a manifest file
+        if 'checkout' in self.actions:
+            self.check_builddir()
+            self.get_repositories()
+
+        # Start to create branch and update package.json
+        if 'branch' in self.actions:
+            self.execute_branch_action()
+
+        # Start to update the packge.json, for example:
+        # - git+https://github.com/RackHD/on-core.git
+        # +     
+        if 'packagerefs' in self.actions:
+            self.update_package_references()
+
+    def execute_branch_action(self):
+        """
+        execute the action "branch"
+        :return: None
+        """
+        if self._branch_name is None:
+            raise ValueError("No setting for branch-name")
+        else:
+            print "create branch and update package.json for the repos..."
+            self.branch_existing_repositories()
+            self.checkout_branch_repositories(self._branch_name)
+            self.update_package_references(version=self._branch_name)
+            commit_message = "update the dependencies version to {0}".format(self._branch_name)
+            self.push_changed_repositories(commit_message)
+
+    def branch_existing_repositories(self):
+        """
+        Issues create branch commands to repos in a provided manifest
+        :return: None
+        """
+        if self._branch_name is None:
+            print "Please provide the new branch name"
+            sys.exit(2)
+
+        repo_list = self._manifest.repositories
+        if repo_list is None:
+            print "No repository list found in manifest file"
+            sys.exit(2)
+        else:
+            # Loop through list of repos and create specified branch on each
+            for repo in repo_list:
+                self.create_repo_branch(repo, self._branch_name)
+
+    def create_repo_branch(self, repo, branch):
+        """
+        create branch  on the repos in the manifest file
+        :param repo: A dictionary
+        :return: None
+        """
+        try:
+            repo_directory = self.directory_for_repo(repo)
+            repo_url = repo["repository"]
+            self.repo_operator.create_repo_branch(repo_url, repo_directory, branch)
+
+        except RuntimeError as error:
+            print "Exiting due to error: {0}".format(error)
+            sys.exit(1)   
+    
+    def checkout_branch_repositories(self, branch):
+        repo_list = self._manifest.repositories
+        if repo_list is None:
+            print "No repository list found in manifest file"
+            sys.exit(2)
+        else:
+            # Loop through list of repos and checkout specified branch on each
+            for repo in repo_list:
+                self.checkout_repo_branch(repo, branch)
+
+    def checkout_repo_branch(self, repo, branch):
+        """
+        checkout to a specify branch on repository
+        :param repo: A dictionary
+        :param branch: the specify branch name
+        :return: None
+        """
+        try:
+            repo_directory = self.directory_for_repo(repo)
+            self.repo_operator.checkout_repo_branch(repo_directory, branch)
+        except RuntimeError as error:
+            print "Exiting due to error: {0}".format(error)
+            sys.exit(1)
+
+    def update_package_references(self, version=None):
+        print "Update internal package lists"
+        repo_list = self._manifest.repositories
+        if repo_list is None:
+            print "No repository list found in manifest file"
+            sys.exit(2)
+        else:
+            # Loop through list of repos and update package.json on each
+            for repo in repo_list:
+                self.update_repo_package_list(repo, pkg_version=version)
+
+    def update_repo_package_list(self, repo, pkg_version=None):
+        """
+        Update the package.json of repository to point to new version
+        :param repo: a manifest repository entry
+        :param pkg_version: the version of package.json to point to
+        :return:
+        """
+        repo_dir = repo['directory-name']
+
+        package_json_file = os.path.join(repo_dir, "package.json")
+        if not os.path.exists(package_json_file):
+            # if there's no package.json file, there is nothing more for us to do here
+            return
+
+        changes = False
+        log = ""
+
+        with open(package_json_file, "r") as fp:
+            package_data = json.load(fp)
+            if 'dependencies' in package_data:
+                for package, version in package_data['dependencies'].items():
+                    new_version = self._update_dependency(version, pkg_version=pkg_version)
+                    if new_version != version:
+                        log += "  {0}:\n    WAS {1}\n    NOW {2}\n".format(package,
+                                                                           version,
+                                                                           new_version)
+                        package_data['dependencies'][package] = new_version
+                        changes = True
+        if changes:
+            print "There are changes to dependencies for {0}\n{1}".format(package_json_file, log)
+            os.remove(package_json_file)
+
+            new_file = package_json_file
+            with open(new_file, "w") as newfile:
+                json.dump(package_data, newfile, indent=4, sort_keys=True)
+
+        else:
+            print "There are NO changes to data for {0}".format(package_json_file)
+
+
+    def _update_dependency(self, version, pkg_version=None):
+        """
+        Check the specified package & version, and return a new package version if
+        the package is listed in the manifest.
+
+        :param version:
+        :return:
+        """
+        if not version.startswith("git+"):
+            return version
+
+        url = strip_prefix(version, "git+")
+        url = url.split('#')[0]
+        new_url = url
+
+        if pkg_version is None:
+            for repo in self._manifest.repositories:
+                if new_url == repo['repository']:
+                    if 'directory-name' in repo:
+                        new_url = os.path.abspath(repo['directory-name'])
+                        return new_url
+        else:
+            for repo in self._manifest.repositories:
+                if new_url == repo['repository']:
+                    new_url = "git+{url}#{pkg_version}".format(url=new_url, pkg_version=pkg_version)
+                    return new_url
+
+        return version
+
+    def push_changed_repositories(self, commit_message):
+        repo_list = self._manifest.repositories
+        if repo_list is None:
+            print "No repository list found in manifest file"
+            sys.exit(2)
+        else:
+            # Loop through list of repos and publish changes on each
+            for repo in repo_list:
+                self.push_changed_repo(repo, commit_message)
+
+    def push_changed_repo(self, repo, commit_message):
+        """
+        publish changes in the repository
+        :param repo: A dictionary
+        :param commit_message: the message to be added to the commit
+        :return: None
+        """
+        repo_dir = repo['directory-name']
+
+        try:
+            self.repo_operator.push_repo_changes(repo_dir, commit_message)
+        except RuntimeError as error:
+            print "Exiting due to error: {0}".format(error)
+            sys.exit(1)
+
+def parse_command_line(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest",
+                        required=True,
+                        help="repository manifest file",
+                        action="store")
+    parser.add_argument("--builddir",
+                        required=True,
+                        help="destination for checked out repositories",
+                        action="store")
+    parser.add_argument("--force",
+                        help="use destination dir, even if it exists",
+                        action="store_true")
+    parser.add_argument("--git-credential",
+                        help="Git credentials for CI services",
+                        action="append")
+    parser.add_argument("--branch-name",
+                        help="branch name applied to repos",
+                        action="store")
+    parser.add_argument("--jobs",
+                        default=1,
+                        help="Number of parallel jobs to run",
+                        type=int)
+    parser.add_argument('action',
+                        nargs="+")
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+def main():
+    try:
+        # Parse arguments
+        args = parse_command_line(sys.argv[1:])
+    
+        # Create and initial an instance of ManifestActions
+        manifest_actions = ManifestActions(args.manifest, args.builddir, force=args.force, git_credentials=args.git_credential, jobs=args.jobs, actions=args.action, branch_name=args.branch_name)
+
+        manifest_actions.execute_actions()
+    except Exception,e:
+        print e
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/build-release-tools/application/tag_change_monitor.py
+++ b/build-release-tools/application/tag_change_monitor.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# Copyright 2016, EMC, Inc.
+
+"""
+This is a command line program that monitor repos tag updates.
+When new tag appears, this script will write a property file contains new tag information.
+So a record file which stored history tags in each line is necessary.
+
+usage:
+    ./on-tools/manifest-build-tools/HWIMO-BUILD.py \
+    on-tools/manifest-build-tools/application/tag_change_monitor.py \
+    --repo rackhd/on-http \
+    --history_file workspace/on-http_tag_history
+    --property_file workspace/property_file
+    --credential CREDS
+
+The required parameters:
+    repo: user_name/repo_name that indicates which repo should be monitoring.
+    history_file: A file stored one history tag in each line. If doesn't exists it will be created.
+    property_file: A file used for downstream job. It's format is like this:
+                  tag_name=release/1.2.3
+                  commit=fb47e10......
+                  repository=https://github.com/RackHD/......
+                  Contains the newly added tags (comparing with the $hsitory_file), with those tags' 
+                  corresponding commit/repository"
+
+The optional parameters:
+    credential, A env var name which stores user:password of github.
+    If you run this scipt continually this parameter is needed, otherwise github will forbidden the api requests.
+"""
+
+import os
+import sys
+import argparse
+import requests
+
+class TagChangeMonitor(object):
+    """
+    A simple class that monitor repo tag updates.
+    One monitor for one repo.
+    """
+    def __init__(self, repo, history_file, property_file, credential):
+        self.api_url = "https://api.github.com"
+        self.repo = repo
+        self.history_file = history_file
+        self.property_file = property_file
+        if credential:
+            user, password = os.environ[credential].split(':')
+            self.auth = (user, password)
+        else:
+            self.auth = ()
+
+        self.history = {}
+        self.new_history = {}
+        self.change = {}
+
+        if os.path.isfile(history_file):
+            with file(history_file, 'r') as f:
+                for tag_commit in f.readlines():
+                    commit = tag_commit.split()[0]
+                    tags = tag_commit.split()[1:]
+                    self.history[commit] = tags
+                f.close()
+        else:
+            with file(history_file, 'w') as f:
+                f.close()
+
+    def handle_tag_monitor(self):
+        """
+        Do tag monitor job
+        """
+        tag_list = self.get_tags()
+        self.parse_tag_info(tag_list)
+        if self.change:
+            self.write_property_file()
+        self.write_history_file()
+
+    def get_tags(self):
+        """
+        Get all tags of current repo.
+        """
+        list_tag_url = "/".join([self.api_url, "repos", self.repo, "tags"])
+        if self.auth:
+            resp = requests.get(list_tag_url, auth=self.auth)
+        else:
+            resp = requests.get(list_tag_url)
+        if resp.ok:
+            return resp.json()
+        else:
+            print "Get tags of repo {0} error.\n{1}".format(self.repo, resp.text)
+            sys.exit(1)
+
+    def parse_tag_info(self, tag_list):
+        """
+        Get tag change and generate new tag history record.
+        """
+        find_change = False
+        contains_in_new = True
+        for tag in tag_list:
+            tag_name = tag['name']
+            commit = tag['commit']['sha']
+
+            if (not self.history.has_key(commit)) or \
+                (tag_name not in self.history[commit]):
+                if not find_change:
+                    self.change[commit] = [tag_name]
+                    find_change = True
+                else:
+                    contains_in_new = False
+
+            if contains_in_new:
+                if self.new_history.has_key(commit):
+                    self.new_history[commit].append(tag_name)
+                else:
+                    self.new_history[commit] = [tag_name]
+            else:
+                contains_in_new = True
+
+    def write_history_file(self):
+        """
+        Write new_history to history_file
+        This can keep history file valid when deleting tags.
+        """
+        with file(self.history_file, 'w') as history_file_handler:
+            for commit, tags in self.new_history.iteritems():
+                tags.insert(0, commit)
+                tags.append('\n')
+                history_file_handler.write(" ".join(tags))
+
+    def write_property_file(self):
+        """
+        For those tags "newly" detected for this run, write those tags' 
+        information into a property file ( being used by downstream Jenkins job )
+        """
+        with file(self.property_file, 'w') as property_file_handler:
+            for commit, tags in self.change.iteritems():
+                output = ""
+                output += "tag_name={0}\n".format(tags[0])
+                output += "commit={0}\n".format(commit)
+                output += "repository=https://github.com/{0}.git".format(self.repo)
+                property_file_handler.write(output)
+
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--repo',
+                        required=True,
+                        help="Indicates the repo",
+                        action='store')
+
+    parser.add_argument('--history_file',
+                        required=True,
+                        help="File stored tag history",
+                        action='store')
+
+    parser.add_argument('--property_file',
+                        required=True,
+                        help="Downstream file to use",
+                        action='store')
+
+    parser.add_argument('--credential',
+                        help="github credits",
+                        action='store')
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+def main():
+    """
+    Monitor tag change of on repo
+    """
+    try:
+        args = parse_args(sys.argv[1:])
+        tcm = TagChangeMonitor(args.repo, args.history_file, args.property_file, args.credential)
+        tcm.handle_tag_monitor()
+    except Exception, e:
+        print e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/build-release-tools/application/update_changelog.py
+++ b/build-release-tools/application/update_changelog.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+# Copyright 2015-2016, EMC, Inc.
+
+"""
+The script will update the debian/changelog files, inside all git repos under the folder which "build-dir" param specified. 
+The version field in changelog file will be updated to given version ( via "dch  -v $ver -b -m" command).
+
+
+usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/update_changelog.py \
+--build-dir d/ \
+--version 1.2.6 \
+--publish \
+--git-credential https://github.com,GITHUB \
+--message "new branch 1.2.6"
+
+The required parameters: 
+build-dir: The top directory which stores all the cloned repositories
+version: The new release version
+
+The optional parameters:
+message (default value is "new release" + version )
+publish: If true, the updated changlog will be push to github.
+git-credential: url, credentials pair for the access to github repos.
+                For example: https://github.com,GITHUB
+                GITHUB is an environment variable: GITHUB=username:password
+                If parameter publish is true, the parameter is required.
+"""
+import os
+import sys
+import argparse
+import datetime
+import subprocess
+from RepositoryOperator import RepoOperator
+from common import *
+
+class ChangelogUpdater(object):
+    def __init__(self, repo_dir, version):
+        """
+        The module updates debian/changelog under the directory of repository
+        _repo_dir: the directory of the repository
+        _version: the new version which is going to be updated to changelog
+        """
+        self._repo_dir = repo_dir
+        self._version = version
+        self.repo_operator = RepoOperator()
+ 
+    def debian_exist(self):
+        """
+        check whether debian directory under the repository
+        return: True if debian exist
+                False
+        """
+        if os.path.isdir(self._repo_dir):
+            for filename in os.listdir(self._repo_dir):
+                if filename == "debian":
+                    return True
+        return False
+
+    def get_repo_name(self):
+        """
+        get the name of the repository
+        :return: the name of the repository
+        """
+        repo_url = self.repo_operator.get_repo_url(self._repo_dir)
+        repo_name = strip_suffix(os.path.basename(repo_url), ".git")
+        return repo_name
+
+    def update_changelog(self, message=None):
+        """
+        add an entry to changelog
+        :param message: the message which is going to be added to changelog
+        return: Ture if changelog is updated
+                False, otherwise
+        """
+        repo_name = self.get_repo_name()
+        debian_exist = self.debian_exist()
+        linked = False
+        if not debian_exist:
+            # Handle repository which contains debianstatic/repository_name folder, 
+            # for example: debianstatic/on-http
+            for filename in os.listdir(self._repo_dir):
+                if filename == "debianstatic":
+                    debianstatic_dir = os.path.join(self._repo_dir, "debianstatic")
+                    for debianstatic_filename in os.listdir(debianstatic_dir):
+                        if debianstatic_filename == repo_name:
+                            debianstatic_repo_dir = "debianstatic/{0}".format(repo_name)
+                            link_dir(debianstatic_repo_dir, "debian", self._repo_dir)
+                            linked = True
+
+        if not debian_exist and not linked:
+            return False
+
+        print "start to update changelog of {0}".format(self._repo_dir)
+        # -v: Add a new changelog entry with version number specified
+        # -b: Force a version to be less than the current one
+        # -m: Don't change (maintain) the trailer line in the changelog entry; i.e.
+        #     maintain the maintainer and date/time details
+        cmd_args = ["dch", "-v", self._version, "-b", "-m"]
+        if message is None:
+            message = "new release {0}".format(self._version)
+        cmd_args += ["-p", message]
+        proc = subprocess.Popen(cmd_args,
+                                cwd=self._repo_dir,
+                                stderr=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                shell=False)
+        (out, err) = proc.communicate()
+
+        if linked:
+            os.remove(os.path.join(self._repo_dir, "debian"))
+
+        if proc.returncode != 0:
+            raise RuntimeError("Failed to add an entry for {0} in debian/changelog due to {1}".format(self._version, err))
+
+        return True
+
+def parse_command_line(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build-dir",
+                        required=True,
+                        help="Top level directory that stores all the cloned repositories.",
+                        action="store")
+    parser.add_argument("--version",
+                        required=True,
+                        help="the new release version",
+                        action="store")
+    parser.add_argument("--message",
+                        help="the message which is going to be added to changelog",
+                        action="store")
+
+    parser.add_argument("--publish",
+                        help="Push the new manifest to github",
+                        action='store_true')
+    parser.add_argument("--git-credential",
+                        help="Git credential for CI services",
+                        action="append")
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+def main():
+    # parse arguments
+    args = parse_command_line(sys.argv[1:])
+    if args.publish:
+        if args.git_credential:
+            repo_operator = RepoOperator(args.git_credential)
+        else:
+            print "If you want to publish the updated changelog, please specify the git-credential. Exiting now..."
+            sys.exit(1)
+
+    if os.path.isdir(args.build_dir):
+        for filename in os.listdir(args.build_dir):
+            try:
+                repo_dir = os.path.join(args.build_dir, filename)
+                updater = ChangelogUpdater(repo_dir, args.version)
+                if updater.update_changelog(message = args.message):
+                    if args.publish:
+                        commit_message = "update changelog for new release {0}".format(args.version)
+                        repo_operator.push_repo_changes(repo_dir, commit_message)
+            except Exception,e:
+                print "Failed to update changelog of {0} due to {1}".format(filename, e)
+                sys.exit(1)
+    else:
+        print "The argument build-dir must be a directory"
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/build-release-tools/application/update_dependencies.py
+++ b/build-release-tools/application/update_dependencies.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+# Copyright 2016, DELLEMC, Inc.
+
+"""
+usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/update_dependencies.py \
+--manifest rackhd-devel \
+--builddir b \
+--force \
+--git-credential https://github.com/PengTian0,GITHUB \
+--jobs 8 \
+--is-official-release true/false
+                     
+The required parameters:
+manifest: The file path of manifest.
+builddir: The destination for repositories in manifest stored.
+          Repositories under the directory include on-xxx and RackHD
+git-credential: url, credentials pair for the access to github repos
+The optional parameter:
+force: Overwrite the build directory if it exists.
+is-official-release: if true, this release is official, the default value is false
+jobs: number of parallel jobs to run(checkout repositories). The number is related to the compute architecture, multi-core processors...
+"""
+import argparse
+import sys
+import os
+import deb822
+
+try:
+    from reprove import ManifestActions
+    from version_generator import VersionGenerator
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class RackhdDebianControlUpdater(object):
+    def __init__(self, builddir, is_official_release=False):
+        """
+        Compute the version of each repository under builddir
+        and update the debian/control with these versions
+        __manifest_repo_dir - The directory of Repository manifest
+        __builddir - Destination for checked out repositories
+        __is_official_release - True if the official is official release
+        :return: None
+        """
+        self._builddir = builddir
+        self._is_official_release = is_official_release
+
+    def _get_control_depends(self, control_path):
+        """
+        Parse debian control file
+        :param control_path: the path of control file
+        :return: a dictionay which contains all the package in field Depends
+        """
+        if not os.path.isfile(control_path):
+            raise RuntimeError("Can't parse {0} because it is not a file".format(control))
+
+        for paragraph in deb822.Deb822.iter_paragraphs(open(control_path)):
+            for item in paragraph.items():
+                if item[0] == 'Depends':
+                    packages = item[1].split("\n")
+                    return packages
+        return None
+
+    def _update_dependency(self, debian_dir, version_dict):
+        """
+        update the dependency version of RackHD/debian/control
+        :param: debian_dir: the directory of RackHD/debian
+        :param: version_dict: a dictionay which includes the version of on-xxx
+        :return: None
+        """
+        control = os.path.join(debian_dir, "control")
+        if not os.path.isfile(control):
+            raise RuntimeError("Can't update dependency of {0} because it is not a file".format(control))
+
+        new_control = os.path.join(debian_dir, "control_new")
+        new_control_fp = open(new_control , "wb")
+
+        packages = self._get_control_depends(control)
+
+        with open(control) as fp:
+            package_count = 0
+            is_depends = False
+            for line in fp:
+                if line.startswith('Depends'):
+                    package_count += 1
+                    is_depends = True
+                    new_control_fp.write("Depends: ")
+                    # Start to write the dependes
+                    # If the depends is on-xxx, it will be replace with on-xxx (= 1.1...)
+                    for package in packages:
+                        package_name = package.split(',',)[0].strip()
+                        if ' ' in package_name:
+                            package_name = package_name.split(' ')[0]
+                        if package_name in version_dict:
+                            if ',' in package:
+                                depends_str = "         {0} (= {1}),{2}".format(package_name, version_dict[package_name], os.linesep)
+                            else:
+                                depends_str = "         {0} (= {1}){2}".format(package_name, version_dict[package_name], os.linesep)
+                            new_control_fp.write(depends_str)
+                        else:
+                            new_control_fp.write("{0}{1}".format(package, os.linesep))
+                else:
+                    if not is_depends or package_count >= len(packages):
+                        new_control_fp.write(line)
+                    else:
+                        package_count += 1
+
+        new_control_fp.close()
+        os.remove(control)
+        os.rename(new_control, control)
+
+    def _generate_version_dict(self):
+        """
+        generate a dictory which includes the version of package on-xxx
+        :return: a dictory
+        """
+        version_dict = {}
+        for repo in os.listdir(self._builddir):
+            repo_dir = os.path.join(self._builddir, repo)
+            version_generator = VersionGenerator(repo_dir)
+            version = version_generator.generate_package_version(self._is_official_release)
+            if version != None:
+                version_dict[repo] = version
+
+        return version_dict
+
+    def update_RackHD_control(self):
+        """
+        udpate RackHD/debian/control according to manifest
+        :return: None     
+        """
+        try:
+            rackhd_dir = os.path.join(self._builddir, "RackHD")
+            debian_dir = os.path.join(rackhd_dir, "debian")
+            version_dict = self._generate_version_dict()
+            self._update_dependency(debian_dir, version_dict)
+        except Exception, e:
+            print "Failed to update RackHD/debian/control due to {0}".format(e)
+            sys.exit(1)
+
+   
+def parse_command_line(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest",
+                        required=True,
+                        help="the path of manifest file",
+                        action="store")
+    
+    parser.add_argument("--builddir",
+                        required=True,
+                        help="destination for checked out repositories",
+                        action="store")
+
+    parser.add_argument("--force",
+                        help="use destination dir, even if it exists",
+                        action="store_true")
+
+    parser.add_argument("--git-credential",
+                        required=True,
+                        help="Git credentials for CI services",
+                        action="append")
+
+    parser.add_argument('--jobs',
+                        help="Number of build jobs to run in parallel",
+                        default=-1,
+                        type=int,
+                        action="store")
+
+    parser.add_argument('--is-official-release',
+                        default="false",
+                        help="Whether this release is official",
+                        action="store")
+
+    parsed_args = parser.parse_args(args)
+    parsed_args.is_official_release = common.str2bool(parsed_args.is_official_release)
+
+    return parsed_args
+
+def checkout_repos(manifest, builddir, force, git_credential, jobs):
+    manifest_actions = ManifestActions(manifest, builddir, force=force, git_credentials=git_credential, jobs=jobs, actions=["checkout"])
+    manifest_actions.execute_actions()
+
+def main():
+    # Parse arguments
+    args = parse_command_line(sys.argv[1:])
+
+    # Checkout repositories according to manifest file
+    checkout_repos(args.manifest, args.builddir, args.force, args.git_credential, args.jobs)
+
+    # Start to initial an instance of UpdateRackhdVersion
+    updater = RackhdDebianControlUpdater(args.builddir, is_official_release=args.is_official_release)
+
+    # Update the RackHD/debian/control according to manifest
+    updater.update_RackHD_control()
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/build-release-tools/application/update_manifest.py
+++ b/build-release-tools/application/update_manifest.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python
+
+# Copyright 2015, EMC, Inc.
+
+"""
+Usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/update_manifest.py \
+--repo "$url" \
+--branch "$branch" \
+--commit "$id" \
+--manifest_download_url https://dl.bintray.com/rackhd-mirror/binary/manifest/ \
+--git-credential https://github.com,GITHUB_CREDS \
+--manifest-file 1.2.3
+--updated-manifest properties_file
+
+The required parameters:
+repo: Git url to match for updating the commit-id
+branch: The target branch for the named repo
+commit: The commit id to target an exact version
+manifest_download_url: The manifest base download URL.
+git_credential: url, credentials pair for the access to github repos
+manifest_file:The target manifest file to be updated
+updated_manifest: The property file that leads downstream job.
+
+The optional parameters:
+dryrun: Do not commit any changes, just print what would be done
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import shutil
+import requests
+
+#pylint: disable=relative-import
+import config
+from RepositoryOperator import RepoOperator
+from manifest import Manifest
+
+
+class UpdateManifest(object):
+
+    def __init__(self):
+        """
+        __repo - the repository url being updated in the manifest
+        __branch - the branch name associated with __repo
+        __sliced_branch - the branch name sliced at any forward slashes
+        __commit - The commit id associated with the __repo and __branch that we want to update
+        __manifest_base_url - the base download url points to the collection of manifest files
+        __manifest_file - the desired manifest file to update which resides in __manifest_repository_url
+        __cleanup_directories - the path/name of directories created are appended here for cleanup in task_cleanup
+        __git_credentials - url, credentials pair for the access to github repos
+        quiet - used for testing to minimize text written to a terminal
+        repo_operator - Class instance of RepoOperator
+        :return: None
+        """
+        self.__repo = None
+        self.__branch = None
+        self.__sliced_branch = None
+        self.__commit = None
+        self.__manifest_download_url = None
+        self.__manifest_file = None
+        self.__cleanup_directories = []
+        self.__git_credentials = None
+        self.__updated_manifest = None
+        self.__dryrun = False
+        self.quiet = False
+        self.repo_operator = RepoOperator()
+
+    #pylint: disable=no-self-use
+    def parse_args(self, args):
+        """
+        Take in values from the user.
+        Repo, branch, and manifest_repo are required. This exits if they are not given.
+        :return: Parsed args for assignment
+        """
+        parser = argparse.ArgumentParser()
+        parser.add_argument('-n', '--dryrun',
+                            help="Do not commit any changes, just print what would be done",
+                            action="store_true")
+        parser.add_argument("--repo",
+                            help="Git url to match for updating the commit-id",
+                            action="store")
+        parser.add_argument("--branch",
+                            help="The target branch for the named repo",
+                            action="store")
+        parser.add_argument("--manifest_download_url",
+                            help="The manifest derectory URL in bintray.",
+                            action="store")
+        parser.add_argument("--commit",
+                            help="OPTIONAL: The commit id to target an exact version",
+                            action="store")
+        parser.add_argument("--manifest_file",
+                            help="The target manifest file to be updated. Searches through all if left empty.",
+                            action="store")
+        parser.add_argument("--git-credential",
+                            help="Git URL and credentials comma separated",
+                            action="append")
+        parser.add_argument('--updated-manifest',
+                            help="Output file containing the name of the updated manifest, the download url, branch, commit of manifest repository. The key, value pairs will be passed to downstream jobs as parameters",
+                            action="store")
+        parser = parser.parse_args(args)
+
+        return parser
+
+
+    def assign_args(self, args):
+        """
+        Assign args to member variables and perform checks on branch and commit-id.
+        :param args: Parsed args from the user
+        :return:
+        """
+        if args.repo:
+            self.__repo = args.repo
+        else:
+            print "\nMust specify repository url for cloning (--repo <git_url>)\n"
+
+        if args.branch:
+            self.__branch = args.branch
+            if "/" in self.__branch:
+                self.__sliced_branch = self.__branch.split("/")[-1]
+            else:
+                self.__sliced_branch = self.__branch
+        else:
+            print "\nMust specify a branch name (--branch <branch_name>)\n"
+
+        # if args.manifest_repo:
+        #     self.__manifest_repository_url = args.manifest_repo
+        # else:
+        #     print "\n Must specify a full repository url for retrieving <manifest>.json files\n"
+        
+        if args.manifest_download_url:
+            self.__manifest_download_url = args.manifest_download_url
+        else:
+            print "\n Must specify a manifest base url for download <manifest>.json files\n"
+
+        if args.dryrun:
+            self.__dryrun = True
+            self.repo_operator.setup_git_dryrun(self.__dryrun)
+
+        if args.commit:
+            self.__commit = args.commit
+
+        if args.manifest_file:
+            self.__manifest_file = args.manifest_file
+
+        if args.git_credential:
+            self.__git_credentials = args.git_credential
+            self.repo_operator.setup_gitbit(credentials=self.__git_credentials)
+
+        if args.updated_manifest:
+            self.__updated_manifest = args.updated_manifest
+
+    def check_args(self):
+        """
+        Check the values given for branch and commit-id
+        """
+        if self.__branch:
+            try:
+                self.repo_operator.check_branch(self.__repo, self.__sliced_branch)
+            except RuntimeError as error:
+                self.cleanup_and_exit(error, 1)
+        if self.__commit:
+            self.__check_commit()
+
+
+    def __check_commit(self):
+        """
+        Check the format of the commit-id. It must be 40 hex characters.
+        Exits if it is not.
+        :return: None
+        """
+        commit_match = re.match('^[0-9a-fA-F]{40}$', self.__commit)
+        if not commit_match:
+            self.cleanup_and_exit("Id, '{0}' is not valid. It must be a 40 character hex string.".format(self.__commit), 1)
+
+    def download_manifest_file(self):
+        """
+        Download the manifest json files. Return that directory name which stores manifest. The directory
+        is temporary and deleted in the cleanup_and_exit function
+        :return: A string containing the name of the folder where the manifest file was download.
+        """
+        directory_name = tempfile.mkdtemp()
+
+        if os.path.isdir(directory_name):
+            pass
+            # For now script of 'upload to bintray' is seperated from this script.
+            # So before uploading this directory shouldn't be deleted'
+            # The blow code snippet will be unfolded when involved bintray upload functions into this script.
+            # self.__cleanup_directories.append(directory_name)
+        else:
+            self.cleanup_and_exit("Failed to make temporary directory for the repository: {0}".format(url), 1)
+        try:
+            url = "/".join([self.__manifest_download_url, self.__manifest_file])
+            dest_dir = "/".join([directory_name, self.__manifest_file])
+            if os.environ['BINTRAY_USERNAME'] and os.environ['BINTRAY_API_KEY']:
+                print "Requests bintray with token"
+                auth = (os.environ['BINTRAY_USERNAME'].strip(), os.environ['BINTRAY_API_KEY'].strip())
+                resp = requests.get(url, auth=auth)
+            else:
+                print "Requests without token"
+                resp = requests.get(url)
+            if resp.ok:
+                with open(dest_dir, "wb") as file_handle:
+                    file_handle.write(resp.content)
+            elif resp.status_code==404:
+                # If there's no manifest file in bintray server, init an empty one
+                print "can't find manifest in remote server, will use template manifest"
+                Manifest.instance_of_sample().dump_to_json_file(dest_dir)
+            else:
+                print "Unknown error, {0}".format(resp.status_code) 
+            return directory_name
+        except RuntimeError as error:
+            self.cleanup_and_exit(error, 1)
+
+    def validate_manifest_files(self, *args):
+        """
+        validate several manifest files
+        For example: validate_manifest_files(file1, file2) or
+                     validate_manifest_files(file1, file2, file3)
+        """
+        validate_result = True
+        for filename in args:
+            try:
+                manifest = Manifest(filename)
+                manifest.validate_manifest()
+                print "manifest file {0} is valid".format(filename)
+            except KeyError as error:
+                print "Failed to validate manifest file {0}".format(filename)
+                print "\nERROR: \n{0}".format(error.message)
+                validate_result = False
+        return validate_result
+
+
+    def cleanup_and_exit(self, message=None, code=0):
+        """
+        Delete all files and folders made during this job which are named in self.cleanup_directories
+        :return: None
+        """
+
+        if not self.quiet:
+            if message is not None:
+                print "\nERROR: {0}".format(message)
+            print "\nCleaning environment!\n"
+        for item in self.__cleanup_directories:
+            subprocess.check_output(["rm", "-rf", item])
+        sys.exit(code)
+
+
+    def get_updated_commit_message(self):
+        """
+        get the updated repository commit message
+        """
+
+        # get commit message based on the arguments repo, branch and commit
+        directory_name = tempfile.mkdtemp()
+
+        if os.path.isdir(directory_name):
+            self.__cleanup_directories.append(directory_name)
+        else:
+            self.cleanup_and_exit("Failed to make temporary directory for the repository: {0}".format(url), 1)
+        try:
+            updated_repo_dir = self.repo_operator.clone_repo(self.__repo, directory_name)
+            repo_commit_message = self.repo_operator.get_commit_message(updated_repo_dir, self.__commit)
+            return repo_commit_message
+        except RuntimeError as error:
+            self.cleanup_and_exit(error, 1)
+
+    def upload_manifest_to_bintray(self, dir_name, bintray):
+        """
+        Update manifest to bintray based on its contents and user arguments.
+        :param dir_name: The directory of the repository
+        :return: if repo is updated, return updated manifest file path and the manifest object
+                 otherwise, return None, None
+        """
+
+    def update_manifest_repo(self, dir_name, repo_commit_message):
+        """
+        Update manifest repository based on its contents and user arguments.
+        :param dir_name: The directory of the repository
+        :return: if repo is updated, return updated manifest file path and the manifest object
+                 otherwise, return None, None
+        """
+
+        if self.__manifest_file is not None:
+            path_name = os.path.join(dir_name, self.__manifest_file)
+            if os.path.isfile(path_name):
+                try:
+                    manifest = Manifest(path_name, self.__git_credentials)
+                    manifest.update_manifest(self.__repo, self.__branch, self.__commit)
+                    if manifest.changed:
+                        manifest.write_manifest_file(path_name, self.__dryrun)
+                        return path_name, manifest
+                    else:
+                        print "No changes to {0}".format(manifest.name)
+                except KeyError as error:
+                    self.cleanup_and_exit("Failed to create an Manifest instance for the manifest file {0}\nError:{1}"\
+                         .format(self.__manifest_file, error.message),1)
+
+                except RuntimeError as error:
+                    self.cleanup_and_exit("Failed to update manifest repo\nError:{0}".format(error.message),1)
+        else:
+            for item in os.listdir(dir_name):
+                path_name = os.path.join(dir_name, item)
+                if os.path.isfile(path_name):
+                    try:
+                        manifest = Manifest(path_name, self.__git_credentials)
+                        manifest.update_manifest(self.__repo, self.__branch, self.__commit)
+                        if manifest.changed:
+                            manifest.write_manifest_file(path_name, self.__dryrun)
+                            return path_name, manifest
+                        else:
+                            print "No changes to {0}".format(manifest.name)
+                    except KeyError as error:
+                        self.cleanup_and_exit("Failed to create an Manifest instance for the manifest file {0}\nError:{1}"\
+                            .format(path_name, error.message),1)
+                    except RuntimeError as error:
+                        self.cleanup_and_exit("Failed to update manifest repo\nError:{0}".format(error.message),1)
+        return None, None
+
+
+    def write_downstream_parameters(self, filename, params):
+        """
+        Add/append downstream parameter (java variable value pair) to the given
+        parameter file. If the file does not exist, then create the file.
+        :param filename: The parameter file that will be used for making environment
+         variable for downstream job.
+        :param params: the parameters dictionary
+        :return:
+                None on success
+                Raise any error if there is any
+        """
+        if filename is None:
+            return
+
+        with open(filename, 'w') as fp:
+            try:
+                for key in params:
+                    entry = "{key}={value}\n".format(key=key, value=params[key])
+                    fp.write(entry)
+            except IOError as error:
+                print "Unable to write parameter(s) for next step(s), exit"
+                self.cleanup_and_exit(error, 1)
+
+    def downstream_manifest_to_use(self, manifest_folder, file_with_path, manifest, validate_result):
+        """
+        Write file which contains the name of the manifest file most recently updated.
+        :param manifest_folder: the path of the manifest repository
+        :param file_with_path: The path to be split to claim the filename
+        :param manifest: the Manifest object of manifest file
+        """
+        file_name = file_with_path.split('/')[-1]
+        downstream_parameters = {}
+        # If not validate_result, do not trigger downstream job
+        downstream_parameters['MANIFEST_FILE_VALID'] = validate_result
+        downstream_parameters['BUILD_REQUIREMENTS'] = manifest.build_requirements
+        downstream_parameters['MANIFEST_FILE_PATH'] = file_with_path
+        downstream_parameters['MANIFEST_FILE_URL'] = "".join([self.__manifest_download_url, file_name])
+
+        self.write_downstream_parameters(self.__updated_manifest, downstream_parameters)
+        return
+
+def split_args(args):
+    """
+    split args that contains string list arg to multi args lists 
+    :param args: the raw args, sys.argv[1:]
+    :return args_list: the splited args
+    """
+    #check if all necessay args exist.
+    update = UpdateManifest()
+    passed_args = update.parse_args(args)
+    update.check_args()
+    
+    #check if the items in repo, branch, commit are same number 
+    if not (len(passed_args.repo.split())==len(passed_args.branch.split()) and \
+            len(passed_args.repo.split())==len(passed_args.commit.split())):
+        update.cleanup_and_exit("Id, repo or branch are not valid. Their numbers must be the same", 1)
+
+    #split args to args list
+    #args is like ['some_arg', 'value', 'repo', 'rackhd/on-http rackhd/on-core']
+    #and then split it to two arg lists
+    #['some_arg', 'value', 'repo', 'rackhd/on-http' ]
+    #['some_arg', 'value', 'repo', 'rackhd/on-core' ]
+    #only the value of args 'repo', 'branch', 'commit' will be splited and combine with other single
+    #arg to generate arg lists
+    args_list = []
+
+    #number of loops equals number of repos(or commit, branch)
+    #generate one new args list in one loop 
+    for i in range(len(passed_args.repo.split())):
+        tmp_args = []
+        #save previous word in args list for recognize value of args 'repo', 'branch', 'commit'
+        pre_word = ""
+
+        #traverse args list generated one new arg list
+        for word in args:
+            if pre_word in ['--repo', '--branch', '--commit']:
+                #choose the correct value
+                tmp_args.append(word.split()[i])
+            else:
+                tmp_args.append(word)
+            pre_word = word
+        print "INFO tmp_args: {0}".format(tmp_args)
+        args_list.append(tmp_args)
+    return args_list
+
+def validate_manifest(update, manifest_folder):
+    print "Starting validate manifest files in manifest repository"
+    validate_result = True
+    for filename in os.listdir(manifest_folder):
+        pathname = os.path.join(manifest_folder, filename)
+        if os.path.isfile(pathname):
+            if not update.validate_manifest_files(pathname):
+                validate_result = False
+    return validate_result
+
+def main():
+    update = UpdateManifest()
+    passed_args = update.parse_args(sys.argv[1:])
+    update.assign_args(passed_args)
+    update.check_args()
+
+    manifest_folder = update.download_manifest_file()
+
+    commit_message = update.get_updated_commit_message()
+    update_filename, manifest = update.update_manifest_repo(manifest_folder, commit_message)
+
+    validate_result = validate_manifest(update, manifest_folder)
+
+    if update_filename is not None:
+        update.downstream_manifest_to_use(manifest_folder, update_filename, manifest, validate_result)
+
+    update.cleanup_and_exit()
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/build-release-tools/application/version_generator.py
+++ b/build-release-tools/application/version_generator.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# Copyright 2015-2016, EMC, Inc.
+
+"""
+The script compute the version of a package, just like:
+1.1-1-20161129UTC
+
+usage:
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/version_generator.py \
+--repo-dir /home/onrack/rackhd/release/rackhd-repos/PengTian0/b/b/on-http \
+--is-official-release true
+
+Because this script need to import scripts under lib.
+The script HWIMO-BUILD helps to add the scripts under lib to python path.
+
+The required parameters: 
+repo-dir: the directory of the repository
+
+The optional parameters:
+is-official-release: whether the release is official (default value is false)
+"""
+import os
+import sys
+import argparse
+from datetime import datetime,timedelta
+
+try:
+    from RepositoryOperator import RepoOperator
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class VersionGenerator(object):
+    def __init__(self, repo_dir):
+        """
+        This module compute the version of a repository
+        The version for candidate release: {big-version}~{version-stage}-{small-version}
+        The big version is parsed from debian/changelog
+        The version-stage is devel if branch is master; or rc if branch if not master
+        The samll version is consist of the commit hash and commit date of manifest repository
+        :return:None
+        """
+        self._repo_dir = repo_dir
+        self.repo_operator = RepoOperator()
+        self._repo_name = self.get_repo_name()
+
+    def get_repo_name(self):
+        repo_url = self.repo_operator.get_repo_url(self._repo_dir)
+        repo_name = common.strip_suffix(os.path.basename(repo_url), ".git")
+        return repo_name
+
+    def generate_small_version(self):
+        """
+        Generate the small version which consists of commit date and commit hash of manifest repository
+        According to small version, users can track the commit of all repositories in manifest file
+        return: small version 
+        """
+        if self._repo_name == "RackHD":
+            utc_now = datetime.utcnow()
+            utc_yesterday = utc_now + timedelta(days=-1)
+            version = utc_yesterday.strftime('%Y%m%dUTC')
+            return version
+        else:
+            commit_timestamp_str = self.repo_operator.get_lastest_commit_date(self._repo_dir)
+            date = datetime.utcfromtimestamp(int(commit_timestamp_str)).strftime('%Y%m%dUTC')
+            commit_id = self.repo_operator.get_lastest_commit_id(self._repo_dir)
+            version = "{date}-{commit}".format(date=date, commit=commit_id[0:7])
+            return version
+
+    def debian_exist(self):
+        """
+        check whether debian or debianstatic directory under the repository
+        return: True if debian or debianstatic exist
+                False
+        """
+        if os.path.isdir(self._repo_dir):
+            for filename in os.listdir(self._repo_dir):
+                if filename == "debian":
+                    return True
+        return False
+
+    def generate_big_version(self):
+        """
+        Generate the big version according to changelog
+        The big version is the latest version of debian/changelog
+        return: big version
+        """
+        # If the repository has the debianstatic/repository name/,
+        # create a soft link to debian before compute version
+        debian_exist = self.debian_exist()
+        linked = False
+        if not debian_exist:
+            for filename in os.listdir(self._repo_dir):
+                if filename == "debianstatic":
+                    debianstatic_dir = os.path.join(self._repo_dir, "debianstatic")
+                    for debianstatic_filename in os.listdir(debianstatic_dir):
+                        if debianstatic_filename == self._repo_name:
+                            debianstatic_repo_dir = "debianstatic/{0}".format(self._repo_name)
+                            common.link_dir(debianstatic_repo_dir, "debian", self._repo_dir)
+                            linked = True
+        if not debian_exist and not linked:
+            return None
+        cmd_args = ["dpkg-parsechangelog", "--show-field", "Version"]
+        version = common.run_command(cmd_args, directory=self._repo_dir)
+
+        if linked:
+            os.remove(os.path.join(self._repo_dir, "debian"))
+
+        return version
+
+    def generate_version_stage(self):
+        """
+        Generate the version stage according to the stage of deveplopment
+        return: devel ,if the branch is master
+                rc, if the branch is not master
+        """
+        current_branch = self.repo_operator.get_current_branch(self._repo_dir)
+        version_stage = ""
+        if "master" in current_branch:
+            version_stage = "devel"
+        else:
+            version_stage = "rc"
+        return version_stage
+        
+    def generate_package_version(self, is_official_release):
+        """
+        generate the version of package, just like:
+        1.1-1-devel-20160809150908-7396d91 or 1.1-1
+        :return: package version
+        """
+        big_version = self.generate_big_version()
+        if big_version is None:
+            common.logging.warning("Failed to generate big version, maybe the {0} doesn't contain debian directory".format(self._repo_dir))
+            return None
+
+        if is_official_release:
+            version = big_version
+        else:
+            small_version = self.generate_small_version()
+            if small_version is None:
+                raise RuntimeError("Failed to generate version for {0}, due to the small version is None".format(self._repo_dir))
+
+            version = "{0}-{1}".format(big_version, small_version)
+        
+        return version
+
+def parse_command_line(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-dir",
+                        required=True,
+                        help="the directory of repository",
+                        action="store")
+
+    parser.add_argument('--is-official-release',
+                        default="false",
+                        help="Whether this release is official",
+                        action="store")
+
+    parsed_args = parser.parse_args(args)
+    parsed_args.is_official_release = common.str2bool(parsed_args.is_official_release)
+    return parsed_args
+
+def main():
+    # parse arguments
+    args = parse_command_line(sys.argv[1:])
+    generator = VersionGenerator(args.repo_dir)
+    try:
+        version = generator.generate_package_version(args.is_official_release)
+        print version
+    except Exception, e:
+        common.logging.error("Failed to generate version for {0} due to {1}\n Exiting now".format(args.repo_dir, e))
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -1,0 +1,122 @@
+#!/bin/bash 
+set -e
+
+#
+# This script is for build/push rackhd docker images.
+# Environmental requirement:
+#   1.A sources.list to replace default sources.list of nodesource/wheezy:4.4.6 image(the root image which on-core pulled)
+#     http://httpredir.debian.org/debiani(not stable for EMC network.) -> http://ftp.us.debian.org/debian
+# Parameters:
+#   ${1}, WORKDIR, default: ../../, a absolute where all repos are cloned
+#   ${2}, IS_OFFICIAL_RELEASE, default: false, a bool value indicates if is building release
+
+
+#when run this script locally use default value
+WORKDIR=${1}
+BASEDIR=$(cd $(dirname "$0");pwd)
+WORKDIR=${WORKDIR:=$(dirname $(dirname $BASEDIR))}
+
+IS_OFFICIAL_RELEASE=${2}
+IS_OFFICIAL_RELEASE=${IS_OFFICIAL_RELEASE:=false}
+
+tagCalculate() {
+    repo=$1
+    #Get package version from debian/changelog
+    if [ -f "debian/changelog" ]; then
+        CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+    elif [ -f "debianstatic/$repo/changelog" ]; then
+        cp -rf debianstatic/$repo ./debian
+        CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+        rm -rf debian
+    else
+        CHANGELOG_VERSION=$RACKHD_CHANGELOG_VERSION
+    fi
+    
+    #generate real TAG
+    if [ "$IS_OFFICIAL_RELEASE" == "true" ]; then
+        PKG_TAG="$CHANGELOG_VERSION"
+    else
+        GIT_COMMIT_DATE=$(git show -s --pretty="format:%ci")
+        DATE_STRING="$(date -d "$GIT_COMMIT_DATE" -u +"%Y%m%d%H%M%S")UTC"
+        GIT_COMMIT_HASH=$(git show -s --pretty="format:%h")
+        PKG_TAG="$CHANGELOG_VERSION-$DATE_STRING-$GIT_COMMIT_HASH"
+    fi
+}
+
+doBuild() {
+    # List order is important, on-tasks image build is based on on-core image, 
+    # on-http and on-taskgraph ard based on on-tasks image 
+    # others are based on on-core image
+    repos=$(echo "on-core on-syslog on-dhcp-proxy on-tftp on-wss on-statsd on-tasks on-taskgraph on-http")
+    #Record all repo:tag for post-pushing
+    repos_tags=""
+    #Set an empty TAG before each build
+    TAG=""
+    #For relpacing the unstable wheezy official source
+    SOURCE_LIST=https://raw.githubusercontent.com/RackHD/on-tools/master/manifest-build-tools/docker_sources.list
+    for repo in $repos;do
+        if [ ! -d $repo ]; then
+            echo "Repo directory of $repo does not exist"
+            popd > /dev/null 2>&1
+            exit 1
+        fi
+        pushd $repo
+            PKG_TAG=""
+            if [ "$BUILD_LATEST" != true ]; then
+                tagCalculate $repo
+                TAG=:${PKG_TAG}
+            fi
+            echo "Building rackhd/$repo$TAG"
+            repos_tags=$repos_tags$repo$TAG" "
+            cp Dockerfile ../Dockerfile.bak
+            if [ "$repo" != "on-core" ];then
+                    # Use the new sources.list
+                    sed -i "/^FROM/a RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak\nADD $SOURCE_LIST /etc/apt/sources.list" Dockerfile
+                    #Based on newly build upstream image to build
+                    sed -i "/^FROM/ s/$/${PRE_TAG}/" Dockerfile
+                    # Recover the sources.list
+                    sed -i -e "\$aRUN mv /etc/apt/sources.list.bak /etc/apt/sources.list" Dockerfile
+                    docker build -t rackhd/$repo$TAG .
+            fi
+            case $repo in
+                "on-core")
+                    docker build -t rackhd/$repo$TAG .
+                    PRE_TAG=$TAG
+                    ;;
+                "on-tasks")
+                    PRE_TAG=$TAG
+                    ;;
+            esac 
+            mv ../Dockerfile.bak Dockerfile
+        popd
+    done
+
+    # write build list to a file for guiding image push. 
+    pushd $WORKDIR
+    echo "Imagename:tag list of this build is $repos_tags"
+    echo $repos_tags >> build_record
+    popd
+}
+
+# Build begins
+pushd $WORKDIR
+
+pushd RackHD
+    #get rackhd changelog Version
+    RACKHD_CHANGELOG_VERSION=$(dpkg-parsechangelog --show-field Version)
+popd
+
+#record all image:tag of each build
+if [ -f build_record ];then
+    rm build_record
+    touch build_record
+fi
+
+doBuild
+if [[ "$IS_OFFICIAL_RELEASE" == true ]];then
+    # latest tag is for master branch build.
+    BUILD_LATEST=true
+    doBuild
+fi
+# Build ends
+popd

--- a/build-release-tools/docker_sources.list
+++ b/build-release-tools/docker_sources.list
@@ -1,0 +1,3 @@
+deb http://ftp.us.debian.org/debian wheezy main
+deb http://ftp.us.debian.org/debian wheezy-updates main
+deb http://security.debian.org wheezy/updates main

--- a/build-release-tools/lib/Builder.py
+++ b/build-release-tools/lib/Builder.py
@@ -1,0 +1,344 @@
+# Copyright 2016, DELLEMC, Inc.
+"""
+This is a module that contains the tool for python to run a list of commands
+and generate report for results of running.
+"""
+
+import os
+import subprocess
+import sys
+
+try:
+    from ParallelTasks import ParallelTasks
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class BuildResult(object):
+    """
+    Complete output from the running of a build command on a given host.
+    Contains the command that was supposed to be run, whether it was present ot not,
+    the return code, and the standard output and standard error text.
+    """
+    def __init__(self, command, present, return_code=None, stdout=None, stderr=None):
+        self._command = command
+        self._present = present
+
+        self._return_code = return_code
+        self._stdout = stdout
+        self._stderr = stderr
+
+    @property
+    def command(self):
+        return self._command
+
+    @command.setter
+    def command(self, command):
+        self._command = command
+
+    @property
+    def present(self):
+        return self._present
+
+    @present.setter
+    def present(self, present):
+        self._present = present
+
+    @property
+    def return_code(self):
+        return self._return_code
+
+    @return_code.setter
+    def return_code(self, return_code):
+        self._return_code = return_code
+
+    @property
+    def stdout(self):
+        return self._stdout
+
+    @stdout.setter
+    def stdout(self, stdout):
+        self._stdout = stdout
+
+    @property
+    def stderr(self):
+        return self._stderr
+
+    @stderr.setter
+    def stderr(self, stderr):
+        self._stderr = stderr
+
+    def generate_detailed_report(self):
+        """
+        Generate reports with details: return code, stdout, stderr
+        """
+        detailed = []
+        if self._present is True:
+            detailed.append(self._command)
+            if self._return_code != 0:
+                detailed.append("  ERROR: EXIT {0}".format(self._return_code))
+                if self._stdout is not None and self._stdout != "":
+                    detailed.append(self._stdout)
+                if self._stderr is not None and self._stderr != "":
+                    detailed.append(self._stderr)
+
+        return detailed
+
+    def generate_summary_report(self):
+        """
+        Generate report with the result of running: 
+        Good or ERROR: EXIT or Not Present
+        """
+        summary = []
+        short_command = os.path.basename(self._command)
+        if self._present is True:
+            if self._return_code is not None:
+                if self._return_code == 0:
+                    status = "GOOD"
+                else:
+                    status = "ERROR: EXIT {0}".format(self._return_code)
+            else:
+                status = "RETURN CODE IS NONE"
+        else:
+            status = " Not Present"
+        summary.append("    {0}: {1}".format(short_command, status))
+        return summary
+
+    @staticmethod
+    def summarize_errors(results):
+        errors = 0
+        for result in results:
+            if result.return_code != 0:
+                errors += 1
+        return errors
+
+class BuildCommand(object):
+    """
+    A module for build command.
+    """
+    def __init__(self, name, directory, arguments=None, use_sudo=False, sudo_creds=None):
+        """
+        _name: the command name that was supposed to be run
+        _directory: the directory under which to run command
+        _use_sudo: whether the command was run with sudo previleges
+        _sudo_creds: the environment variable name of sudo credentials. 
+                     For example: SUDO_CREDS=username:password
+        _arguments: the arguments of the command
+        """
+        self._name = name
+        self._directory = directory
+        self._use_sudo = use_sudo
+        self._sudo_creds = sudo_creds
+        self._arguments = arguments
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
+    @property
+    def directory(self):
+        return self._directory
+
+    @directory.setter
+    def directory(self, directory):
+        self._directory = directory
+
+    @property
+    def use_sudo(self):
+        return self._use_sudo
+
+    @use_sudo.setter
+    def use_sudo(self, use_sudo):
+        self._use_sudo = use_sudo
+
+    @property
+    def sudo_creds(self):
+        return self._sudo_creds
+
+    @sudo_creds.setter
+    def sudo_creds(self, sudo_creds):
+        self._sudo_creds = sudo_creds
+        
+    def to_string(self):
+        cmd_args = []
+        if self._use_sudo:
+            if self._sudo_creds is None:
+                raise ValueError("sudo credential missing from commands {0}".format(name))
+            (username, password) = common.parse_credential_variable(self._sudo_creds)
+            cmd_args += ["echo"]
+            cmd_args += [password]
+            cmd_args += ["|sudo -S"]
+
+        cmd_args += [self._name]
+
+        if self._arguments:
+            cmd_args += self._arguments
+
+        command_str = " ".join(cmd_args)
+        return command_str
+
+    def run(self):
+        try:
+            command = self.to_string()
+            print "Execute command: {0} under {1}".format(command, self._directory)
+            proc = subprocess.Popen(command,
+                                    stderr=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    cwd=self._directory,
+                                    shell=True)
+            (out, err) = proc.communicate()
+        except Exception, ex:
+            # this is a terrible failure, not just process exit != 0
+            return BuildResult(self._name,
+                               present=True,
+                               return_code=1,
+                               stderr=ex)
+
+        result = BuildResult(self._name,
+                             present=True,
+                             return_code=proc.returncode,
+                             stdout=out,
+                             stderr=err)
+        return result
+
+    def is_executable(self):
+        exe_file = os.path.join(self._directory, self._name)
+        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+            return True
+
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
+                return True
+
+        return False
+
+class Builder(ParallelTasks):
+    """
+    Run a list of command under a directory.
+
+    This class is intended for use with ParallelTasks, and each commands list may be done
+    in a separate process.
+
+    """
+    def add_task(self, data, name):
+        """
+        Add a task to task queue
+        :param data: A dictonary which should contain:
+                     commands: A list of comamnd instances. It's required.
+                     env_file: A property file which contains environment variables. It's optional
+        :param name: The name of the task. The key by which the job results will be returned.
+        :return: None
+        """
+        if data is None:
+            raise ValueError("Task parameter data not present")
+
+        if 'commands' not in data:
+            raise ValueError("commands key missing from data: {0}".format(data))
+
+        super(Builder, self).add_task(data, name)
+
+    @staticmethod
+    def initail_environment(env_file):
+        print "start to export environment file {0}".format(env_file)
+        if not os.path.isfile(env_file):
+            raise RuntimeError("Failed to initial environment due to the file {0} doesn't exist"
+                               .format(env_file))
+        props = common.parse_property_file(env_file)
+        if props:
+            for item in props.items():
+                key = item[0]
+                value = item[1]
+                os.environ[key] = value
+
+    def do_one_task(self, name, data, results):
+        """
+        Perform the actual work.
+        name and data will come from the values passed in to add_task()
+        :param results: a list of instances of BuildResult
+        :return: None
+        """
+        try:
+            if 'command' not in results:
+                results['command'] = []
+
+            if 'env_file' in data and data['env_file'] is not None:
+                self.initail_environment(data['env_file'])
+
+            for command in data['commands']:
+                if not command.is_executable():
+                    build_result = BuildResult(command, present=False)
+                build_result = command.run()
+                if build_result is not None:
+                    results['command'].append(build_result)
+
+        except Exception, e:
+            raise RuntimeError("Failed to do task {0} due to {1}".format(name, e))
+
+    def summarize_results(self):
+        """
+        :return: True if the number of errors found is 0
+                 False if the number of errors found is greater than 0
+        """
+        results = self.get_results()
+        key_list = results.keys()
+
+        for name in sorted(key_list):
+            if 'command' in results[name]:
+                build_results = results[name]['command']
+                errors = BuildResult.summarize_errors(build_results)
+                if errors > 0:
+                    return False
+        return True
+
+    def generate_detailed_report(self):
+        """
+        Generate reports with details: return code, stdout, stderr
+        """
+        all_detailed = []
+        results = self.get_results()
+        key_list = results.keys()
+        for name in sorted(key_list):
+            if 'command' in results[name]:
+                task_detailed = []
+                task_detailed.append("=== Results for {0} ===".format(name))
+                for result in results[name]['command']:
+                    detailed = result.generate_detailed_report()
+                    task_detailed.extend(detailed)
+
+                all_detailed.extend(task_detailed)
+        return all_detailed
+
+    def generate_summary_report(self):
+        """
+        Generate report with the result of running:
+        Good or ERROR: EXIT or Not Present
+        """       
+        all_summary = []
+
+        results = self.get_results()
+        key_list = results.keys()
+
+        for name in sorted(key_list):
+            if 'command' in results[name]:
+                task_summary = []
+                task_summary.append("{0}:".format(name))
+                build_results = results[name]['command']
+                errors = BuildResult.summarize_errors(build_results)
+                if errors > 0:
+                    task_summary.append("    Number of falied commands: {0}".format(errors))
+
+                for result in build_results:
+                    summary = result.generate_summary_report()
+                    task_summary.extend(summary)
+
+                all_summary.extend(task_summary)
+
+        return all_summary
+

--- a/build-release-tools/lib/DebianBuilder.py
+++ b/build-release-tools/lib/DebianBuilder.py
@@ -1,0 +1,139 @@
+"""
+This is a module that contains the tool for python to build the
+debians after all the directories are checked out based on a given manifest file.
+"""
+# Copyright 2016, EMC, Inc.
+
+import os
+import subprocess
+import sys
+
+try:
+    from Builder import Builder
+    from Builder import BuildCommand
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class DebianBuilder(object):
+    """
+    This is a class that builds the debian packages. 
+    It assumes that the repository is cloned successfully and is accessible for the tool.
+    """
+    def __init__(self, top_level_dir, repos, jobs=1, sudo_creds=None):
+        """
+        :param top_level_dir: the directory that holds all the cloned
+                              repositories according to manifest
+                              example: <top_level_dir>/on-http/...
+                                                      /on-tftp/...
+        :param repos: a list of repositories to be build
+        :param jobs: Number of parallel jobs(build debian packages) to run.
+        :param sudo_creds: the environment variable name of sudo credentials.
+                           for example: SUDO_CRED=username:password
+        :return: None
+        """
+        self.top_level_dir = top_level_dir
+        self._repos = repos
+        self._jobs = jobs
+        self._sudo_creds = sudo_creds
+        self._builder = Builder(self._jobs)        
+
+    @property
+    def top_level_dir(self):
+        return self._top_level_dir
+
+    @top_level_dir.setter
+    def top_level_dir(self, top_level_dir):
+        """
+        Setter for the repository directory
+        :param top_level_dir: the directory that holds all the cloned
+                              repositories according to manifest
+                              example: <top_level_dir>/on-http/...
+                                                      /on-tftp/...
+        :return: None
+        """
+        if os.path.isdir(top_level_dir):
+            self._top_level_dir = os.path.abspath(top_level_dir)
+        else:
+            raise ValueError("The path provided '{dir}' is not a directory."
+                             .format(dir=top_level_dir))
+
+    def generate_tasks(self):
+        """
+        Generate a list of tasks to be perform.
+        An example of task:
+                   {
+                    'name': repo,
+                    'data': {
+                             'commands': [command1, ...], #command1 is an instance of BuildCommand
+                             'env_file': on-http.version
+                            }
+                   }
+        
+        """
+        tasks = []
+        for repo in self._repos:
+            task = {
+                    'name': repo,
+                    'data': {
+                             'commands': [],
+                             'env_file': None
+                            }
+                   }
+            command_name = './HWIMO-BUILD'
+            path = os.path.abspath(os.path.join(self._top_level_dir, repo))
+            if not os.path.exists(path):
+                raise ValueError("Repository {0} doesn't exist under {1}"
+                                 .format(repo, self._top_level_dir))
+            command = BuildCommand(command_name, path)
+            if repo == "on-imagebuilder" and self._sudo_creds:
+                command.use_sudo = True
+                command.sudo_creds = self._sudo_creds
+            task['data']['commands'].append(command)
+
+            version_file = "{0}.version".format(repo)
+            version_path = os.path.abspath(os.path.join(path, version_file))
+            if os.path.exists(version_path):
+                task['data']['env_file'] = version_path
+            tasks.append(task)
+
+        return tasks
+
+    def blind_build_all(self):
+        """
+        Iterate through the first layer subdirectory of top_level_dir and
+        if found HWIMO-BUILD, then execute the script.
+        """
+        try:
+            tasks = self.generate_tasks()
+            for task in tasks:
+                self._builder.add_task(task['data'], task['name'])
+            self._builder.finish()
+        except Exception, e:
+            raise RuntimeError("Failed to build all debian packages due to \n{0}".format(e))
+
+    def get_build_result(self):
+        """
+        If all the tasks success, then return true,
+        otherwise return false
+        :return: True if build success.
+                 False if build failed.
+        """
+        build_result = self._builder.summarize_results()
+        return build_result
+
+    def print_detailed_report(self):
+        detailed = self._builder.generate_detailed_report()
+        print "\n\nvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n\n"
+        print "Full Details\n"
+        for item in detailed:
+            print item
+
+    def print_summary_report(self):
+        summary = self._builder.generate_summary_report()
+        print "\n\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n"
+        print "Summary:"
+        for item in summary:
+            print item
+        print "\n\n"
+

--- a/build-release-tools/lib/ManifestGenerator.py
+++ b/build-release-tools/lib/ManifestGenerator.py
@@ -1,0 +1,127 @@
+# Copyright 2016, EMC, Inc.
+
+"""
+Module to generate a manifest file
+"""
+import os
+import sys
+import json
+import shutil
+
+try:
+    from RepositoryOperator import RepoOperator
+    from manifest import Manifest
+    import common
+except ImportError as import_err:
+    print import_err
+    sys.exit(1)
+
+class ManifestGenerator(object):
+    def __init__(self, dest, branch, builddir, git_credential, force=False, jobs=1):
+        """
+        Generate a new manifest according to the manifest sample: manifest.json
+
+        _dest_manifest_file: the path of new manifest
+        _branch: the branch name
+        _force: overwrite the destination if it exists.
+        _builddir: the destination for checked out repositories.
+        _jobs: number of parallel jobs to run. The number is related to the compute architecture, multi-core processors...
+        :return: None
+        """
+        self._dest_manifest_file = dest
+        self._branch = branch
+        self._builddir = builddir
+        self._force = force
+        self._jobs = jobs
+        self._manifest = Manifest.instance_of_sample()
+        self.repo_operator = RepoOperator(git_credential)
+        self.check_builddir()
+
+    def directory_for_repo(self, repo):
+        """
+        Get the directory of a repository
+        :param repo: a dictionary
+        :return: the directary of repository
+        """
+        if 'checked-out-directory-name' in repo:
+            repo_directory = repo['checked-out-directory-name']
+        else:
+            if 'repository' in repo:
+                repo_url = repo['repository']
+                repo_directory = common.strip_suffix(os.path.basename(repo_url), ".git")
+            else:
+                raise ValueError("no way to find basename")
+
+        repo_directory = os.path.join(self._builddir, repo_directory)
+        return repo_directory
+
+    def check_builddir(self):
+        """
+        Checks the given builddir name and force flag.
+        Deletes exists directory if one already exists and --force is set
+        :return: None
+        """
+        if os.path.exists(self._builddir):
+            if self._force:
+                shutil.rmtree(self._builddir)
+                print "Removing existing data at {0}".format(self._builddir)
+            else:
+                print "Unwilling to overwrite destination builddir of {0}".format(self._builddir)
+                sys.exit(1)
+
+        os.makedirs(self._builddir)
+
+    def update_repositories_commit(self, repositories):
+        """
+        update the commit-id of repository with the lastest commit id
+        :param repositories: a list of repository directory
+        :return: None
+        """
+        for repo in repositories:
+            repo_dir = self.directory_for_repo(repo)
+            repo["commit-id"] = self.repo_operator.get_lastest_commit_id(repo_dir)
+
+    def update_manifest(self):
+        """
+        update the manifest with branch name
+        :return: None
+        """
+        repositories = self._manifest.repositories
+        downstream_jobs = self._manifest.downstream_jobs
+        for repo in repositories:
+            repo["branch"] = self._branch
+            repo["commit-id"] = ""
+        self.repo_operator.clone_repo_list(repositories, self._builddir, jobs=self._jobs)
+        self.update_repositories_commit(repositories)
+
+        for job in downstream_jobs:
+            job["branch"] = self._branch
+            repo["commit-id"] = ""
+        self.repo_operator.clone_repo_list(downstream_jobs, self._builddir, jobs=self._jobs)
+        self.update_repositories_commit(downstream_jobs)
+
+        self._manifest.validate_manifest()
+
+    def generate_manifest(self):
+        """
+        generate a new manifest
+        :return: None
+        """
+        if os.path.isfile(self._dest_manifest_file):
+            if self._force == False:
+                raise RuntimeError("The file {0} already exist . \n \
+                                    If you want to overrite the file, please specify --force."
+                                    .format(dest_file))
+
+        with open(self._dest_manifest_file, 'w') as fp:
+            json.dump(self._manifest.manifest, fp, indent=4, sort_keys=True)
+
+class SpecifyDayManifestGenerator(ManifestGenerator):
+    def __init__(self, dest, branch, date, builddir, git_credential, force=False, jobs=1):
+        self._date = date
+        super(SpecifyDayManifestGenerator, self).__init__(dest, branch, builddir, git_credential, force=force, jobs=jobs)
+
+    def update_repositories_commit(self, repositories):
+        for repo in repositories:
+            repo_dir = self.directory_for_repo(repo)
+            repo["commit-id"] = self.repo_operator.get_lastest_merge_commit_before_date(repo_dir,self._date)

--- a/build-release-tools/lib/ParallelTasks.py
+++ b/build-release-tools/lib/ParallelTasks.py
@@ -1,0 +1,142 @@
+# Copyright 2016, EMC, Inc.
+
+import datetime
+import os
+import sys
+
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
+
+import multiprocessing
+
+class ParallelTasks(object):
+    """
+    Run a set of tasks in parallel, collecting the output from each task (stdout & stderr), along
+    with the process exit code, the child process ID and the start/end/elapsed time of each task.
+
+    This class is intended to be subclassed, where the subclass will provide the specific code
+    to be run for each task.   The do_one_task method will be called once per task, in a child
+    process.   Various timing and other housekeeping results will be collected without the
+    assistance of the do_one_task method.
+
+    All results will be returned in a dictionary shared amongst all processes.   The do_one_task
+    should populate the passed in results dictionary, which will then be collected by the parent
+    and saved per-child, using the passed in task name as the key.
+
+    """
+    def __init__(self, job_count):
+        if job_count < 1:
+            job_count = 1
+
+        self._notification_queue = multiprocessing.JoinableQueue()
+        self._manager = multiprocessing.Manager()
+        self._shared_results = self._manager.dict()
+
+        self._processes = [multiprocessing.Process(target=self._run_task_queue)
+                           for i in range(job_count)
+                          ]
+
+        for process in self._processes:
+            process.start()
+
+
+    def get_results(self):
+        """
+        Return the current result status from all subprocesses that have completed
+        :return: subprocess results, keyed via 'name' passed in to add_task
+        """
+        return self._shared_results
+
+
+    def add_task(self, data, name):
+        """
+        Initiate the checkout process -- this notifies the worker queue that a
+        specific repository needs to be checked out
+
+        :param data: arbitrary data to be passed to a worker child process
+        :param name: the key by which this data's job results will be returned
+        """
+        if data is None or name is None:
+            raise ValueError ("no task parameter may be none")
+
+        if self._notification_queue is None:
+            raise RuntimeError("no notification queue available")
+
+        self._notification_queue.put((name, data))
+
+
+    def _run_task_queue(self):
+        """
+        Continually check the notification queue for work to do, and then do it
+        :return:
+
+        This function will run forever.   When there are no more items in the work queue,
+        the main process will terminate all of the child processes, which will all be waiting
+        on Queue.get() to return a value (which won't be coming)
+
+        """
+        while True:
+            (name,data) = self._notification_queue.get()
+
+            if name is None or data is None:
+                raise ValueError("will not run a job without name or data")
+
+            results = { 'task': {}}
+            results['task']['start_time'] = datetime.datetime.now()
+            results['task']['name'] = name
+            results['task']['pid'] = os.getpid()
+            results['task']['ppid'] = os.getppid()
+
+            try:
+                self.do_one_task(name, data, results)
+            except Exception as ex: # pylint: disable=broad-except
+                results['exception'] = ex
+                results['status'] = 'exception'
+            except: # catch *all* exceptions # pylint: disable=bare-except
+                results['error'] = sys.exc_info()[0]
+                results['status'] = 'error'
+
+            self._shared_results[name] = results
+
+            results['task']['end_time'] = datetime.datetime.now()
+            results['task']['elapsed_time'] = results['task']['end_time'] - results['task']['start_time']
+
+            self._notification_queue.task_done()
+
+    def do_one_task(self, name, data, results):
+        """
+        Perform the actual work.  This portion of the task is performed in a
+        subprocess, and may be performed in parallel with other instances.
+
+        The specific data to be passed to the child process is passed in via data.
+
+        Results should be returned via the results dictionary parameter, and should be
+        entesavedred via a key named by name.  The resulting data will normally
+        be a dictionary of multiple values
+
+        :return: any calculated results via results dictionary
+        """
+        # example usage might be
+        #  results[name]['value'] = calculate_value_from(data)
+
+        raise NotImplementedError("__do_one_task must be implemented by a subclass")
+
+
+    def finish(self):
+        """
+        Wait for all of the subprocesses to complete all assigned tasks.
+
+        :return: none
+        """
+
+        # Block until all items in the queue have been gotten and processed.
+        self._notification_queue.join()
+
+        # so now we can do through all of the child processes and stop them
+        # (extreme prejudice is okay, since all work has been performed and they're
+        # just waiting on the queue.get() operation).
+        for process in self._processes:
+            process.terminate()
+

--- a/build-release-tools/lib/RepositoryOperator.py
+++ b/build-release-tools/lib/RepositoryOperator.py
@@ -1,0 +1,488 @@
+"""
+Module to abstract operations to repository
+"""
+import os
+import config
+from gitbits import GitBit
+from ParallelTasks import ParallelTasks
+from common import *
+
+class RepoCloner(ParallelTasks):
+    """
+    Do the actual work of checking out a git repository to the specifications
+    given in the manifest file.
+    Usage:
+    cloner = RepoCloner(integer)
+    # the cloner could add several tasks 
+    cloner.add_task(data)
+    # data should contain:
+      'repo': {
+              "repository": "https://github.com/RackHD/on-tools.git",  ##required
+              "commit-id": xxx,                                        ##optional
+              "branch": xxx                                            ##optional
+      },
+      'builddir': dest_dir,   # the location to check out the repository into
+      'credentials': git_credential  # a list of Git credentials in URL:VARIABLE_NAME format
+
+    # run tasks in parallel
+    cloner.finish()
+    # get the result of tasks
+    results = cloner.get_results()
+    """
+    def add_task(self, data, name=None):
+        """
+        Place data for a specific build into the work queue.  The work is to be done in
+        a separate process.   This method will return quickly, as soon as the data is placed
+        into the queue.  No guarantees are made as to when the work will be completed.
+
+        :param data:
+        data should contain:
+           'credentials': a list of Git credentials in URL:VARIABLE_NAME format
+           'repo': a repository entry from a manifest file
+           'builddir': the location to check out the repository into
+        :param name: a unique key for used for storing results
+        :return: nothing
+        """
+        if data is not None and 'repo' in data and 'repository' in data['repo']:
+            name = data['repo']['repository']
+            super(RepoCloner, self).add_task(data, name)
+        else:
+            raise ValueError("no repository entry in data: {0}".format(data))
+
+    
+    @staticmethod
+    def _get_reset_value(repo):
+        """
+        Return the appropriate reset value for the given repository.   This may be none.
+        The idea is that a commit-id is the most specific thing that can be specified, so
+        use that if it's available.   A tag should be used if present and no commit-id is
+        available.
+
+        :param repo: a specific manifest repository
+        :return: the value to use with git reset --hard
+        """
+        reset_id = None
+        if 'commit-id' in repo and repo['commit-id'] != '':
+            reset_id = repo['commit-id']
+        elif 'tag' in repo:
+            reset_id = repo['tag']
+        return reset_id
+
+
+    def do_one_task(self, name, data, results):
+        """
+        Perform the actual work of checking out a repository.   This portion of the
+        task is performed in a subprocess, and may be performed in parallel with other
+        instances.
+
+        name and data will come from the values passed in to add_task()
+
+        :param name:
+        :param data:
+        data should contain:
+           'credentials': a list of Git credentials in URL:VARIABLE_NAME format
+           'repo': a repository entry from a manifest file
+           'builddir': the location to check out the repository into
+        :param results: a shared dictionary for storing results and sharing them to the
+                        parent process
+        :return: None (all output data stored in results)
+        """
+
+        # make sure we have all of the right data that we need to start the build
+        if name is None or data is None:
+            raise ValueError("name or data not present")
+
+        for key in ['repo', 'builddir']:
+            if key not in data:
+                raise ValueError("{0} key missing from data: {1}".format(key, data))
+
+        repo = data['repo']
+        if 'repository' not in repo:
+            raise ValueError("no repository in work {0}".format(repo))
+
+        # data validation okay, so start the work
+
+        print "Starting checkout of {0}".format(name)
+
+        # someplace to start storing results of the commands that will be run
+        results['commands'] = []
+        commands = results['commands']
+        git = GitBit(verbose=False)
+        if 'credentials' in data and data['credentials'] is not None:
+            for credential in data['credentials']:
+                url, cred = credential.split(',', 2)
+                git.add_credential_from_variable(url, cred)
+        repo_url = repo['repository']
+        destination_directory_name = strip_suffix(os.path.basename(repo_url), ".git")
+        # build up a git clone command line
+        # clone [ -b branchname ] repository_url [ destination_name ]
+
+        command = ['clone']
+
+        #clone big files with git-lfs is much faster
+        if repo.has_key('lfs') and repo['lfs']:
+            command = ['lfs', 'clone']
+
+        if 'branch' in repo and repo['branch'] != "":
+            command.extend(['-b', repo['branch']])
+
+        command.append(repo_url)
+
+        if 'checked-out-directory-name' in repo:
+            # this specifies what the directory name of the checked out repository
+            # should be, as opposed to using Git's default (the basename of the repository URL)
+
+            # note to self: do not combine the following two lines again
+            destination_directory_name = repo['checked-out-directory-name']
+            command.append(destination_directory_name)
+
+        return_code, out, err = git.run(command, data['builddir'])
+
+        commands.append({'command': command,
+                         'return_code': return_code,
+                         'stdout': out,
+                         'stderr': err
+                        })
+
+        if return_code != 0:
+            raise RuntimeError("Unable to clone the repository")
+
+        # the clone has been performed -- now check to see if we need to move the HEAD
+        # to point to a specific location within the tree history.   That will be true
+        # if there is a commit-id or tag value specified in the repository (which will
+        # be the case most of the time).
+
+        reset_id = self._get_reset_value(repo)
+
+        if reset_id is not None:
+            working_directory = os.path.join(data['builddir'], destination_directory_name)
+
+            command = ["reset", "--hard", reset_id]
+            return_code, out, err = git.run(command, directory=working_directory)
+            commands.append({'command': command,
+                             'return_code': return_code,
+                             'stdout': out,
+                             'stderr': err
+                            })
+            if return_code != 0:
+                raise RuntimeError("unable to move to correct commit/tag")
+
+        results['status'] = "success"
+
+
+class RepoOperator(object):
+
+    def __init__(self, git_credentials=None):
+        """
+        Create a repository interface object
+
+        :return:
+        """
+        self._git_credentials = git_credentials
+        
+        self.git = GitBit(verbose=True)
+        if self._git_credentials:
+            self.setup_gitbit()
+
+
+    def setup_gitbit(self, credentials=None):
+        """
+        Set gitbit credentials.
+        :return:
+        """
+        self.git.set_identity(config.gitbit_identity['username'], config.gitbit_identity['email'])
+        if credentials is None:
+            if self._git_credentials is None:
+                return
+            else:
+                credentials = self._git_credentials
+        else:
+            self._git_credentials = credentials
+        for url_cred_pair in credentials:
+            url, cred = url_cred_pair.split(',')
+            self.git.add_credential_from_variable(url, cred)
+
+    def set_git_dryrun(self, dryrun):
+        self.git.set_dryrun(dryrun)
+    
+    def set_git_verbose(self, verbose):
+        self.git.set_verbose(verbose)
+
+    def set_git_executable(self, executable):
+        self.git.set_excutable(excutable)
+
+    @staticmethod
+    def print_command_summary(name, results):
+        """
+        Print the results of running commands.
+          first the command line itself
+            and the error code if it's non-zero
+          then the stdout & stderr values from running that command
+
+        :param name:
+        :param results:
+        :return: True if any command exited with an error condition
+        """
+
+        error_found = False
+
+        print "============================"
+        print "Command output for {0}".format(name)
+
+        if 'commands' in results[name]:
+            commands = results[name]['commands']
+            for command in commands:
+                for key in ['command', 'stdout', 'stderr']:
+                    if key in command:
+                        if command[key] != '':
+                            print command[key]
+                        if key == 'command':
+                            if command['return_code'] != 0:
+                                error_found = True
+                                print "EXITED: {0}".format(command['return_code'])
+
+        return error_found
+
+    def clone_repo_list(self, repo_list, dest_dir, jobs=1):
+        """
+        check out repository to dest dir based on repo list
+        :param repo_list: a list of repository entry which should contain:
+                          'repository': the url of repository, it is required
+                          'branch': the branch to be check out, it is optional
+                          'commit-id': the commit id to be reset, it is optional
+        :param dest_dir: the directory where repository will be check out
+        :param jobs: Number of parallel jobs to run
+        :return:
+        """
+        cloner = RepoCloner(jobs)
+        if cloner is not None:
+            for repo in repo_list:
+                data = {'repo': repo,
+                        'builddir': dest_dir,
+                        'credentials': self._git_credentials
+                       }
+                cloner.add_task(data)
+            cloner.finish()
+            results = cloner.get_results()
+
+            error = False
+            for name in results.keys():
+                error |= self.print_command_summary(name, results)
+
+            if error:
+                raise RuntimeError("Failed to clone repositories")
+
+    def clone_repo(self, repo_url, dest_dir, repo_commit="HEAD"):
+        """
+        check out a repository to dest directory from the repository url
+        :param repo_url: the url of repository, it is required
+        :param dest_dir: the directory where repository will be check out
+        :return: the directory of the repository
+        """
+        repo = {}
+        repo["repository"] = repo_url
+        repo["commit-id"] = repo_commit
+        repo_list = [repo]
+        self.clone_repo_list(repo_list, dest_dir)
+        
+        repo_directory_name = strip_suffix(os.path.basename(repo_url), ".git")
+        return os.path.join(dest_dir, repo_directory_name)
+
+    def get_lastest_commit_date(self, repo_dir):
+        """
+        :param repo_dir: path of the repository
+        :return: commit-date
+        """
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+        return_code, output, error = self.git.run(['show', '-s', '--pretty=format:%ct'], directory=repo_dir)
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to get commit date in directory {0}".format(repo_dir))
+
+    def get_lastest_commit_id(self, repo_dir):
+        """
+        :param repo_dir: path of the repository
+        :return: commit-id
+        """
+         
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+
+        return_code, output, error = self.git.run(['log', '--format=format:%H', '-n', '1'], directory=repo_dir)
+
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to get commit id in directory {0}".format(repo_dir))
+
+    def get_lastest_merge_commit_before_date(self, repo_dir, date):
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+        return_code, output, error = self.git.run(['log', '--merges', '--format=format:%H', '--before='+date, '-n', '1'], directory=repo_dir)
+
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to get commit id before {date} in directory {repo_dir}"\
+                  .format(date=date, repo_dir=repo_dir))
+
+    def get_commit_message(self, repo_dir, commit):
+        """
+        :param repo_dir: path of the repository
+        :param commit: the commit id of the repository
+        :return: commit-message
+        """
+
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+
+        return_code, output, error = self.git.run(['log', '--format=format:%B', '-n', '1', commit], directory=repo_dir)
+
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to get commit message of {commit_id} in directory {repo_dir}"\
+                  .format(commit_id=commit, repo_dir=repo_dir))
+
+
+    def get_repo_url(self, repo_dir):
+        """
+        get the remote url of the repository
+        :param repo_dir: the directory of the repository
+        :return: repository url
+        """
+
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+
+        return_code, output, error = self.git.run(['ls-remote', '--get-url'], directory=repo_dir)
+
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to find the repository url in directory {0}".format(repo_dir))
+
+    def get_current_branch(self, repo_dir):
+        """
+        get the current branch name of the repository
+        :param repo_dir: the directory of the repository
+        :return: branch name
+        """
+
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+
+        return_code, output, error = self.git.run(['symbolic-ref', '--short', 'HEAD'], directory=repo_dir)
+
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to find the current branch in directory {0}".format(repo_dir))
+
+    def check_branch(self, repo_url, branch):
+        """
+        Checks if the specified branch name exists for the provided repository. Leave only the characters
+        following the final "/". This is to handle remote repositories.
+        Raise RuntimeError if it is not found.
+        :return: None
+        """
+        if "/" in branch:
+            sliced_branch = branch.split("/")[-1]
+        else:
+            sliced_branch = branch
+
+        return_code, output, error = self.git.run(['ls-remote', repo_url, 'heads/*{0}'.format(sliced_branch)])
+
+        if return_code is not 0 or output is '':
+            raise RuntimeError("The branch, '{0}', provided for '{1}', does not exist."
+                               .format(branch, repo_url))
+
+    def set_repo_tagname(self, repo_url, repo_dir, tag_name):
+        """
+        Sets tagname on the repo
+        :param repo_url: the url of the repository
+        :param repo_dir: the directory of the repository
+        :param tag_name: the tag name to be set
+        :return: None
+        """
+        # See if that tag exists for the repo
+        return_code, output, error  = self.git.run(["tag", "-l", tag_name], repo_dir)
+
+        # Raise RuntimeError if tag already exists, otherwise create it
+        if return_code == 0 and output != '':
+            raise RuntimeError("Error: Tag {0} already exists - exiting now...".format(output))
+        else:
+            print "Creating tag {0} for repo {1}".format(tag_name, repo_url)
+            self.git.run(["tag", "-a", tag_name, "-m", "\"Creating new tag\""], repo_dir)
+            self.git.run(["push", "origin", "--tags"], repo_dir)
+
+    def create_repo_branch(self, repo_url, repo_dir, branch_name):
+        """
+        Creates branch on the repo
+        :param repo_url: the url of the repository
+        :param repo_dir: the directory of the repository
+        :param branch_name: the branch name to be set
+        :return: None
+        """
+        # See if that branch exists for the repo
+        return_code, output, error  = self.git.run(["ls-remote", "--exit-code", "--heads", repo_url, branch_name], repo_dir)
+        # Raise RuntimeError if branch already exists, otherwise create it
+        if return_code == 0 and output != '':
+            raise RuntimeError("Error: Branch {0} already exists - exiting now...".format(output))
+        else:
+            print "Creating branch {0} for repo {1}".format(branch_name, repo_url)
+            return_code, output, error = self.git.run(["branch", branch_name], repo_dir)
+            if return_code != 0:
+                print output
+                raise RuntimeError("Error: Failed to create local branch {0} with error: {1}.".format(branch_name, error))
+            return_code, output, error = self.git.run(["push", "-u", "origin", branch_name], repo_dir)
+            if return_code != 0:
+                print output
+                raise RuntimeError("Error: Failed to publish local branch {0} with error: {1}".format(branch_name, error))
+
+    def checkout_repo_branch(self, repo_dir, branch_name):
+        """
+        Check out to specify branch on the repo
+        :param repo_dir: the directory of the repository
+        :param branch_name: the branch name to be checked
+        :return: None
+        """
+        return_code, output, error  = self.git.run(["checkout", branch_name], repo_dir)
+
+        if return_code != 0:
+            raise RuntimeError("Error: Failed to checkout branch {0}".format(output))
+
+    def push_repo_changes(self, repo_dir, commit_message, push_all=False):
+        """
+        publish changes of reposioty
+        :param repo_dir: the directory of the repository
+        :param commit_message: the message to be added to commit
+        :return: None
+        """
+
+        status_code, status_out, status_error = self.git.run(['status'], repo_dir)
+        if status_code == 0:
+            if "nothing to commit, working directory clean" in status_out:
+                print status_out
+                return
+
+        if push_all:
+            add_code, add_out, add_error = self.git.run(['add', '-A'], repo_dir)
+        else:
+            add_code, add_out, add_error = self.git.run(['add', '-u'], repo_dir)
+
+        if add_code != 0:
+            raise RuntimeError('Unable to add files for commiting.\n{0}\n{1}\n{2}'.format\
+                                 (add_code, add_out, add_error))
+
+        commit_code, commit_out, commit_error = self.git.run(['commit', '-m', commit_message], repo_dir)
+        if commit_code != 0:
+            raise RuntimeError('Unable to commit changes for pushing.\n{0}\n{1}\n{2}'.format\
+                                 (commit_code, commit_out, commit_error))
+
+        push_code, push_out, push_error = self.git.run(['push'], repo_dir)
+        if push_code !=0:
+            raise RuntimeError('Unable to push changes.\n{0}\n{1}\n{2}'.format(push_code, push_out, push_error))
+        return

--- a/build-release-tools/lib/common.py
+++ b/build-release-tools/lib/common.py
@@ -1,0 +1,128 @@
+# Copyright 2016, EMC, Inc.
+
+import subprocess
+import logging
+from pyjavaproperties import Properties
+import os
+
+log_file = 'manifest-build-tools.log'
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p', filename=log_file, filemode='w', level=logging.DEBUG)
+
+def strip_suffix(text, suffix):
+    """
+    Cut a set of the last characters from a provided string
+    :param text: Base string to cut
+    :param suffix: String to remove if found at the end of text
+    :return: text without the provided suffix
+    """
+    if text is not None and text.endswith(suffix):
+        return text[:len(text) - len(suffix)]
+    else:
+        return text
+
+def strip_prefix(text, prefix):
+    if text is not None and text.startswith(prefix):
+        return text[len(prefix):]
+    else:
+        return text
+
+def write_parameters(filename, params):
+    """
+    Add/append parameters(java variable value pair) to the given parameter file.
+    If the file does not exist, then create the file.
+    :param filename: The path of the parameter file
+    :param params: the parameters dictionary
+    :return:None on success
+            Raise any error if there is any
+    """
+    if filename is None:
+        raise ValueError("parameter file name is not None")
+    with open(filename, 'w') as fp:
+        for key in params:
+            entry = "{key}={value}\n".format(key=key, value=params[key])
+            fp.write(entry)
+
+def link_dir(src, dest, dir):
+    cmd_args = ["ln", "-s", src, dest]
+    run_command(cmd_args, directory=dir)
+
+def get_debian_version(file_path):
+    """
+    Get the version of a debian file
+    :param file_path: the path of the debian file
+    :return: the version of the debian file
+    """
+    cmd_args = ["dpkg-deb", "-f", file_path, "Version"]
+    debian_version = run_command(cmd_args)
+    return debian_version
+
+def get_debian_package(file_path):
+    cmd_args = ["dpkg-deb", "-f", file_path, "Package"]
+    debian_name = run_command(cmd_args)
+    return debian_name
+
+def parse_property_file(filename):
+    """
+    parse java properties file
+    :param filename: the path of the properties file
+    :return: dictionary loaded from the file
+    """
+    if not os.path.isfile(filename):
+        raise RuntimeError("No file found for parameter at {0}".format(filename))
+    p = Properties()
+    p.load(open(filename))
+    return p
+
+def parse_credential_variable(varname):
+    """
+    Get the specified variable name from the environment and split it into username,password
+    :param varname: environment variable name
+    :return: username, password tuple
+    """
+    try:
+        if varname not in os.environ:
+            raise ValueError("Credential variable {0} doesn't exist".format(varname))
+
+        credential = os.environ[varname]
+        if credential is None:
+            raise ValueError("Failed to parse credential variable {0}".format(varname))
+
+        (username, password) = credential.split(':', 2)
+        if username is None or password is None:
+            raise ValueError("Failed to split credential variable {0} into username, password".format(varname))
+
+        return username, password
+    except Exception, e:
+        raise ValueError(e)
+
+def run_command(cmd_args, directory=None):
+    proc = subprocess.Popen(cmd_args,
+                            stderr=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            cwd=directory,
+                            shell=False)
+    (out, err) = proc.communicate()
+    if proc.returncode == 0:
+        return out.strip()
+    else:
+        commandline = " ".join(cmd_args)
+        raise RuntimeError("Failed to run command {0} due to {1}".format(commandline, err))
+
+def find_specify_type_files(directory, suffix, depth=4096):
+    file_list = []
+    top_dir_depth = directory.count(os.path.sep) #How deep is at starting point
+    for root, dirs, files in os.walk(directory):
+        root_depth = root.count(os.path.sep)
+        if (root_depth - top_dir_depth) <= depth:
+            for file_itr in files:
+                if file_itr.endswith(suffix):
+                    abs_file = os.path.abspath(os.path.join(root, file_itr))
+                    file_list.append(abs_file)
+    return file_list
+
+def str2bool(string):
+    if string.lower() in ("true", "yes", "t", "1"):
+        return True
+    else:
+        return False
+

--- a/build-release-tools/lib/config.py
+++ b/build-release-tools/lib/config.py
@@ -1,0 +1,4 @@
+gitbit_identity = dict(
+    username='Robbie the Build Robot',
+    email='robot@hwimo.lab.emc.com'
+)

--- a/build-release-tools/lib/gitbits.py
+++ b/build-release-tools/lib/gitbits.py
@@ -1,0 +1,189 @@
+# Copyright 2015, EMC, Inc.
+
+"""
+Module to abstract Git commands from within a program, by using the git command line
+
+Credentials and identity information can be added to these jobs as needed.
+
+"""
+
+import os
+import subprocess
+import tempfile
+from urlparse import urlparse
+from common import *
+
+class GitBit(object):
+    @staticmethod
+    def __parse_credential_variable(varname):
+        """
+        Get the specified variable name from the environment and split it into username,password
+        :param varname: environment variable name
+        :return: username, password tuple
+        """
+        credential = os.environ[varname]
+
+        (username, password) = credential.split(':', 2)
+        return username, password
+
+
+    def __init__(self, verbose=False):
+        """
+        Create a GitBit interface object
+
+        :return:
+        """
+        self.__credentials = []
+        self.__credential_filename = None
+        self.__username = None
+        self.__email = None
+        self.__git_executable = "/usr/bin/git"
+
+        self.__verbose = verbose
+
+
+    def __del__(self):
+        self.cleanup()
+
+
+    def cleanup(self):
+        """
+        Cleans up the temporary file created by this object.
+
+        :return:
+        """
+        if self.__credential_filename is not None:
+            if os.path.exists(self.__credential_filename):
+                os.remove(self.__credential_filename)
+                self.__credential_filename = None
+
+
+    def add_credential(self, server_url, username, password):
+        """
+        Associate the given URL with the credentials specified as arguments
+
+        :param server_url:  Git repository URL (or fragment; only the host is needed)
+        :param username: the repository user name
+        :param password: the user's password (or token string)
+        :return:
+        """
+        parts = urlparse(server_url)
+        if (username is not None) and (password is not None):
+            full_url = "{0}://{1}:{2}@{3}".format(parts.scheme,
+                                                  username,
+                                                  password,
+                                                  parts.netloc)
+            self.__credentials.append({"scheme": parts.scheme,
+                                       "host": parts.netloc,
+                                       "username": username,
+                                       "password": password,
+                                       "url": full_url,
+                                      })
+            return True
+        else:
+            return False
+
+
+    def add_credential_from_variable(self, server_url, env_var_name):
+        """
+        Associate the given URL with the credentials found from the environment
+
+        :rtype: None
+        :param server_url: a Git repository URL (or fragment; only the host is needed)
+        :param env_var_name: environment variable name containing credentials
+        :return: success of operation
+        """
+        if env_var_name in os.environ:
+            (username, password) = self.__parse_credential_variable(env_var_name)
+            return self.add_credential(server_url, username, password)
+        else:
+            return False
+
+
+    def get_credentials(self):
+        """
+        Return a list of all known credentials
+        :return:
+        """
+        return self.__credentials
+
+
+    def __write_credential_file(self):
+        """
+        Write the known credentials to a file suitable for Git's store credential helper.
+        The filename is saved for later removal, and is returned
+
+        See git-credential-store(1) for details on the format
+        :return:
+        """
+        if self.__credential_filename is None:
+            (fd, filename) = tempfile.mkstemp()    # pylint: disable=unused-variable
+            self.__credential_filename = filename
+
+            with open(filename, "w") as credential_file:
+                for credential in self.get_credentials():
+                    print >> credential_file, "{0}".format(credential['url'])
+
+
+    def set_identity(self, username, email):
+        """
+        Define a username and email for the Git identity.  Git will autogenerate one as it can
+        if not provided.  As our automated Git tools should not have a persistent identity via
+        $HOME, we need to provide this in the tool.
+
+        :param username:
+        :param email:
+        :return:
+        """
+        self.__username = username
+        self.__email = email
+
+
+    def run(self, args, directory=None, dry_run=False):
+        """
+        Run a Git command, with the arguments specified in args.
+
+        Authentication information (if available) will be added to the command line
+
+        :return: exit code,stdout,stderr: exit code, standard out and standard err
+        :rtype: object
+        :param args: the desired git command and arguments
+        :param directory: the desired working directory (used via -C), None for cwd
+        """
+        config_args = []
+
+        if directory is not None:
+            config_args += ["-C", directory]
+
+        if len(self.get_credentials()) > 0:
+            self.__write_credential_file()
+            config_args += ["-c", "credential.helper=store --file {0}".format(self.__credential_filename)]
+
+        if self.__username is not None:
+            config_args += ["-c", "user.name={0}".format(self.__username)]
+
+        if self.__email is not None:
+            config_args += ["-c", "user.email={0}".format(self.__email)]
+
+        # get rid of the warning message
+        config_args += ["-c", "push.default=simple"]
+
+        # git should be found via the command line
+        cmd_args = [self.__git_executable] + config_args + args
+
+        if dry_run or self.__verbose:
+            logging.warning("GIT: {0}".format(" ".join(cmd_args)))
+
+        if dry_run:
+            return 0, None, None
+
+        try:
+            proc = subprocess.Popen(cmd_args,
+                                    stderr=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    shell=False)
+            (out, err) = proc.communicate()
+        except subprocess.CalledProcessError as ex:
+            return ex.returncode, None, None
+
+        return proc.returncode, out, err

--- a/build-release-tools/lib/manifest.json
+++ b/build-release-tools/lib/manifest.json
@@ -1,0 +1,72 @@
+{
+    "build-name": "rackhd-devel", 
+    "build-requirements": "xenial", 
+    "downstream-jobs": [], 
+    "repositories": [
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-core.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-dhcp-proxy.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-http.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-syslog.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-taskgraph.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-tasks.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-tftp.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-skupack.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/di.js.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/RackHD.git"
+        }, 
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-imagebuilder.git"
+        },
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-wss.git"
+        },
+        {
+            "branch": "", 
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/on-statsd.git"
+        }
+    ]
+}

--- a/build-release-tools/lib/manifest.py
+++ b/build-release-tools/lib/manifest.py
@@ -1,0 +1,406 @@
+# Copyright 2016, EMC, Inc.
+
+"""
+Module to abstract a manifest file
+"""
+import json
+import os
+import re
+import sys
+import datetime
+import config
+
+from gitbits import GitBit
+
+manifest_sample = "manifest.json"
+class Manifest(object):
+    def __init__(self, file_path, git_credentials = None):
+        """
+        __build_name - Refer to the field "build-name" in manifest file.
+        __repositories - Refer to the field "repositories" in manifest file.
+        __downstream_jobs - Refer to the field "downstream-jobs" in manifest file.
+        __file_path - The file path of the manifest file
+        __name - The file name of the manifest file
+        __manifest -The content of the manifest file
+        __changed - If manifest is changed, be True; The default value is False
+        __git_credentials  - URL, credentials pair for the access to github repos
+        gitbit - Class instance of gitbit
+        """
+
+        self._build_name = None
+        self._build_requirements = None
+        self._repositories = []
+        self._downstream_jobs = []
+        self._file_path = file_path
+        self._name = file_path.split('/')[-1]
+        self._manifest = None
+        self._changed = False
+
+        self._git_credentials = None
+        self.gitbit = GitBit(verbose=True)
+
+        if git_credentials:
+            self._git_credentials = git_credentials
+            self.setup_gitbit()
+
+        self.read_manifest_file(self._file_path)
+        self.parse_manifest()
+
+    @staticmethod
+    def instance_of_sample():
+        repo_dir = os.path.dirname(sys.path[0])
+        for subdir, dirs, files in os.walk(repo_dir):
+            for file in files:
+                if file == manifest_sample:
+                    manifest = Manifest(os.path.join(subdir, file))
+                    return manifest
+        return None
+
+    def set_git_credentials(self, git_credentials):
+        self._git_credentials = git_credentials
+        self.setup_gitbit()
+
+    @property
+    def downstream_jobs(self):
+        return self._downstream_jobs
+
+    @property
+    def repositories(self):
+        return self._repositories
+
+    @property
+    def manifest(self):
+        return self._manifest
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def file_path(self):
+        return self._file_path
+
+    @property
+    def build_name(self):
+        return self._build_name
+
+    @build_name.setter
+    def build_name(self, build_name):
+        self._build_name = build_name
+        self._manifest['build-name'] = build_name
+
+    @property
+    def build_requirements(self):
+        return self._build_requirements
+    
+    @build_requirements.setter
+    def build_requirements(self, requirements):
+        self._manifest['build-requirements'] = requirements
+        self._build_requirements = requirements
+
+    @property
+    def changed(self):
+        return self._changed
+
+    def setup_gitbit(self):
+        """
+        Set gitbit credentials.
+        :return: None
+        """
+        self.gitbit.set_identity(config.gitbit_identity['username'], config.gitbit_identity['email'])
+        if self._git_credentials:
+            for url_cred_pair in self._git_credentials:
+                url, cred = url_cred_pair.split(',')
+                self.gitbit.add_credential_from_variable(url, cred)
+
+    def read_manifest_file(self, filename):
+        """
+        Reads the manifest file json data to class member _manifest.
+        :param filename: where to read the manifest data from
+        :return: None
+        """
+        if not os.path.isfile(filename):
+            raise KeyError("No file found for manifest at {0}".format(filename))
+
+        with open(filename, "r") as manifest_file:
+            self._manifest = json.load(manifest_file)
+
+    def parse_manifest(self):
+        """
+        parse manifest and assign properties
+        :return: None
+        """
+        if 'build-name' in self._manifest:
+            self._build_name = self._manifest['build-name']
+  
+        if 'build-requirements' in self._manifest:
+            self._build_requirements = self._manifest['build-requirements']
+
+        if 'repositories' in self._manifest:     
+            for repo in self._manifest['repositories']:
+                self._repositories.append(repo)
+
+        if 'downstream-jobs' in self._manifest:
+            for job in self._manifest['downstream-jobs']:
+                self._downstream_jobs.append(job)
+
+    @staticmethod
+    def validate_repositories(repositories):
+        """
+        validate whether the entry 'repositories' contains useful information
+        return: True if the entry is valid,
+                False if the entry is unusable
+                and message including omission imformation
+        """
+        result = True
+        message = []
+        for repo in repositories:
+            valid = True
+            # repository url is required
+            if 'repository' not in repo or repo['repository'] == "":
+                valid = False
+                message.append("entry without tag repository")
+
+            # either branch or commit-id should be set.
+            if ('branch' not in repo or repo['branch'] == "") and \
+               ('commit-id' not in repo or repo['commit-id'] == ""):
+                valid = False
+                message.append("Either branch or commit-id should be set for entry")
+            
+            if not valid:
+                result = False
+                message.append("entry content:")
+                message.append("{0}".format(json.dumps(repo, indent=True)))
+        
+        return result, message
+
+    @staticmethod
+    def validate_downstream_jobs(downstream_jobs):
+        """
+        validate whether the entry 'downstream-jobs' contains useful information
+        return: True if the entry is valid,
+                False if the entry is unusable
+                and message including omission imformation
+        """
+        result = True
+        message = []
+        for job in downstream_jobs:
+            valid = True
+            # repository url is required
+            if 'repository' not in job or job['repository'] == "":
+                valid = False
+                message.append("entry without tag repository")
+
+            #command is required
+            if 'command' not in job:
+                valid = False
+                message.append("entry without tag command")
+
+            #working-directory is required
+            if 'working-directory' not in job:
+                valid = False
+                message.append("entry without tag working-directory")
+
+            #running-label is required
+            if 'running-label' not in job:
+                valid = False
+                message.append("entry without tag running-label")
+
+            # either branch or commit-id should be set.
+            if ('branch' not in job or job['branch'] == "") and \
+               ('commit-id' not in job or job['commit-id'] == ""):
+                valid = False
+                message.append("Either commit-id or branch should be set for job repository")
+
+            # downstream-jobs is optional
+            # if it is specified, the value should be validate
+            if 'downstream-jobs' in job:
+                downstream_result, downstream_message = Manifest.validate_downstream_jobs(job['downstream-jobs'])
+                if not downstream_result:
+                    valid = False
+                    message.extend(downstream_message)
+
+            if not valid:
+                result = False
+                message.append("entry content:")
+                message.append("{0}".format(json.dumps(job, indent=True)))
+
+        return result, message
+
+    def validate_manifest(self):
+        """
+        Identify whether the manifest contains useful information (as we understand it)
+        raise error if manifest is unusable
+        :return: None
+        """
+
+        result = True
+        messages = ["Validate manifest file: {0}".format(self._name)]
+        if self._manifest is None:
+            result = False
+            messages.append("No manifest contents")
+
+        #build-name is required
+        if 'build-name' not in self._manifest:
+            result = False
+            messages.append("No build-name in manifest file")
+
+        #repositories is required
+        if 'repositories' not in self._manifest:
+            result = False
+            messages.append("No repositories in manifest file")
+        else:
+            r, m = self.validate_repositories(self._repositories)
+            if not r:
+                result = False
+                messages.extend(m)
+        #downstream-jobs is required
+        if 'downstream-jobs' not in self._manifest:
+            result = False
+            messages.append("No downstream-jobs in manifest file")
+        else:
+            r, m = Manifest.validate_downstream_jobs(self._downstream_jobs)
+            if not r:
+                result = False
+                messages.extend(m)
+        #build-requirements is required
+        if 'build-requirements' not in self._manifest:
+            result = False
+            messages.append("No build-requirements in manifest file")
+        
+        if not result:
+            messages.append("manifest file {0} is not valid".format(self._name))
+            error = '\n'.join(messages)
+            raise KeyError(error)
+
+    @staticmethod
+    def check_commit_changed(repo, repo_url, branch, commit):
+        """
+        Check whether the repository is changed based on its url, branch ,commit-id and arguments repo_url, branch, commit
+        :param repo: an repository entry of member _repositories or _downstream_jobs
+        :param repo_url: the url of the repository
+        :param branch: the branch of the repository
+        :param commit: the commit id of the repository
+        :return: True when the commit-id is different with argument commit
+                 and the url and branch is the same with the arguments repo_url, branch;
+                 otherwise, False
+        """
+
+        if (repo['repository'] == repo_url):
+            # If repo has "branch", compare "commit-id" in repo with the argument commit
+            # only when "branch" is the same with argument branch.
+
+            if 'branch' in repo:
+                sliced_repo_branch = repo['branch'].split("/")[-1]
+                sliced_branch = branch.split("/")[-1]
+                if (repo['branch'] == branch or
+                    repo['branch'] == sliced_branch or
+                    sliced_repo_branch == sliced_branch):
+
+                    if 'commit-id' in repo:
+                        print "checking the commit-id for {0} with branch {1} from {2} to {3}".format\
+                                (repo_url, branch, repo['commit-id'], commit)
+
+                        if repo['commit-id'] != commit:
+                            print "   commit-id updated!"
+                            return True
+                        else:
+                            print "   commit-id unchanged"
+                            return False
+                    else:
+                        print "add commit-id{0} for {1} with branch {2} ".format\
+                              (commit, repo_url, branch)
+                        return True
+            # If repo doesn't have "branch", compare "commit-id" in repo with argument commit
+            # Exits with 1 if repo doesn't have "commit-id"
+            else:
+                if 'commit-id' not in repo:
+                    raise KeyError("Neither commit-id nor branch is set for repository {0}".format(repo['repository']))
+                else:
+                    if repo['commit-id'] != commit:
+                        print "   commit-id updated!"
+                        return True
+                    else:
+                        print "   commit-id unchanged"
+                        return False
+        return False
+
+    @staticmethod
+    def update_downstream_jobs(downstream_jobs, repo_url, branch, commit):
+        """
+        update the instance of the class based on member:
+        _downstream_jobs and provided arguments.
+
+        :param downstream_jobs: the entry downstream_jobs
+        :param repo_url: the url of the repository
+        :param branch: the branch of the repository
+        :param commit: the commit id of the repository
+        :return: True if any job in downstream_jobs is updated
+                 False if none of jobs in downstream_jobs is updated
+        """
+        updated = False
+        for job in downstream_jobs:
+            if Manifest.check_commit_changed(job, repo_url, branch, commit):
+                job['commit-id'] = commit
+                updated = True
+            if 'downstream-jobs' in job:
+                nested_downstream_jobs = job['downstream-jobs']
+                if Manifest.update_downstream_jobs(nested_downstream_jobs, repo_url, branch, commit):
+                    updated = True
+        return updated
+
+    @staticmethod
+    def update_repositories(repositories, repo_url, branch, commit):
+        """
+        update the instance of the class based on member:
+        _repositories and provided arguments.
+
+        :param repositories: the entry repositories
+        :param repo_url: the url of the repository
+        :param branch: the branch of the repository
+        :param commit: the commit id of the repository
+        :return:
+        """
+        updated = False
+        for repo in repositories:
+            if Manifest.check_commit_changed(repo, repo_url, branch, commit):
+                repo['commit-id'] = commit
+                updated = True
+        return updated
+
+    def update_manifest(self, repo_url, branch, commit):
+        """
+        update the instance of the class based on members
+         _repositories , _downstream_jobs and provided arguments.
+        :param repo_url: the url of the repository
+        :param branch: the branch of the repository
+        :param commit: the commit id of the repository
+        :return:
+        """
+        print "start updating  manifest file {0}".format(self._name)
+        if self.update_repositories(self._repositories, repo_url, branch, commit):
+            self._changed = True
+
+        if self.update_downstream_jobs(self._downstream_jobs, repo_url, branch, commit):
+            self._changed = True
+
+    def write_manifest_file(self, file_path=None, dryrun=False):
+        """
+        Add, commit, and push the manifest changes to the manifest repo.
+        :param file_path: String, The path to the temporary file.
+                          If it is not set, the default value is self._file_path where manifest come from
+        :param dry_run: If true, would not push changes
+        :return:
+        """
+        self.dump_to_json_file(file_path)
+        return
+
+    def dump_to_json_file(self, file_path=None):
+        """
+        dump manifest json to a file
+        """
+        if file_path is None:
+            file_path = self._file_path
+
+        with open(file_path, 'w') as fp:
+            json.dump(self._manifest, fp, indent=4, sort_keys=True)

--- a/build-release-tools/mkenv.sh
+++ b/build-release-tools/mkenv.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+####################################################
+# Run this without options to create a virtual
+# environment for the current git branch
+#
+# Override the default virtual enviornment name through
+# the single argument to script:
+#
+# mkenv.sh <env_name>
+####################################################
+
+set -e
+PROG=${0}
+
+# We need virtualenv from somewhere
+virtualenv=`which virtualenv`
+if [ ! -x "${virtualenv}" ]; then
+    echo "location of virtualenv executable is unknown"
+    exit 1
+fi
+
+# Set up env_name either from command line, else current git branch
+if [ $# -eq 1 ]; then
+    env_name=$1
+else
+    env_name=`git rev-parse --abbrev-ref HEAD`
+fi
+
+# Normalize env_name, replace '/' with '_'
+env_name=${env_name//\//_}
+
+# Our virtual environments are found within <toplevelgit>/env
+#cd "$(git rev-parse --show-toplevel)"
+export WORKON_HOME=`pwd`/env
+
+# mkvirtualenv, OK if its already there
+${virtualenv} --clear env/${env_name}
+
+# activate the virtual environment
+source "env/${env_name}/bin/activate"
+
+# Use locally sourced pip configuration
+export PIP_CONFIG_FILE=`pwd`/pip.conf
+
+# Install all required packages
+pip install -r requirements.txt
+
+# Create local requirements (for example, pylint)
+if [ -f requirements_local.txt ]
+then
+  pip install -r requirements_local.txt
+fi
+
+# Generate a script that assists in switching environments
+cat > myenv_${env_name} <<End-of-message
+# *** Autgenerated file, do not commit to remote repository
+export WORKON_HOME="${WORKON_HOME}"
+source "env/${env_name}/bin/activate"
+End-of-message
+
+echo ""
+echo "${PROG}: complete, run the following to use '${env_name}' environment:"
+echo
+echo "source myenv_${env_name}"
+
+exit 0

--- a/build-release-tools/post_test.sh
+++ b/build-release-tools/post_test.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+
+############################################
+# Post-Test scripts for ova, vagrantBox and docker.
+# This script will up/deploy ova, box and docker images,
+# Then check if RackHD services are good running.
+#
+# Usage: 
+# post_test.sh \
+# --type ova, vagrant or docker
+#
+# ova-post-test need some special parameter of net config and target esxi server
+# --adminIP ***.***.***.***
+# --adminGateway ***.***.***.***
+# --adminNetmask 255.255.255.0
+# --adminDNS ***.***.***.***
+# --net "ADMIN"="External Connection"
+# --datastore some-datastore
+# --deployName ova-for-post-test
+# --ovaFile /someDir/some.ova
+# --vcenterHost ***.***.***.***
+# --ntName user
+# --ntPass password
+# --esxiHost ***.***.***.***
+#
+# vagrant-post-test need some special parameter of boxFile and controlNetwork name
+# --boxFile ./someDir/some.box
+# --controlNetwork vmnet*
+# --
+#
+# docker-post-test need some special parameter of docker build record file and cloned RackHD repo
+# --RackHDDir ./someDir/RackHD
+# --buildRecord ./record_file
+# A recorde_file contains repo:tag of all rackhd repos which build in one docker build, its format is like this:
+# repo1:tag1 repo2:tag2 ......
+# If build twice in one docker build job, the repos:tags of each build will be stored in each line
+############################################
+
+set -x
+
+while [ "$1" != "" ];do
+    case $1 in
+        --type)
+            shift
+            type=$1;;
+        --adminIP)
+            shift
+            adminIP=$1;;
+        --adminGateway)
+            shift
+            adminGateway=$1;;
+        --adminNetmask)
+            shift
+            adminNetmask=$1;;
+        --adminDNS)
+            shift
+            adminDNS=$1;;
+        --net)
+            shift
+            net=$1;;
+        --datastore)
+            shift
+            datastore=$1;;
+        --deployName)
+            shift
+            deployName=$1;;
+        --ovaFile)
+            shift
+            ovaFile=$1;;
+        --vcenterHost)
+            shift
+            vcenterHost=$1;;
+        --ntName)
+            shift
+            ntName=$1;;
+        --ntPass)
+            shift
+            ntPass=$1;;
+        --esxiHost)
+            shift
+            esxiHost=$1;;
+        --boxFile)
+            shift
+            boxFile=$1;;
+        --controlNetwork)
+            shift
+            controlNetwork=$1;;
+        --RackHDDir)
+            shift
+            RackHDDir=$1;;
+        --buildRecord)
+            shift
+            buildRecord=$1;;
+        *)
+        exit 1
+    esac
+    shift
+done
+
+findRackHDService() {
+    case $type in
+        ova)
+        # ova northPort default to 8080
+        api_test_result=`ansible ova-for-post-test -a "wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue localhost:8080/api/2.0/nodes"`
+        echo $api_test_result | grep "$service_normal_sentence" > /dev/null  2>&1
+        ;;
+        docker)
+        # docker southPort default to 9080
+        wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue http://172.31.128.1:9080/api/2.0/nodes
+        ;;
+        vagrant)
+        # Vagrantfile northPort default to 9090
+        curl 127.0.0.1:9090/api/2.0/nodes
+        ;;
+    esac
+}
+
+waitForAPI() {
+    #will be edit after build own ova
+    service_normal_sentence="Authentication Failed"
+    timeout=0
+    maxto=60
+    while [ ${timeout} != ${maxto} ]; do
+        findRackHDService
+        if [ $? = 0 ]; then
+          echo "RackHD services perform normally!"
+          break
+        fi
+        sleep 10
+        timeout=`expr ${timeout} + 1`
+    done
+    if [ ${timeout} == ${maxto} ]; then
+        echo "Timed out waiting for RackHD API service (duration=`expr $maxto \* 10`s)."
+        exit 1
+      fi
+}
+
+############################################
+# ova post test
+############################################
+
+deploy_ova() {
+    echo yes | ovftool \
+    --prop:adminIP=$adminIP  --prop:adminGateway=$adminGateway --prop:adminNetmask=$adminNetmask  --prop:adminDNS=$adminDNS \
+    --overwrite --powerOffTarget --powerOn --skipManifestCheck \
+    --net:$net \
+    --datastore=$datastore \
+    --name=$deployName \
+    ${ovaFile} \
+    vi://${ntName}:${ntPass}@${vcenterHost}/Infrastructure@onrack.cn/host/${esxiHost}/
+    ssh-keygen -f "$HOME/.ssh/known_hosts" -R $adminIP
+}
+
+delete_ova() {
+	ansible esxi -a "./vm_operation.sh -a delete ${esxiHost} 1 $deployName"
+    if [ $? = 0 ]; then
+      echo "Delete $deployName successfully!"
+    fi
+}
+
+post_test_ova() {
+    delete_ova
+    deploy_ova
+    waitForAPI
+    delete_ova
+}
+
+############################################
+# vagrant post test
+############################################
+
+create_vagrant_file() {
+    wget vagrantFile -O Vagrantfile.in
+    sed -e "s#rackhd/rackhd#${boxFile}#g" \
+        -e '/target.vm.box_version/d' \
+        -e "s#em1#${controlNetwork}#g" \
+        Vagrantfile.in > Vagrantfile
+}
+
+post_test_vagrant() {
+    vagrant destroy -f
+    vagrant up --provision
+    waitForAPI
+    vagrant destroy -f
+}
+
+############################################
+# docker post test
+############################################
+
+clean_all_containers() {
+    docker stop $(docker ps -a -q)
+    docker rm $(docker ps -a -q)
+}
+
+post_test_docker() {
+    clean_all_containers
+    cd $RackHDDir/docker 
+    #if clone file name is not repo name, this scirpt should be edited.
+    while read -r LINE; do
+        cp docker-compose-mini.yml docker-compose-mini.yml.bak
+        for repo_tag in $LINE; do
+            repo=${repo_tag%:*}
+            sed -i "s#rackhd/${repo}.*#rackhdmirror/${repo_tag}#g" docker-compose-mini.yml
+        done
+        docker-compose -f docker-compose-mini.yml pull --ignore-pull-failures
+        docker-compose -f docker-compose-mini.yml up -d
+        mv docker-compose-mini.yml.bak docker-compose-mini.yml
+        waitForAPI
+        clean_all_containers
+    done < $buildRecord
+}
+
+############################################
+# run post test
+############################################
+case $type in
+    ova)
+    post_test_ova
+    ;;
+    docker)
+    post_test_docker
+    ;;
+    vagrant)
+    post_test_vagrant 
+    ;;
+esac

--- a/build-release-tools/pushToBintray.sh
+++ b/build-release-tools/pushToBintray.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+############################################
+# Usage: 
+# pushToBintray.sh \
+# --user username \
+# --api_key api_key \
+# --subject subject \                   
+# --repo bintray_repo \
+# --package bintray_package_name \
+# --version bintray_package_version \
+# --file_path local_package_path \
+# --component "main" \
+# --distribution "trusty" \
+# --architecture "amd64,i386" \
+# --target_folder "abc/xyz"
+
+# The parameters are required:
+# user:  the Bintray user name
+# api_key: the Bintray api key with privilege being able to upload packages to target "subject"
+# subject: the Bintray subject, which is either a user or an organization
+# repo: the Bintary repository name
+# package: the Bintray package name
+# version: the Bintray version
+# file_path: the local file's path which is going to be uploaded
+#
+# Below parameters are optional:
+# component (default: main)
+# distribution (default: trusty)
+# architecture (default: amd64)
+# The above 3 parameters are the attibutes of debian package used to identify the apt-get source
+# target_folder (default: blank) it's used for uploading specific generic files to remote bintray customized folder.( use it to upload debian package, only for experienced user)
+############################################
+
+set -e
+
+while [ "$1" != "" ];do
+    case $1 in
+        --user)
+            shift
+            BINTRAY_USER=$1;;
+        --api_key)
+            shift
+            BINTRAY_API_KEY=$1;;
+        --subject)
+            shift
+            BINTRAY_SUBJECT=$1;;
+        --repo)
+            shift
+            BINTRAY_REPO=$1;;
+        --package)
+            shift
+            BINTRAY_PCK=$1;;
+        --version)
+            shift
+            BINTRAY_PCK_VERSION=$1;;
+        --file_path)
+            shift
+            PACKAGE_PATH=$1;;
+        --component)
+            shift
+            COMPONENT=$1;;
+        --distribution)
+            shift
+            DISTRIBUTION=$1;;
+        --architecture)
+            shift
+            ARCHITECTURE=$1;;
+        --target_folder)
+            shift
+            TARGET_FOLDER=$1;;
+
+        *)
+        echo "[Error] Bad Parameter ($1). Aborting.."
+        exit 1
+    esac
+    shift
+done
+BINTRAY_API="https://api.bintray.com"
+if [ -z "$BINTRAY_USER" ]
+then
+   echo "Must specify \$user of bintray"
+   exit 1
+fi
+
+if [ -z "$BINTRAY_API_KEY" ]
+then
+   echo "Must specify \$api_key of bintray"
+   exit 1
+fi
+
+if [ -z "$BINTRAY_SUBJECT" ]
+then
+   echo "Must specify \$subject of bintray"
+   exit 1
+fi
+
+if [ -z "$BINTRAY_REPO" ]
+then
+   echo "Must specify \$repo of bintray"
+   exit 1
+fi
+
+if [ -z "$BINTRAY_PCK" ]
+then
+   echo "Must specify \$package of bintray"
+   exit 1
+fi
+
+if [ -z "$BINTRAY_PCK_VERSION" ]
+then
+   echo "Must specify \$version of bintray"
+   exit 1
+fi
+
+if [ -z "$PACKAGE_PATH" ]
+then
+   echo "Must specify \$file_path which is going to be uploaded to bintray"
+   exit 1
+fi
+
+if [ -z "$COMPONENT" ]
+then
+    COMPONENT="main"
+fi
+
+if [ -z "$DISTRIBUTION" ]
+then
+    DISTRIBUTION="trusty"
+fi
+
+if [ -z "$ARCHITECTURE" ]
+then
+    ARCHITECTURE="amd64"
+fi
+
+main() {
+  CURL="curl -u${BINTRAY_USER}:${BINTRAY_API_KEY} -H Content-Type:application/json -H Accept:application/json"
+  if (check_package_exists); then
+    echo "The package ${BINTRAY_PCK} does not exist. Creating now..."
+    create_package
+  fi
+
+  if (check_version_exists); then
+    echo "The version ${BINTRAY_PCK_VERSION} does not exist. Creating now..."
+    create_version
+  fi
+  deploy_package
+}
+
+check_package_exists() {
+  echo "Checking if package ${BINTRAY_PCK} exists..."
+
+  if [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -X GET ${BINTRAY_API}/packages/${BINTRAY_SUBJECT}/${BINTRAY_REPO}/${BINTRAY_PCK}) -eq "200" ]; then
+      echo "package already exists"
+      return 1
+  else
+      return 0
+  fi
+}
+
+check_version_exists() {
+  echo "Checking if version ${BINTRAY_PCK_VERSION} exists..."
+  if [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -X GET ${BINTRAY_API}/packages/${BINTRAY_SUBJECT}/${BINTRAY_REPO}/${BINTRAY_PCK}/versions/${BINTRAY_PCK_VERSION}) -eq "200" ]; then
+      echo "version already exists"
+      return 1
+  else
+      return 0
+  fi
+}
+
+create_package() {
+  echo "Creating package ${BINTRAY_PCK}..."
+  data="{
+  \"name\": \"${BINTRAY_PCK}\",
+  \"desc\": \"This package ...\",
+  \"vcs_url\": \"auto\",
+  \"licenses\": [\"Apache-2.0\"]
+  }"
+
+  if [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -X POST ${BINTRAY_API}/packages/${BINTRAY_SUBJECT}/${BINTRAY_REPO} --data "${data}") -eq "201" ];then
+    echo "Succeed to create package ${BINTRAY_PCK}."
+  else
+    echo "Failed to create package ${BINTRAY_PCK}."
+    exit 1
+  fi
+}
+
+create_version() {
+  echo "Creating version ${BINTRAY_PCK_VERSION}..."
+  data="{
+  \"name\": \"${BINTRAY_PCK_VERSION}\",
+  \"desc\": \"This version ...\"
+  }"
+
+  if [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -X POST ${BINTRAY_API}/packages/${BINTRAY_SUBJECT}/${BINTRAY_REPO}/${BINTRAY_PCK}/versions --data "${data}") -eq "201" ];then
+    echo "Succeed to create version ${BINTRAY_PCK_VERSION}."
+  else
+    echo "Failed to create version ${BINTRAY_PCK_VERSION}."
+    exit 1
+  fi
+}
+
+deploy_package() {
+  if (upload_content); then
+    echo "Publishing ${PACKAGE_PATH}..."
+    if [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -X POST ${BINTRAY_API}/content/${BINTRAY_SUBJECT}/${BINTRAY_REPO}/${BINTRAY_PCK}/${BINTRAY_PCK_VERSION}/publish) -eq "200" ]; then
+      echo "Package ${PACKAGE_PATH} published"
+      return 0
+    else
+      echo "Failed to publish your package ${PACKAGE_PATH}"
+      return 1
+    fi
+  else
+      return 1
+  fi
+}
+
+upload_content() {
+  echo "Uploading ${PACKAGE_PATH}..."
+
+  uploaded_file_name=$(basename ${PACKAGE_PATH})
+
+  if [ $(${CURL} --write-out %{http_code} --silent --output /dev/null -H X-Bintray-Debian-Distribution:${DISTRIBUTION} -H X-Bintray-Debian-Component:${COMPONENT} -H X-Bintray-Debian-Architecture:${ARCHITECTURE} -H X-Bintray-Override:1 -T ${PACKAGE_PATH} ${BINTRAY_API}/content/${BINTRAY_SUBJECT}/${BINTRAY_REPO}/${BINTRAY_PCK}/${BINTRAY_PCK_VERSION}/${TARGET_FOLDER}/${uploaded_file_name} ) -eq "201" ]; then
+      echo "Package ${PACKAGE_PATH} uploaded"
+      return 0
+  else
+      echo "Failed to upload package ${PACKAGE_PATH}"
+      return 1
+  fi
+}
+
+main "$@"

--- a/build-release-tools/requirements.txt
+++ b/build-release-tools/requirements.txt
@@ -1,0 +1,6 @@
+subprocess32==3.2.7
+nose==1.3.7
+pyjavaproperties==0.6
+deb_pkg_tools
+python-dateutil
+requests


### PR DESCRIPTION
Folder ```build-release-tools``` contains scripts that are used in build/release/test etc.

So we consider it more suitable to be stored in this repo rather than on-tools.

The priority of this PR is pretty high. We will redirect all usage of these scripts after this PR merged.

@panpan0000 @PengTian0 