### PR TITLE
 create tag to repositoties in a provided manifest

### DIFF
--- a/build-release-tools/application/reprove.py
+++ b/build-release-tools/application/reprove.py
@@ -402,12 +402,12 @@ class ManifestActions(object):
 
     def create_tag(self):
         if self._tag_name is None:
-            raise ValueError("No setting for branch-name")
+            raise ValueError("No setting for tag-name")
         else:
             print "create tag for the repos..."
-            self.tag_existing_repositories()
+            self.create_tag_for_repositories()
 
-    def tag_existing_repositories(self):
+    def create_tag_for_repositories(self):
         """
         Issues set_tagname commands to repos in a provided manifest
         :return: None
@@ -423,7 +423,7 @@ class ManifestActions(object):
   
     def set_repo_tagname(self, repo):
         """
-        Sets tagname on the repos in the manifest file
+        Add a tag to a repository
         :param repo: A dictionary
         :return: None
         """


### PR DESCRIPTION
## Background

Release process is triggered by tag of repositories.
When core committers think it's time to do release, they need to create tag for each repository under RackHD.
The repeat of creating tag is annoy.
This PR helps to create tag automatically.

## Test Done
By testing this PR, I temporarily use rackhd-mirror in the template of manifest.
The job will create tag to repositories in rackhd-mirror.
http://rackhdci.lss.emc.com/job/Experimental-Jobs/job/CreateTag/7/console
