### PR TITLE
Fix: git credentials is not necessary when read repositories of open …

### DIFF
--- a/build-release-tools/application/generate_manifest.py
+++ b/build-release-tools/application/generate_manifest.py
@@ -26,10 +26,10 @@ date: The commit of each repository are last commit before the date.
                       date string, such as: 2016-12-01 00:00:00 (the commit of each repository are the last commit before the date")
 
 timezone: The Time Zone for the date, such as: +0800, -0800, -0500
-git-credential: Git credentials for CI services.
 builddir: The directory for checked repositories.
 
 The optional parameters:
+git-credential: Git credentials for CI services.
 force: If true, overwrite the destination manifest file even it already exists.
 jobs: number of parallel jobs to run. The number is related to the compute architecture, multi-core processors...
 """
@@ -75,7 +75,6 @@ def parse_command_line(args):
                         action="store")
 
     parser.add_argument("--git-credential",
-                        required=True,
                         help="Git credential for CI services",
                         action="append")
 
@@ -113,13 +112,13 @@ def main():
             utc_now = datetime.utcnow()
             day_str = utc_now.strftime("%Y%m%d")
             dest_manifest = "{branch}-{day}".format(branch=slice_branch, day=day_str)
-            generator = ManifestGenerator(dest_manifest, args.branch, args.builddir, args.git_credential, jobs=args.jobs, force=args.force)
+            generator = ManifestGenerator(dest_manifest, args.branch, args.builddir, git_credential=args.git_credential, jobs=args.jobs, force=args.force)
         else:
             dt = convert_date(args.date)
             day_str = dt.strftime("%Y%m%d")
             dest_manifest = "{branch}-{day}".format(branch=slice_branch, day=day_str)
             date_str = "{0} {1}".format(dt.strftime("%Y-%m-%d %H:%M:%S"), args.timezone)
-            generator = SpecifyDayManifestGenerator(dest_manifest, args.branch, date_str, args.builddir, args.git_credential, jobs=args.jobs, force=args.force)
+            generator = SpecifyDayManifestGenerator(dest_manifest, args.branch, date_str, args.builddir, git_credential=args.git_credential, jobs=args.jobs, force=args.force)
             
         generator.update_manifest()
         generator.generate_manifest()

--- a/build-release-tools/application/make_debian_packages.py
+++ b/build-release-tools/application/make_debian_packages.py
@@ -20,9 +20,9 @@ Usage:
 The required parameters:
 build-directory: A directory where all the repositories are cloned to. 
 manifest-file: The path of manifest file. 
-git-credential: Git URL and credential for CI services: <URL>,<Credentials>
 
 The optional parameters:
+git-credential: Git URL and credential for CI services: <URL>,<Credentials>
 is-official-release: Whether this release is official. The default value is False
 parameter-file: The file with parameters. The file will be passed to downstream jobs.
 force: Use destination directory, even if it exists.
@@ -71,7 +71,6 @@ def parse_args(args):
                         default="downstream_parameters")
 
     parser.add_argument('--git-credential',
-                        required=True,
                         help="Git URL and credential for CI services: <URL>,<Credentials>",
                         action='append',
                         default=None)
@@ -171,7 +170,7 @@ def get_build_repos(directory):
         repos.append(filename)
     return repos
 
-def checkout_repos(manifest, builddir, force, git_credential, jobs):
+def checkout_repos(manifest, builddir, force, jobs, git_credential=None):
     try:
         manifest_actions = ManifestActions(manifest, builddir, force=force, git_credentials=git_credential, jobs=jobs, actions=["checkout", "packagerefs"])
         manifest_actions.execute_actions()
@@ -243,7 +242,7 @@ def main():
     Exit on encountering any error.
     """
     args = parse_args(sys.argv[1:])
-    checkout_repos(args.manifest_file, args.build_directory, args.force, args.git_credential, args.jobs)
+    checkout_repos(args.manifest_file, args.build_directory, args.force, args.jobs, git_credential=args.git_credential)
     build_debian_packages(args.build_directory, args.jobs, args.is_official_release, args.sudo_credential)
     write_downstream_parameter_file(args.build_directory, args.manifest_file, args.is_official_release, args.parameter_file)
 

--- a/build-release-tools/application/reprove.py
+++ b/build-release-tools/application/reprove.py
@@ -21,10 +21,6 @@ branch
 The required parameters:
 manifest: the path of manifest file.
 builddir: the destination for checked out repositories.
-git-credential: url, credentials pair for the access to github repos.
-                For example: https://github.com,GITHUB
-                GITHUB is an environment variable: 
-                GITHUB=username:password
 action: the supported action, includes checkout branch.
         "checkout": it  will clone all the repositories in a manifest file;
                     if "branch" in a repository dictionary, the action will check out to the branch.
@@ -36,6 +32,10 @@ action: the supported action, includes checkout branch.
                   + git+https://github.com/RackHD/on-core.git#branch/release-1.2.3
 
 The optional parameters:
+git-credential: url, credentials pair for the access to github repos.
+                For example: https://github.com,GITHUB
+                GITHUB is an environment variable:
+                GITHUB=username:password
 force: use destination directory, even if it exists
 jobs: number of parallel jobs to run. The number is related to the compute architecture, multi-core processors...
 branch-name: the name of new branch.

--- a/build-release-tools/application/update_dependencies.py
+++ b/build-release-tools/application/update_dependencies.py
@@ -15,8 +15,9 @@ The required parameters:
 manifest: The file path of manifest.
 builddir: The destination for repositories in manifest stored.
           Repositories under the directory include on-xxx and RackHD
-git-credential: url, credentials pair for the access to github repos
+
 The optional parameter:
+git-credential: url, credentials pair for the access to github repos
 force: Overwrite the build directory if it exists.
 is-official-release: if true, this release is official, the default value is false
 jobs: number of parallel jobs to run(checkout repositories). The number is related to the compute architecture, multi-core processors...
@@ -162,7 +163,6 @@ def parse_command_line(args):
                         action="store_true")
 
     parser.add_argument("--git-credential",
-                        required=True,
                         help="Git credentials for CI services",
                         action="append")
 
