### PR TITLE
RAC 4651: pipeline display missing graphic

### DIFF
--- a/jobs/function_test/function_test.groovy
+++ b/jobs/function_test/function_test.groovy
@@ -131,7 +131,9 @@ def run_test(RUN_TESTS){
             function_test(test_name,label_name,test_group, run_fit_test, run_cit_test)
         }
     }
-    parallel test_branches
+    if(test_branches.size() > 0){
+        parallel test_branches
+    }
 }
 
 

--- a/jobs/unit_test/unit_test.groovy
+++ b/jobs/unit_test/unit_test.groovy
@@ -92,7 +92,9 @@ node{
                         unit_test(repo_name, "unittest", used_resource)   
                     }
                 }
-                parallel test_branches
+                if(test_branches.size() > 0){
+                    parallel test_branches
+                }
             }catch(error){
                 echo "Caught: ${error}"
                 currentBuild.result="FAILURE"


### PR DESCRIPTION
[RAC4651](https://rackhd.atlassian.net/browse/RAC-4651)
Jenkins threw Exception:
```
Caused by: java.lang.IllegalStateException: Hit a BlockStartNode with no record of the start!
at org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.hitParallelStart(ForkScanner.java:554)
at org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.next(ForkScanner.java:584)
at org.jenkinsci.plugins.workflow.graphanalysis.AbstractFlowScanner.next(AbstractFlowScanner.java:212)
at org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.next(ForkScanner.java:566)
at org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.visitSimpleChunks(ForkScanner.java:764)
at org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner.visitSimpleChunks(ForkScanner.java:635)
at io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeGraphVisitor.<init>(PipelineNodeGraphVisitor.java:85)
at io.jenkins.blueocean.rest.impl.pipeline.NodeGraphBuilder$NodeGraphBuilderFactory.getInstance(NodeGraphBuilder.java:39)
at io.jenkins.blueocean.rest.impl.pipeline.PipelineNodeContainerImpl.<init>(PipelineNodeContainerImpl.java:32)
at io.jenkins.blueocean.rest.impl.pipeline.PipelineRunImpl.getNodes(PipelineRunImpl.java:101)
```
It's caused by running "parallel empty map" in groovy.
It's a bug of the plugin workflow api
