### PR TITLE
Use internal static files source in PR gate

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -36,16 +36,22 @@ dlHttpFiles() {
       dir=${WORKSPACE}/build-deps/on-http/static/http/common
   fi
   mkdir -p ${dir} && cd ${dir}
-  # pull down index from bintray repo and parse files from index
-  wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
-      exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
-  for i in `cat ./files`; do
-    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/${i}
-  done
-  # attempt to pull down user specified static files
-  for i in ${HTTP_STATIC_FILES}; do
-     wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/builds/${i}
-  done
+  if [ -n "${INTERNAL_HTTP_ZIP_FILE_URL}" ]; then
+    # use INTERNAL TEMP SOURCE
+    wget ${INTERNAL_HTTP_ZIP_FILE_URL} 
+    unzip common.zip && mv common/* . && rm -rf common
+  else
+    # pull down index from bintray repo and parse files from index
+    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/ && \
+        exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
+    for i in `cat ./files`; do
+      wget --no-check-certificate https://dl.bintray.com/rackhd/binary/builds/${i}
+    done
+    # attempt to pull down user specified static files
+    for i in ${HTTP_STATIC_FILES}; do
+      wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/builds/${i}
+    done
+  fi
 }
 
 dlTftpFiles() {
@@ -57,17 +63,23 @@ dlTftpFiles() {
   if [[ "${REPO_NAME}" != *"on-tftp"* ]]; then
       dir=${WORKSPACE}/build-deps/on-tftp/static/tftp
   fi
-  mkdir -p ${dir} && cd ${dir}
-  # pull down index from bintray repo and parse files from index
-  wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/ && \
-      exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
-  for i in `cat ./files`; do
-    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/${i}
-  done
-  # attempt to pull down user specified static files
-  for i in ${TFTP_STATIC_FILES}; do
-    wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/ipxe/${i}
-  done
+  if [ -n "${INTERNAL_TFTP_ZIP_FILE_URL}" ]; then
+    # use INTERNAL TEMP SOURCE
+    wget ${INTERNAL_TFTP_FILE_ZIP_URL} 
+    unzip pxe.zip && mv pxe/* . && rm -rf pxe pxe.zip
+  else
+    mkdir -p ${dir} && cd ${dir}
+    # pull down index from bintray repo and parse files from index
+    wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/ && \
+        exec  cat index.html |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g' > files
+    for i in `cat ./files`; do
+      wget --no-check-certificate https://dl.bintray.com/rackhd/binary/ipxe/${i}
+    done
+    # attempt to pull down user specified static files
+    for i in ${TFTP_STATIC_FILES}; do
+      wget --no-check-certificate https://bintray.com/artifact/download/rackhd/binary/ipxe/${i}
+    done
+  fi
 }
 
 preparePackages() {


### PR DESCRIPTION
### Background
Now in PR Gate Smoke test, the static files(common, pxe files) are directly downloaded from bintray latest.
Statistical information shows that this action spends 500GB/Month bintray date exchange in average.
RackHD will be the paying user soon and then we'll pay 0.45 for per 1GB downloads.

### PR Details
This PR make PR Gate to use internal static files source.
This source is support by http://rackhdci.lss.emc.com/job/Tools/job/Static-Files-Service/
A timely build Jenkins job keep consistent data with bintray.

This feature need bintray/rackhd/debian/on-imagebuilder deb up to date.
So there's another PR in on-imagebuilder to support this https://github.com/RackHD/on-imagebuilder/pull/75.
After https://github.com/RackHD/on-imagebuilder/pull/75 is merged, this PR can be merged

@panpan0000 @PengTian0 

