### PR TITLE
add retry when downloading internal static files

### DIFF
--- a/jobs/function_test/prepare.sh
+++ b/jobs/function_test/prepare.sh
@@ -22,7 +22,7 @@ dlHttpFiles() {
   mkdir -p ${dir} && cd ${dir}
   if [ -n "${INTERNAL_HTTP_ZIP_FILE_URL}" ]; then
     # use INTERNAL TEMP SOURCE
-    wget ${INTERNAL_HTTP_ZIP_FILE_URL} 
+    wget -c -t 5 ${INTERNAL_HTTP_ZIP_FILE_URL} 
     unzip common.zip && mv common/* . && rm -rf common
   else
     # pull down index from bintray repo and parse files from index
@@ -43,7 +43,7 @@ dlTftpFiles() {
   mkdir -p ${dir} && cd ${dir}
   if [ -n "${INTERNAL_TFTP_ZIP_FILE_URL}" ]; then
     # use INTERNAL TEMP SOURCE
-    wget ${INTERNAL_TFTP_ZIP_FILE_URL} 
+    wget -c -t 5 ${INTERNAL_TFTP_ZIP_FILE_URL} 
     unzip pxe.zip && mv pxe/* . && rm -rf pxe pxe.zip
   else
     # pull down index from bintray repo and parse files from index


### PR DESCRIPTION
When downloading internal static file, in rare cases it will download incomplete packages.
Add -c -t will solve this problem.

### Details:
In every function test, after downloading ```common.zip``` and try to unzip
sometime unzip error will occur because this common.zip is an incomplete zip file, possiblely network problem.

@panpan0000 @PengTian0 