### PR TITLE
rac-3815 virtual environment for jenkins needs to use mechanism from rackhd/test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -150,6 +150,9 @@ runTests() {
   done
   cp -f ${WORKSPACE}/build-config/config.ini ${WORKSPACE}/RackHD/test/config
   cd ${WORKSPACE}/RackHD/test
+  rm -rf .venv/on-build-config
+  ./mkenv.sh on-build-config
+  source myenv_on-build-config
   RACKHD_BASE_REPO_URL=${BASE_REPO_URL} RACKHD_TEST_LOGLVL=INFO \
       python run.py ${args} --with-xunit 
   mkdir -p ${WORKSPACE}/xunit-reports

--- a/test.sh
+++ b/test.sh
@@ -141,10 +141,11 @@ generateSolLog(){
 }
 
 setupVirtualEnv(){
-  cd ${WORKSPACE}/RackHD/test
+  pushd ${WORKSPACE}/RackHD/test
   rm -rf .venv/on-build-config
   ./mkenv.sh on-build-config
   source myenv_on-build-config
+  popd
 }
 
 BASE_REPO_URL="${BASE_REPO_URL}"

--- a/test.sh.in
+++ b/test.sh.in
@@ -150,6 +150,9 @@ runTests() {
   done
   cp -f ${WORKSPACE}/build-config/config.ini ${WORKSPACE}/RackHD/test/config
   cd ${WORKSPACE}/RackHD/test
+  rm -rf .venv/on-build-config
+  ./mkenv.sh on-build-config
+  source myenv_on-build-config
   RACKHD_BASE_REPO_URL=${BASE_REPO_URL} RACKHD_TEST_LOGLVL=INFO \
       python run.py ${args} --with-xunit 
   mkdir -p ${WORKSPACE}/xunit-reports

--- a/test.sh.in
+++ b/test.sh.in
@@ -141,10 +141,11 @@ generateSolLog(){
 }
 
 setupVirtualEnv(){
-  cd ${WORKSPACE}/RackHD/test
+  pushd ${WORKSPACE}/RackHD/test
   rm -rf .venv/on-build-config
   ./mkenv.sh on-build-config
   source myenv_on-build-config
+  popd
 }
 
 BASE_REPO_URL="${BASE_REPO_URL}"


### PR DESCRIPTION

This change moves the kind of cut-and-paste virtual environment setup from the jenkin's job code to the (version controlled and execution environment controlled) test.sh

The directions at one time basically said "setup the environment by typing these N things". The better way to do this is with an environment setup script within the code.

Note, the Jenkin's job code will work WITH this code. Once in place, the virtual-env setup from the Jenkin's job will need to be removed before https://github.com/RackHD/RackHD/pull/544 can pass its build-step.

Note 2: not sure why there are test.sh.in and test.sh files here, since there does not seem to be a mechanism to generate the later from the former. I updated both to match.

@RackHD/corecommitters @johren @yyscamper 
Anyone else?
