### PR TITLE
RAC-4395 - Updated scripts to use the rackhd 2.0 api

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -201,7 +201,7 @@ runTests() {
 waitForAPI() {
   timeout=0
   maxto=30
-  url=http://localhost:9090/api/1.1/nodes
+  url=http://localhost:9090/api/2.0/nodes
   while [ ${timeout} != ${maxto} ]; do
     wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue ${url}
     if [ $? = 0 ]; then 

--- a/test.sh.in
+++ b/test.sh.in
@@ -368,7 +368,7 @@ runTests() {
 waitForAPI() {
   timeout=0
   maxto=60
-  url=http://localhost:9090/api/1.1/nodes
+  url=http://localhost:9090/api/2.0/nodes
   while [ ${timeout} != ${maxto} ]; do
     wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue ${url}
     if [ $? = 0 ]; then 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -64,7 +64,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
 
         if ENV['TEST_GROUP']		
-          if ENV['TEST_GROUP'] =~  /esxi-5-5-min-install.v1.1.test/ || ENV['TEST_GROUP'] =~  /esxi-5-5-max-install.v1.1.test/		
+          if ENV['TEST_GROUP'] =~  /esxi-5-5-min-install.v2.0.test/ || ENV['TEST_GROUP'] =~  /esxi-5-5-max-install.v2.0.test/		
             config.vm.provision "file", source: "./dhcpd.conf", destination: "~/dhcpd.conf"		
             config.vm.provision "shell" do |s|		
             s.inline = "cp /home/vagrant/dhcpd.conf /etc/dhcp"		


### PR DESCRIPTION
RackHD API 1.1 is being deprecated for the Release 2.0.
This PR changes references to the /api/1.1 to /api/2.0 in the test scripts.
The scripts and the Vagrant file are used in the testbed creation during the PR gate.

