### PR TITLE
[Skip CI]Don't run docker stop unless there're running containers.

### DIFF
--- a/build-release-tools/post_test.sh
+++ b/build-release-tools/post_test.sh
@@ -259,8 +259,13 @@ post_test_vagrant() {
 ############################################
 
 clean_all_containers() {
-    docker stop $(docker ps -a -q)
-    docker rm $(docker ps -a -q)
+    local containers=$(docker ps -a -q)
+    if [ "$containers" != "" ]; then
+        echo "Clean Up containers : " ${containers}
+        docker stop ${containers}
+        docker rm  ${containers}
+    fi
+
 }
 
 post_test_docker() {

--- a/jobs/release/release_docker.sh
+++ b/jobs/release/release_docker.sh
@@ -31,12 +31,21 @@ clean_up(){
     fi
 }
 
+clean_running_containers() {
+    local containers=$(docker ps -a -q)
+    if [ "$containers" != "" ]; then
+        echo "Clean Up containers : " ${containers}
+        docker stop ${containers}
+        docker rm  ${containers}
+    fi
+}
+
+
 echo "Show local docker images"
 docker ps
 docker images
-echo "Stop & rm all docker running images " 
-docker stop $(docker ps -a -q)
-docker rm $(docker ps -a -q)
+echo "Stop & rm all docker running containers " 
+clean_running_containers
 echo "Clean Up all docker images in local repo"
 clean_up none
 # clean images by order, on-core should be last one because others depends on it


### PR DESCRIPTION
from http://rackhdci.lss.emc.com/job/BuildRelease/job/Build/job/docker-post-test/222/console

failure like below. 
```
04:14:04 [docker-build] $ /bin/bash +xe /tmp/hudson4629335785275031084.sh
04:14:04 "docker stop" requires at least 1 argument(s).
04:14:04 See 'docker stop --help'.
```

this issue may be exposed by a manual run of ```docker stop $(docker ps -a -q)``` on that slave.


so we need to check ```  if [ "$containers" != "" ]; ```


@changev 
@anhou 
@yyscamper 
@PengTian0 
@RackHD/corecommitters 