### PR TITLE
[Skip CI]HotFix: stop docker before deleting.

### DIFF
--- a/jobs/release/release_docker.sh
+++ b/jobs/release/release_docker.sh
@@ -18,7 +18,7 @@ while read -r LINE; do
     done
 done < $WORKSPACE/build_record
 
-#move the original clean up steps to post-build, avoid failure impacts build status.
+# Clean UP. (was in Jenkins job post-build, avoid failure impacts build status.)
 set +e
 set -x
 
@@ -31,7 +31,13 @@ clean_up(){
     fi
 }
 
+echo "Show local docker images"
+docker ps
 docker images
+echo "Stop & rm all docker running images " 
+docker stop $(docker ps -a -q)
+docker rm $(docker ps -a -q)
+echo "Clean Up all docker images in local repo"
 clean_up none
 # clean images by order, on-core should be last one because others depends on it
 clean_up on-taskgraph
@@ -46,3 +52,5 @@ clean_up on-wss
 clean_up on-statsd
 clean_up on-core
 clean_up rackhd
+
+exit 0 # this is a workaround. to avoid the cleanup failure makes whole workflow fail.don't worry, the set -e will ensure failure captured for necessary steps(those lines before set +e)


### PR DESCRIPTION
relevant to build failure of http://rackhdci.lss.emc.com/job/MasterCI/10/consoleFull
and some notes logged in https://rackhd.atlassian.net/browse/RAC-4357

in short, the clean up "docker rmi" failed ,due to some image has dependence.
I found there's still running instance without stopping. (caused by issue described in https://github.com/RackHD/on-build-config/pull/99)

so 
(1) add ```docker stop``` before clean up
(2) add ```exit 0``` at the end, to ensure the "clean up" step will never impact the normal logic.


@anhou  @johren   @changev  @PengTian0 @RackHD/corecommitters 