### PR TITLE
[skip ci]Fix: the commit in manifest skipped the jump version commit

### DIFF
--- a/build-release-tools/application/version_generator.py
+++ b/build-release-tools/application/version_generator.py
@@ -62,9 +62,9 @@ class VersionGenerator(object):
             version = utc_yesterday.strftime('%Y%m%dUTC')
             return version
         else:
-            commit_timestamp_str = self.repo_operator.get_lastest_commit_date(self._repo_dir)
+            commit_timestamp_str = self.repo_operator.get_latest_commit_date(self._repo_dir)
             date = datetime.utcfromtimestamp(int(commit_timestamp_str)).strftime('%Y%m%dUTC')
-            commit_id = self.repo_operator.get_lastest_commit_id(self._repo_dir)
+            commit_id = self.repo_operator.get_latest_commit_id(self._repo_dir)
             version = "{date}-{commit}".format(date=date, commit=commit_id[0:7])
             return version
 

--- a/build-release-tools/lib/ManifestGenerator.py
+++ b/build-release-tools/lib/ManifestGenerator.py
@@ -121,7 +121,7 @@ class ManifestGenerator(object):
 class SpecifyDayManifestGenerator(ManifestGenerator):
     def __init__(self, dest, branch, date, builddir, git_credential=None, force=False, jobs=1):
         self._date = date
-        self._author = config.gitbit_identity["username"]
+        self._jenkins_author = config.gitbit_identity["username"]
         super(SpecifyDayManifestGenerator, self).__init__(dest, branch, builddir, git_credential=git_credential, force=force, jobs=jobs)
 
     def update_repositories_commit(self, repositories):
@@ -133,13 +133,12 @@ class SpecifyDayManifestGenerator(ManifestGenerator):
                 # Get the last merge commit before the date
                 merge_commit = self.repo_operator.get_latest_merge_commit_before_date(repo_dir,self._date)
                 # Get the last commit of Jenkins before the date
-                jenkins_commit = self.repo_operator.get_latest_author_commit_before_date(repo_dir,self._date, self._author)
+                jenkins_commit = self.repo_operator.get_latest_author_commit_before_date(repo_dir,self._date, self._jenkins_author)
             except Exception,e:
                 if merge_commit is None:
                     raise RuntimeError(e)
 
             repo["commit-id"] = merge_commit
             if len(jenkins_commit) > 0:
-                jenkins_commit_newer = self.repo_operator.commit1_newer_than_commit2(repo_dir, jenkins_commit, merge_commit)
-                if jenkins_commit_newer:
-                    repo["commit-id"] = jenkins_commit
+                newer_commit = self.repo_operator.get_newer_commit(repo_dir, jenkins_commit, merge_commit)
+                repo["commit-id"] = newer_commit

--- a/build-release-tools/lib/ManifestGenerator.py
+++ b/build-release-tools/lib/ManifestGenerator.py
@@ -12,6 +12,8 @@ try:
     from RepositoryOperator import RepoOperator
     from manifest import Manifest
     import common
+    import config
+
 except ImportError as import_err:
     print import_err
     sys.exit(1)
@@ -73,13 +75,13 @@ class ManifestGenerator(object):
 
     def update_repositories_commit(self, repositories):
         """
-        update the commit-id of repository with the lastest commit id
+        update the commit-id of repository with the latest commit id
         :param repositories: a list of repository directory
         :return: None
         """
         for repo in repositories:
             repo_dir = self.directory_for_repo(repo)
