### PR TITLE
support creating branch with github username and password

### DIFF
--- a/build-release-tools/application/reprove.py
+++ b/build-release-tools/application/reprove.py
@@ -47,7 +47,6 @@ import json
 import os
 import shutil
 import sys
-import config
 
 from urlparse import urlparse, urlunsplit
 from RepositoryOperator import RepoOperator

--- a/build-release-tools/lib/RepositoryOperator.py
+++ b/build-release-tools/lib/RepositoryOperator.py
@@ -2,7 +2,6 @@
 Module to abstract operations to repository
 """
 import os
-import config
 from gitbits import GitBit
 from ParallelTasks import ParallelTasks
 from common import *
@@ -190,7 +189,6 @@ class RepoOperator(object):
         Set gitbit credentials.
         :return:
         """
-        self.git.set_identity(config.gitbit_identity['username'], config.gitbit_identity['email'])
         if credentials is None:
             if self._git_credentials is None:
                 return

--- a/build-release-tools/lib/gitbits.py
+++ b/build-release-tools/lib/gitbits.py
@@ -79,6 +79,7 @@ class GitBit(object):
                                        "password": password,
                                        "url": full_url,
                                       })
+            self.set_identity(username=username)
             return True
         else:
             return False
@@ -125,7 +126,7 @@ class GitBit(object):
                     print >> credential_file, "{0}".format(credential['url'])
 
 
-    def set_identity(self, username, email):
+    def set_identity(self, username=None, email=None):
         """
         Define a username and email for the Git identity.  Git will autogenerate one as it can
         if not provided.  As our automated Git tools should not have a persistent identity via

--- a/build-release-tools/lib/manifest.py
+++ b/build-release-tools/lib/manifest.py
@@ -8,7 +8,6 @@ import os
 import re
 import sys
 import datetime
-import config
 
 from gitbits import GitBit
 
@@ -107,7 +106,6 @@ class Manifest(object):
         Set gitbit credentials.
         :return: None
         """
-        self.gitbit.set_identity(config.gitbit_identity['username'], config.gitbit_identity['email'])
         if self._git_credentials:
             for url_cred_pair in self._git_credentials:
                 url, cred = url_cred_pair.split(',')


### PR DESCRIPTION
**Background**:
Jenkins provides a job to create branches and update dependency and changelog for repositories with username and password on github.
The author of these commits should be the user with who provides the username and password to run the job.

However, the tools always use the username and email in the file build-release-tools/lib/config,py.

This PR will change the tools to use the provided username as the author.

