### PR TITLE
decode utf-8 first before ansi2html

### DIFF
--- a/post-deploy.sh
+++ b/post-deploy.sh
@@ -7,5 +7,7 @@ echo "Running post-deploy script"
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    # decode to utf-8 before, because ansi2html will broke when finding invalid char
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done


### PR DESCRIPTION
In rare cases post-deploy.sh will broke the whole pr-gate, just because ansi2html can't decode some char in sol log, like "ÿ".

Before ansi2html decode utf-8 first using iconv.

@panpan0000 @PengTian0 