### PR TITLE
Add on-imagebuilder docker build

### DIFF
--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -47,7 +47,7 @@ doBuild() {
     # List order is important, on-tasks image build is based on on-core image, 
     # on-http and on-taskgraph ard based on on-tasks image 
     # others are based on on-core image
-    repos=$(echo "on-core on-syslog on-dhcp-proxy on-tftp on-wss on-statsd on-tasks on-taskgraph on-http")
+    repos=$(echo "on-imagebuilder on-core on-syslog on-dhcp-proxy on-tftp on-wss on-statsd on-tasks on-taskgraph on-http")
     #Record all repo:tag for post-pushing
     repos_tags=""
     #Set an empty TAG before each build
@@ -69,7 +69,10 @@ doBuild() {
             echo "Building rackhd/$repo$TAG"
             repos_tags=$repos_tags$repo$TAG" "
             cp Dockerfile ../Dockerfile.bak
-            if [ "$repo" != "on-core" ];then
+            if [ "$repo" == "on-imagebuilder" ]; then
+                    docker build -t rackhd/files$TAG .
+                    repos_tags=files$TAG" "
+            elif [ "$repo" != "on-core" ];then
                     # Use the new sources.list
                     sed -i "/^FROM/a RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak\nADD $SOURCE_LIST /etc/apt/sources.list" Dockerfile
                     #Based on newly build upstream image to build

--- a/build-release-tools/post_test.sh
+++ b/build-release-tools/post_test.sh
@@ -178,6 +178,7 @@ create_vagrant_file() {
 }
 
 post_test_vagrant() {
+    create_vagrant_file
     vagrant destroy -f
     vagrant up --provision
     waitForAPI


### PR DESCRIPTION
### Background

In docker build/docker compose up, used to build image ```rackhd/files```  with downloading static files from bintray directly, and this image don't be pushed to dockerhub.
As a result, rackhd docker images use static files without version control.
And this doesn't satisfy the needs of build/release.

### Details
This PR add on-imagebuilder docker in docker_build.sh

@panpan0000 @PengTian0 

### Related PRs

* add Dockerfile in on-imagebuilder repo https://github.com/RackHD/on-imagebuilder/pull/73
* modify ```docker-compose.yml``` and delete old static files docker build https://github.com/RackHD/RackHD/pull/553
skip ci