-            repo["commit-id"] = self.repo_operator.get_lastest_commit_id(repo_dir)
+            repo["commit-id"] = self.repo_operator.get_latest_commit_id(repo_dir)
 
     def update_manifest(self):
         """
@@ -119,9 +121,25 @@ class ManifestGenerator(object):
 class SpecifyDayManifestGenerator(ManifestGenerator):
     def __init__(self, dest, branch, date, builddir, git_credential=None, force=False, jobs=1):
         self._date = date
+        self._author = config.gitbit_identity["username"]
         super(SpecifyDayManifestGenerator, self).__init__(dest, branch, builddir, git_credential=git_credential, force=force, jobs=jobs)
 
     def update_repositories_commit(self, repositories):
         for repo in repositories:
             repo_dir = self.directory_for_repo(repo)
-            repo["commit-id"] = self.repo_operator.get_lastest_merge_commit_before_date(repo_dir,self._date)
+            merge_commit = None
+            jenkins_commit = None
+            try:
+                # Get the last merge commit before the date
+                merge_commit = self.repo_operator.get_latest_merge_commit_before_date(repo_dir,self._date)
+                # Get the last commit of Jenkins before the date
+                jenkins_commit = self.repo_operator.get_latest_author_commit_before_date(repo_dir,self._date, self._author)
+            except Exception,e:
+                if merge_commit is None:
+                    raise RuntimeError(e)
+
+            repo["commit-id"] = merge_commit
+            if len(jenkins_commit) > 0:
+                jenkins_commit_newer = self.repo_operator.commit1_newer_than_commit2(repo_dir, jenkins_commit, merge_commit)
+                if jenkins_commit_newer:
+                    repo["commit-id"] = jenkins_commit

--- a/build-release-tools/lib/ManifestGenerator.py
+++ b/build-release-tools/lib/ManifestGenerator.py
@@ -136,7 +136,7 @@ class SpecifyDayManifestGenerator(ManifestGenerator):
                 jenkins_commit = self.repo_operator.get_latest_author_commit_before_date(repo_dir,self._date, self._jenkins_author)
             except Exception,e:
                 if merge_commit is None:
-                    raise RuntimeError(e)
+                    raise RuntimeError("Failed to update repositories commit: repository {0} \nDue to {1}".format(repo_dir, e))
 
             repo["commit-id"] = merge_commit
             if len(jenkins_commit) > 0:

--- a/build-release-tools/lib/RepositoryOperator.py
+++ b/build-release-tools/lib/RepositoryOperator.py
@@ -292,7 +292,7 @@ class RepoOperator(object):
         :return: commit-date
         """
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
         return_code, output, error = self.git.run(['show', '-s', '--pretty=format:%ct'], directory=repo_dir)
         if return_code == 0:
             return output.strip()
@@ -306,7 +306,7 @@ class RepoOperator(object):
         """
          
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
 
         return_code, output, error = self.git.run(['log', '--format=format:%H', '-n', '1'], directory=repo_dir)
 
@@ -317,7 +317,8 @@ class RepoOperator(object):
 
     def get_latest_merge_commit_before_date(self, repo_dir, date):
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
+
         return_code, output, error = self.git.run(['log', '--merges', '--format=format:%H', '--before='+date, '-n', '1'], directory=repo_dir)
 
         if return_code == 0:
@@ -328,7 +329,8 @@ class RepoOperator(object):
 
     def get_latest_author_commit_before_date(self, repo_dir, date, author):
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
+
         return_code, output, error = self.git.run(['log', '--author='+author, '--format=format:%H', '--before='+date, '-n', '1'], directory=repo_dir)
 
         if return_code == 0:
@@ -338,22 +340,22 @@ class RepoOperator(object):
                   .format(author=author, date=date, repo_dir=repo_dir))
 
 
-    def commit1_newer_than_commit2(self, repo_dir, commit1, commit2):
+    def get_newer_commit(self, repo_dir, commit1, commit2):
         '''
         if commit1 is newer than commit2, return True
         else, return False
         '''
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
         return_code, output, error = self.git.run(['rev-list', commit1+'..'+commit2, '--count'], directory=repo_dir)
         if return_code == 0:
             if output.strip() == "0":
-                return True
+                return commit1
             else:
-                return False
+                return commit2
         else:
-            raise RuntimeError("Unable to get commit id of {author} before {date} in directory {repo_dir}"\
-                  .format(author=author, date=date, repo_dir=repo_dir))
+            raise RuntimeError("Unable to get any commit between {commit1} and {commit2} in directory {repo_dir}"\
+                  .format(commit1=commit1, commit2=commit2, repo_dir=repo_dir))
 
 
     def get_commit_message(self, repo_dir, commit):
@@ -364,7 +366,7 @@ class RepoOperator(object):
         """
 
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
 
         return_code, output, error = self.git.run(['log', '--format=format:%B', '-n', '1', commit], directory=repo_dir)
 
@@ -383,7 +385,7 @@ class RepoOperator(object):
         """
 
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
 
         return_code, output, error = self.git.run(['ls-remote', '--get-url'], directory=repo_dir)
 
@@ -400,7 +402,7 @@ class RepoOperator(object):
         """
 
         if repo_dir is None or not os.path.isdir(repo_dir):
