### PR TITLE
Remove set  -x

### DIFF
--- a/build-release-tools/post_test.sh
+++ b/build-release-tools/post_test.sh
@@ -36,7 +36,6 @@
 # If build twice in one docker build job, the repos:tags of each build will be stored in each line
 ############################################
 
-set -x
 
 while [ "$1" != "" ];do
     case $1 in


### PR DESCRIPTION
to avoid all those IP address dumped in Jenkins Console, as a security concern


@changev  @PengTian0 @yyscamper @anhou 