### PR TITLE
bugfix: sol log missing

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -139,6 +139,7 @@ apiPackageModify() {
     pushd ${WORKSPACE}/on-http/extra
     sed -i "s/.*git symbolic-ref.*/ continue/g" make-deb.sh
     sed -i "/build-package.bash/d" make-deb.sh
+    sed -i "/GITCOMMITDATE/d" make-deb.sh
     sed -i "/mkdir/d" make-deb.sh
     sudo bash make-deb.sh
     popd

--- a/vagrant/Vagrantfile.in
+++ b/vagrant/Vagrantfile.in
@@ -22,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # target.vm.network :public_network
         if ENV['WORKSPACE']
           target.vm.synced_folder "#{ENV['WORKSPACE']}/build-deps", "/home/vagrant/src/"
+          target.vm.synced_folder "#{ENV['WORKSPACE']}/build-config", "/home/vagrant/src/build-config"
           if ENV['MULTI'] =="true"
             target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/build"
             for repo in ENV['REPO_NAME'].split(' ')


### PR DESCRIPTION
mount build-config to vagrant/src

then build-config/generate-sol-log.sh can be run inside vagrant.

@panpan0000 @PengTian0 