### PR TITLE
Fix: pip fails with the error bad interpreter because of the shebang …

### DIFF
--- a/build-release-tools/mkenv.sh
+++ b/build-release-tools/mkenv.sh
@@ -41,7 +41,7 @@ ${virtualenv} --clear env/${env_name}
 source "env/${env_name}/bin/activate"
 
 # Use locally sourced pip configuration
-export PIP_CONFIG_FILE=`pwd`/pip.conf
+export PIP_CONFIG_FILE=pip.conf
 
 # Install all required packages
 pip install -r requirements.txt


### PR DESCRIPTION
…length limit

Fix: OS install of WindowsServer-2012 failed with the message:
```
./mkenv.sh: /home/jenkins/workspace/BuildRelease/Test/OsInstall/WindowsServer-2012/build-config/manifest-build-tools/env/hwimobuild/bin/pip: /home/jenkins/workspace/BuildRelease/Test/OsInstall/WindowsServer-2012/build-: bad interpreter: No such file or directory
```

Cause:
The path to the python interpreter is too long.
The maximum length is limited in the kernel by BINPRM_BUF_SIZE, set in /usr/include/linux/binfmts.h. 
On the Linux machines I looked at, this limit is set to 128.

