### PR TITLE
after CIT/FIT, clean & delete vagrant instance both in RAM & Disk

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -279,6 +279,9 @@ fi
 
 if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
 
+  # register the signal handler to clean up( vagrantDestroy ), with process being killed
+  trap vagrantDestroy SIGINT SIGTERM SIGKILL
+
   # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
   
   # Power off nodes

--- a/test.sh.in
+++ b/test.sh.in
@@ -279,6 +279,9 @@ fi
 
 if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
 
+  #avoid previous run exist abnormally, without cleanup, do the vagrant destroy again in current folder
+  vagrantDestroy
+  
   # Power off nodes
   nodesOff
 

--- a/test.sh.in
+++ b/test.sh.in
@@ -279,8 +279,7 @@ fi
 
 if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
 
-  #avoid previous run exist abnormally, without cleanup, do the vagrant destroy again in current folder
-  vagrantDestroy
+  # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
   
   # Power off nodes
   nodesOff
@@ -309,7 +308,7 @@ if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
   #vagrantSuspendAll
 
   # Delete any running VMs
-  virtualBoxDestroyRunning
+  #virtualBoxDestroyRunning
 
 
 fi

--- a/test.sh.in
+++ b/test.sh.in
@@ -278,15 +278,9 @@ if [ "$SKIP_PREP_DEP" == false ] ; then
 fi
 
 if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
-  # Power off nodes and shutdown vagrant box
-  vagrantDestroy
+
+  # Power off nodes
   nodesOff
-
-  # Suspend any other running vagrant boxes
-  vagrantSuspendAll
-
-  # Delete any running VMs
-  virtualBoxDestroyRunning
 
   # Power on vagrant box and nodes 
   vagrantUp
@@ -302,5 +296,18 @@ if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
   generateSolLog
   # Run tests
   runTests
+
+  # Clean Up below
+
+  #shutdown vagrant box and delete all resource (like removing vm disk files in "~/VirtualBox VMs/")
+  vagrantDestroy
+
+  # Suspend any other running vagrant boxes
+  #vagrantSuspendAll
+
+  # Delete any running VMs
+  virtualBoxDestroyRunning
+
+
 fi
 


### PR DESCRIPTION
**Background**
-----

there's problem for the original test.sh.* , the vagrant instance keep running after test.sh.
and when that Jenkins build exits, Jenkins will force kill the vagrant process.
which brings problem for next vagrant running( that VM shown aborted in vagrant list ) and dirty disk space(large disk files in  ~/VirtualBox VMs)

**usual problems**
```VM inaccessable```  :  when  ```vagrant up``` after  Jenkins kill process(stop from last build) and ```rm ~/VirtualBox VMs/ ```
```VERR_DISK_FULL```     :  when nobody clean up in ~/VirtualBox VMs . the disk will be 98% full and fail.
 

**Fix**
-----

1. ```vagrant destroy -f``` will both shut down VMs (listed in current folder's VagrantFile) , and both destroys all resources associated with the VMs (~/VirtualBox VMs)

2. remove the ```rm ~/VirtualBox VMs``` line in both CIT/FIT Jenkins jobs script
![image](https://cloud.githubusercontent.com/assets/14049268/21757683/8edd2d3a-d66d-11e6-8f29-b229475004b0.png)

3. in CIT/FIT's  Jenkins “post-build action”, do ```vagrant destroy ``` after job run , whenever it’s  aborted or failed or successful.
![image](https://cloud.githubusercontent.com/assets/14049268/21762778/90db0742-d695-11e6-95da-7cf6e67211bf.png)


**Test Done**
-----

by testing this PR, I temporarily redirect the  Jenkins job Continuous-Test/job/build-config-setup/ to my personal repo.

Test Case 1.  Normal Case
  * temporary re-direct the build-config-setup to my personal repo, and re-kick-off builds
http://rackhdci.lss.emc.com/job/Continuous-Test/job/Continuous-Functional/15085/
http://rackhdci.lss.emc.com/job/Continuous-Test/job/Continuous-Functional/15096/
![image](https://cloud.githubusercontent.com/assets/14049268/21763663/f3f3aeca-d699-11e6-9321-874cb59726e9.png)
  *. then ssh into the VM slave 03, shown the ~/VirtualBox VMs are clean.
![image](https://cloud.githubusercontent.com/assets/14049268/21763679/099e0dce-d69a-11e6-9f69-f1d74f88a90f.png)



Test Case 2.  Abnormal Abort
  * abort the test.sh during running of CIT or FIT , leave the slave into a "dirty state"
  * and re-run the continous-test, all set. no vagrant error found in next CIT/FIT
   test http://rackhdci.lss.emc.com/job/Continuous-Test/job/Continuous-Functional/15095/ as below:
![image](https://cloud.githubusercontent.com/assets/14049268/21762686/15764472-d695-11e6-85d9-b308c3653cca.png)


@keedya  @PengTian0 @changev 
