### PR TITLE
Bugfix/failed download static files

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,7 @@ dlHttpFiles() {
   mkdir -p ${dir} && cd ${dir}
   # pull down index from bintray repo and parse files from index
   wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
-      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+      exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
   for i in `cat ./files`; do
     wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/${i}
   done
@@ -48,7 +48,7 @@ dlTftpFiles() {
   mkdir -p ${dir} && cd ${dir}
   # pull down index from bintray repo and parse files from index
   wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/ && \
-      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+      exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
   for i in `cat ./files`; do
     wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/${i}
   done

--- a/test.sh.in
+++ b/test.sh.in
@@ -36,7 +36,7 @@ dlHttpFiles() {
   mkdir -p ${dir} && cd ${dir}
   # pull down index from bintray repo and parse files from index
   wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
-      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+      exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
   for i in `cat ./files`; do
     wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/${i}
   done
@@ -58,7 +58,7 @@ dlTftpFiles() {
   mkdir -p ${dir} && cd ${dir}
   # pull down index from bintray repo and parse files from index
   wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/ && \
-      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
+      exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
   for i in `cat ./files`; do
     wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/${i}
   done


### PR DESCRIPTION
### Background
```test.sh``` failed to download static files and lead to smoke-test && continuous-test failure.

### Rootcause

Used to get static files use this script
```
 wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
      exec grep 'href=' index.html | awk '{print $3}' | cut -c8-200 | sed -e "s/\"//g" > files
```
index.html format has changed at sometime, so the script doesn't work any more.

### Solution
use regex to extract staic files name from index.html

@panpan0000 @PengTian0 @iceiilin 