### PR TITLE
add non-free to docker sourcelist for fixing snmp-mibs-downloader installation failure

### DIFF
--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -53,7 +53,7 @@ doBuild() {
     #Set an empty TAG before each build
     TAG=""
     #For relpacing the unstable wheezy official source
-    SOURCE_LIST=https://raw.githubusercontent.com/RackHD/on-tools/master/manifest-build-tools/docker_sources.list
+    SOURCE_LIST=https://raw.githubusercontent.com/RackHD/on-build-config/master/build-release-tools/docker_sources.list
     for repo in $repos;do
         if [ ! -d $repo ]; then
             echo "Repo directory of $repo does not exist"

--- a/build-release-tools/docker_sources.list
+++ b/build-release-tools/docker_sources.list
@@ -1,3 +1,6 @@
 deb http://ftp.us.debian.org/debian wheezy main
 deb http://ftp.us.debian.org/debian wheezy-updates main
 deb http://security.debian.org wheezy/updates main
+deb http://ftp.us.debian.org/debian wheezy main non-free
+deb http://ftp.us.debian.org/debian wheezy-updates main non-free
+deb http://security.debian.org wheezy/updates main non-free


### PR DESCRIPTION
on-taskgraph Docker Build has all failed from last week.
 
### Root cause:   
in debian source, the “snmp-mibs-downloader”  seems become “non-free” recently, so our build script can’t find it.
 
### fix :   
add “non-free” tag 
deb http://ftp.us.debian.org/debian wheezy      main   non-free
deb http://ftp.us.debian.org/debian wheezy-updates        main non-free
deb http://security.debian.org wheezy/updates       main  non-free

@panpan0000 @PengTian0 

skip ci