@@ -182,7 +182,7 @@ def parse_command_line(args):
 
     return parsed_args
 
-def checkout_repos(manifest, builddir, force, git_credential, jobs):
+def checkout_repos(manifest, builddir, force, jobs, git_credential=None):
     manifest_actions = ManifestActions(manifest, builddir, force=force, git_credentials=git_credential, jobs=jobs, actions=["checkout"])
     manifest_actions.execute_actions()
 
@@ -191,7 +191,7 @@ def main():
     args = parse_command_line(sys.argv[1:])
 
     # Checkout repositories according to manifest file
-    checkout_repos(args.manifest, args.builddir, args.force, args.git_credential, args.jobs)
+    checkout_repos(args.manifest, args.builddir, args.force, args.jobs, git_credential=args.git_credential)
 
     # Start to initial an instance of UpdateRackhdVersion
     updater = RackhdDebianControlUpdater(args.builddir, is_official_release=args.is_official_release)

--- a/build-release-tools/application/update_manifest.py
+++ b/build-release-tools/application/update_manifest.py
@@ -18,11 +18,11 @@ repo: Git url to match for updating the commit-id
 branch: The target branch for the named repo
 commit: The commit id to target an exact version
 manifest_download_url: The manifest base download URL.
-git_credential: url, credentials pair for the access to github repos
 manifest_file:The target manifest file to be updated
 updated_manifest: The property file that leads downstream job.
 
 The optional parameters:
+git_credential: url, credentials pair for the access to github repos
 dryrun: Do not commit any changes, just print what would be done
 """
 

--- a/build-release-tools/lib/ManifestGenerator.py
+++ b/build-release-tools/lib/ManifestGenerator.py
@@ -17,7 +17,7 @@ except ImportError as import_err:
     sys.exit(1)
 
 class ManifestGenerator(object):
-    def __init__(self, dest, branch, builddir, git_credential, force=False, jobs=1):
+    def __init__(self, dest, branch, builddir, git_credential=None, force=False, jobs=1):
         """
         Generate a new manifest according to the manifest sample: manifest.json
 
@@ -117,9 +117,9 @@ class ManifestGenerator(object):
             json.dump(self._manifest.manifest, fp, indent=4, sort_keys=True)
 
 class SpecifyDayManifestGenerator(ManifestGenerator):
-    def __init__(self, dest, branch, date, builddir, git_credential, force=False, jobs=1):
+    def __init__(self, dest, branch, date, builddir, git_credential=None, force=False, jobs=1):
         self._date = date
-        super(SpecifyDayManifestGenerator, self).__init__(dest, branch, builddir, git_credential, force=force, jobs=jobs)
+        super(SpecifyDayManifestGenerator, self).__init__(dest, branch, builddir, git_credential=git_credential, force=force, jobs=jobs)
 
     def update_repositories_commit(self, repositories):
         for repo in repositories:


### PR DESCRIPTION
…source project

**Background**
For open source repositories, reading operation doesn't need git credential.
There are several scripts requires git credential when reading  repositories.

This PR will fix the bug.


