### PR TITLE
dependency-PR-test, fix corner case

### DIFF
--- a/pr_parser.py
+++ b/pr_parser.py
@@ -117,11 +117,12 @@ class PrParser(object):
         pr_text_segment = []
         for pr_text in pr_texts:
             pr_text = pr_text.lower()
-            partition = [i for i in pr_text.split('jenkins') if i]
-            if len(partition) <= 1:
-                continue
-            for segment in partition[1:]:
-                pr_text_segment.append("jenkins"+segment)
+            jenkins_index = pr_text.find("jenkins")
+            if jenkins_index != -1:
+                pr_text = pr_text[jenkins_index:]
+                partition = [i for i in pr_text.split('jenkins') if i]
+                for segment in partition:
+                    pr_text_segment.append("jenkins"+segment)
 
         #parse pr
         related_prs = []


### PR DESCRIPTION
Fix corner case, which is caused by recent changes.
* when there's only one sentence "jenkins: depends on....", on-multi won't be triggered.
@panpan0000 @PengTian0 @iceiilin 