### PR TITLE
[skip ci]add usc-service to manifest

### DIFF
--- a/build-release-tools/lib/manifest.json
+++ b/build-release-tools/lib/manifest.json
@@ -67,6 +67,11 @@
             "branch": "", 
             "commit-id": "",
             "repository": "https://github.com/RackHD/on-statsd.git"
+        },
+        {
+            "branch": "",
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/ucs-service.git"
         }
     ]
 }


### PR DESCRIPTION
The smoketest-fit need to checkout usc-service.git but the repository is not controlled by manifest.
If the job is triggered by nightly build (masterci), SprintTag or Sprint-Release, it will fail because the leak of the repository.

The current job smoketest-fit doesn't fail because it doesn't accept a manifest file url as its parameter and always checkout the latest commit of master.
