### PR TITLE
Fix: RAC4649: Jenkins is not updating PR quality gate status in PR

### DIFF
--- a/jobs/pr_gate/pr_parser.groovy
+++ b/jobs/pr_gate/pr_parser.groovy
@@ -8,19 +8,22 @@ node{
         dir("on-build-config") {
             checkout scm
         }
-        env.stash_manifest_path = "manifest"
-        withCredentials([string(credentialsId: 'JENKINSRHD_GITHUB_TOKEN',
-                                variable: 'GITHUB_TOKEN')]) {
-            sh '''#!/bin/bash -ex
-            ./on-build-config/build-release-tools/HWIMO-BUILD ./on-build-config/build-release-tools/application/pr_parser.py \
-            --change-url $ghprbPullLink \
-            --target-branch $ghprbTargetBranch \
-            --ghtoken ${GITHUB_TOKEN} \
-            --manifest-file-path "${stash_manifest_path}"
-            '''
+        try{
+            env.stash_manifest_path = "manifest"
+            withCredentials([string(credentialsId: 'JENKINSRHD_GITHUB_TOKEN',
+                                    variable: 'GITHUB_TOKEN')]) {
+                sh '''#!/bin/bash -ex
+                ./on-build-config/build-release-tools/HWIMO-BUILD ./on-build-config/build-release-tools/application/pr_parser.py \
+                --change-url $ghprbPullLink \
+                --target-branch $ghprbTargetBranch \
+                --ghtoken ${GITHUB_TOKEN} \
+                --manifest-file-path "${stash_manifest_path}"
+                '''
+             }
+        } finally{
+            archiveArtifacts 'manifest'
+            stash name: 'manifest', includes: 'manifest'
+            env.stash_manifest_name = "manifest"
         }
-        archiveArtifacts 'manifest'
-        stash name: 'manifest', includes: 'manifest'
-        env.stash_manifest_name = "manifest"
     }
 }

--- a/jobs/write_back_github/write_back_github.sh
+++ b/jobs/write_back_github/write_back_github.sh
@@ -1,6 +1,6 @@
 #!/bin/bash 
 
-set -ex
+set -x
 pushd $WORKSPACE
 build_status="${status}"
 


### PR DESCRIPTION
Fix  [RAC4649](https://rackhd.atlassian.net/browse/RAC-4649)
There are 2 causes of this issue:
1. For pull request which has merge conflict, there is no manifest file generated.
    So the stage write back won't add comments to pull request or set the status of it.
2. If there is no test report generated, the post-result.py will add comments to pull request and exit with 1.      
    That leads to the shell script write_back_github.sh exit with 1 and won't execute the script commit_status_setter.py

The pull requests affected by this issue:
https://github.com/RackHD/on-build-config/pull/131