### PR TITLE
[skip ci]post-test add version check

### DIFF
--- a/build-release-tools/application/release_to_atlas.py
+++ b/build-release-tools/application/release_to_atlas.py
@@ -217,7 +217,7 @@ def upload_boxs(build_directory, atlas, is_release, atlas_version):
             if is_release:
                 # Box file name is like "rackhd-ubuntu-14.04-1.2.3.box" when release.
                 # Extract 1.2.3 only
-                atlas_version = "-".join(full_file_path.split('/')[-1:][0].strip(".box").split('-')[3])
+                atlas_version = full_file_path.split('/')[-1:][0].strip(".box").split('-')[3]
             else:
                 from datetime import datetime
                 datatime_now_md = datetime.utcnow().strftime("0.%m.%d")


### PR DESCRIPTION
add version check in post-test.

If in vagrant/ova has been installed rackhd of wrong version,
this script will report the error.

@panpan0000 @PengTian0  

F.Y.I
when ```aptitude install onePackage=someVersion``` if the package of someVersion is invalid(like missing dependency, aptitude will choose a latest "backup" package for installation) 