-            raise RuntimeError("The repository directory is not a directory")
+            raise RuntimeError("The repository directory {0} is not specified. or its format is wrong".format(repo_dir))
 
         return_code, output, error = self.git.run(['symbolic-ref', '--short', 'HEAD'], directory=repo_dir)
 

--- a/build-release-tools/lib/RepositoryOperator.py
+++ b/build-release-tools/lib/RepositoryOperator.py
@@ -286,7 +286,7 @@ class RepoOperator(object):
         repo_directory_name = strip_suffix(os.path.basename(repo_url), ".git")
         return os.path.join(dest_dir, repo_directory_name)
 
-    def get_lastest_commit_date(self, repo_dir):
+    def get_latest_commit_date(self, repo_dir):
         """
         :param repo_dir: path of the repository
         :return: commit-date
@@ -299,7 +299,7 @@ class RepoOperator(object):
         else:
             raise RuntimeError("Unable to get commit date in directory {0}".format(repo_dir))
 
-    def get_lastest_commit_id(self, repo_dir):
+    def get_latest_commit_id(self, repo_dir):
         """
         :param repo_dir: path of the repository
         :return: commit-id
@@ -315,7 +315,7 @@ class RepoOperator(object):
         else:
             raise RuntimeError("Unable to get commit id in directory {0}".format(repo_dir))
 
-    def get_lastest_merge_commit_before_date(self, repo_dir, date):
+    def get_latest_merge_commit_before_date(self, repo_dir, date):
         if repo_dir is None or not os.path.isdir(repo_dir):
             raise RuntimeError("The repository directory is not a directory")
         return_code, output, error = self.git.run(['log', '--merges', '--format=format:%H', '--before='+date, '-n', '1'], directory=repo_dir)
@@ -325,6 +325,36 @@ class RepoOperator(object):
         else:
             raise RuntimeError("Unable to get commit id before {date} in directory {repo_dir}"\
                   .format(date=date, repo_dir=repo_dir))
+
+    def get_latest_author_commit_before_date(self, repo_dir, date, author):
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+        return_code, output, error = self.git.run(['log', '--author='+author, '--format=format:%H', '--before='+date, '-n', '1'], directory=repo_dir)
+
+        if return_code == 0:
+            return output.strip()
+        else:
+            raise RuntimeError("Unable to get commit id of {author} before {date} in directory {repo_dir}"\
+                  .format(author=author, date=date, repo_dir=repo_dir))
+
+
+    def commit1_newer_than_commit2(self, repo_dir, commit1, commit2):
+        '''
+        if commit1 is newer than commit2, return True
+        else, return False
+        '''
+        if repo_dir is None or not os.path.isdir(repo_dir):
+            raise RuntimeError("The repository directory is not a directory")
+        return_code, output, error = self.git.run(['rev-list', commit1+'..'+commit2, '--count'], directory=repo_dir)
+        if return_code == 0:
+            if output.strip() == "0":
+                return True
+            else:
+                return False
+        else:
+            raise RuntimeError("Unable to get commit id of {author} before {date} in directory {repo_dir}"\
+                  .format(author=author, date=date, repo_dir=repo_dir))
+
 
     def get_commit_message(self, repo_dir, commit):
         """

--- a/build-release-tools/lib/config.py
+++ b/build-release-tools/lib/config.py
@@ -1,4 +1,3 @@
 gitbit_identity = dict(
-    username='Robbie the Build Robot',
-    email='robot@hwimo.lab.emc.com'
+    username='JenkinsRHD'
 )


### PR DESCRIPTION
Solution for the story: [Jenkins: release docker version check](https://rackhd.atlassian.net/browse/RAC-4158)

The generated manifest file contains wrong commit hash.
The script generate_manifest.py filters commit with the command:
```git log --merges --before="date string"```
The command only chooses commits which are merged.
But the commit "jump version for new release x.y.z" is pushed directly by jenkins.
So the generated manifest file skipped  the commit.


The PR will filter the last merged commit before the specify date with the command:
 ```git log --merges --before="date string"```
And also filter the last commit of JenkinsRHD before the date with the command:
```git log --author="JenkinsRHD" --bofore="date string"```

After that, the PR will find which one is more recent with the command:
``` git rev-list commit1..commit2 --count```

The PR will choose the more recent one to the manifest file.

Test:
http://rackhdci.lss.emc.com/job/Experimental-Jobs/job/MasterCI-Test/16/



