### PR TITLE
[skip ci]fix: update version only when nightly build

### DIFF
--- a/build-release-tools/application/release_npm_packages.py
+++ b/build-release-tools/application/release_npm_packages.py
@@ -223,7 +223,7 @@ def main():
     checkout_repos(args.manifest_file, args.build_directory, args.force, args.jobs, git_credential=args.git_credential)
 
     version_dict = compute_packages_version(args.build_directory, args.is_official_release)
-    if args.is_official_release == "false":
+    if not args.is_official_release:
         update_packages_version(args.build_directory, version_dict)
 
     update_packages_dependency(args.build_directory, version_dict)


### PR DESCRIPTION
Fix:
The version in package.json should not be updated during official release.

The parameter ```args.is_official_release``` is converted to Boolean Var.
So the condition should be ```if not args.is_official_release```