### PR TITLE
Added check for incorrect Jenkins syntax. If Jenkins is the last word, continue

### DIFF
--- a/pr_parser.py
+++ b/pr_parser.py
@@ -133,6 +133,10 @@ class PrParser(object):
                 continue
             position = pr_words.index('jenkins')
 
+            #Checks to make sure jenkins is not the last element in pr_words
+            if ((position+1) == len(pr_words)) :
+                continue
+
             #analyse dependency relationship, "depend" or "ignore" 
             if ('ignore' not in pr_words[position+1]) and ('depend' not in pr_words[position+1]):
                 continue

--- a/pr_parser.py
+++ b/pr_parser.py
@@ -133,8 +133,9 @@ class PrParser(object):
                 continue
             position = pr_words.index('jenkins')
 
-            #Checks to make sure jenkins is not the last element in pr_words
-            if ((position+1) == len(pr_words)) :
+            #Checks to make sure the pr_words are long enough to parse.
+            #Needs to be at least length of 3 ("Jenkins ignore/depend PR")
+            if ((position+2) >= len(pr_words)) :
                 continue
 
             #analyse dependency relationship, "depend" or "ignore" 


### PR DESCRIPTION
@DavidjohnBlodgett @brianparry @lacarb 

So this adds a check to make sure that "position+1" is out of bounds