### PR TITLE
[skip ci]docker build use uniform source list

### DIFF
--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -78,12 +78,8 @@ doBuild() {
                     docker build -t rackhd/files$TAG .
                     repos_tags=files$TAG" "
             elif [ "$repo" != "on-core" ];then
-                    # Use the new sources.list
-                    sed -i "/^FROM/a RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak\nADD $SOURCE_LIST /etc/apt/sources.list" Dockerfile
                     #Based on newly build upstream image to build
                     sed -i "/^FROM/ s/$/${PRE_TAG}/" Dockerfile
-                    # Recover the sources.list
-                    sed -i -e "\$aRUN mv /etc/apt/sources.list.bak /etc/apt/sources.list" Dockerfile
                     docker build -t rackhd/$repo$TAG .
             fi
             case $repo in


### PR DESCRIPTION
https://rackhd.atlassian.net/browse/RAC-4048

### Background
The root base image of rackhd on-xxx docker images is ```nodesource/wheezy```
However, the source list of this base image can not satisfy our needs.
So we used to 
* replace sources list when build and recover it after build.
but now
* add source list in https://github.com/RackHD/on-core/pull/255 and remove related steps here.. 

@panpan0000 @PengTian0 

PR merge order:
https://github.com/RackHD/on-core/pull/255 first, then after dockerhub autobuild success,
https://github.com/RackHD/on-taskgraph/pull/211 should be merged.
then the next day
this PR should be merged to support the daily build.