### PR TITLE
decode utf-8 first before ansi2html

### DIFF
--- a/on-core/post-deploy.sh.in
+++ b/on-core/post-deploy.sh.in
@@ -15,5 +15,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done

--- a/on-dhcp-proxy/post-deploy.sh.in
+++ b/on-dhcp-proxy/post-deploy.sh.in
@@ -14,5 +14,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done

--- a/on-http/post-deploy.sh.in
+++ b/on-http/post-deploy.sh.in
@@ -14,5 +14,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done

--- a/on-syslog/post-deploy.sh.in
+++ b/on-syslog/post-deploy.sh.in
@@ -14,5 +14,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done

--- a/on-taskgraph/post-deploy.sh.in
+++ b/on-taskgraph/post-deploy.sh.in
@@ -14,5 +14,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done

--- a/on-tasks/post-deploy.sh.in
+++ b/on-tasks/post-deploy.sh.in
@@ -14,5 +14,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build/${file%.*}
 done

--- a/on-tftp/post-deploy.sh.in
+++ b/on-tftp/post-deploy.sh.in
@@ -14,5 +14,6 @@ fi
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done

--- a/post-deploy.sh.in
+++ b/post-deploy.sh.in
@@ -1,10 +1,13 @@
 #!/bin/bash
 echo "Running post-deploy script"
 
+
 #raw sol logs saved in WORKSPACE/build-deps
 #this script convert them into html by ansi2html tool
 #and move them to 'build' folder for publishing
 cd $WORKSPACE/build-deps
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build-deps/${file%.*}
+    # decode to utf-8 before, because ansi2html will broke when finding invalid char
+    iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
+    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
 done


### PR DESCRIPTION
In rare cases post-deploy.sh will broke the whole pr-gate, just because ansi2html can't decode some char in sol log, like "ÿ".

Before ansi2html decode utf-8 first using iconv.

@panpan0000 @PengTian0 