### PR TITLE
[skip ci]move packer cache dir from /tmp to /home/onrack

### DIFF
--- a/jobs/build_ova/build_ova.sh
+++ b/jobs/build_ova/build_ova.sh
@@ -11,7 +11,7 @@ pkill packer
 pkill vmware
 set -x
 cd $WORKSPACE/build/packer 
-export PACKER_CACHE_DIR=/tmp/packer_cache
+export PACKER_CACHE_DIR=$HOME/.packer_cache
 export BUILD_TYPE=vmware
 #export vars to build ova
 if [ "${IS_OFFICIAL_RELEASE}" == true ]; then

--- a/jobs/build_vagrant/build_vagrant.sh
+++ b/jobs/build_vagrant/build_vagrant.sh
@@ -11,7 +11,7 @@ pkill packer
 cd ..
 cd $WORKSPACE/build/packer 
 #export vars to build virtualbox
-export PACKER_CACHE_DIR=/tmp/packer_cache
+export PACKER_CACHE_DIR=$HOME/.packer_cache
 if [ "${IS_OFFICIAL_RELEASE}" == "true" ]; then
     export ANSIBLE_PLAYBOOK=rackhd_release
 else


### PR DESCRIPTION
There's an issue that when build vagrant/ova, the cache was clean by someone during the build.

This PR moves the cache from /tmp to $HOME to reduce the probability that packer cache be cleaned unexpected.

@panpan0000 @PengTian0 