### PR TITLE
[Bugfix] run apiPackageModify after setup venv

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -117,7 +117,6 @@ prepareDeps(){
   preparePackages
   dlTftpFiles
   dlHttpFiles
-  apiPackageModify
 }
 
 apiPackageModify() {
@@ -226,6 +225,7 @@ setupVirtualEnv(){
   ./mkenv.sh on-build-config
   source myenv_on-build-config
   popd
+  apiPackageModify
 }
 
 BASE_REPO_URL="${BASE_REPO_URL}"


### PR DESCRIPTION
### Background
When ```RackHD``` and ```on-http``` both in **interpendent PRs**, we consider the swagger-ui-api packages ```on-http-api1.1 on-http-api2.0 on-http-redfish-1.0``` may be changed, so they must be uninstalled->rebuild->installed again. Function ```apiPackageModify``` is for this.

setup virtualenv used to be done out of  ```test.sh```, so  ```apiPackageModify``` will be applied in new venv.
but recent changes setup venv after  ```apiPackageModify```, this make ```apiPackageModify``` invalid.

### Solution
add ```apiPackageModify``` to the last step of  setupVirtualEnv

@panpan0000 @PengTian0 