### PR TITLE
Support vSphere with DHCP in OVA-POST-TEST & move to US ESXi

### DIFF
--- a/build-release-tools/post_test.sh
+++ b/build-release-tools/post_test.sh
@@ -157,6 +157,7 @@ findRackHDService() {
         rm -f $TMP_LOG_FILE
         check_api_command="wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue ${url}"
         sshpass -p ${rackhd_default_pwd} ssh ${rackhd_default_usr}@${adminIP}  -o StrictHostKeyChecking=no  ${check_api_command}  > $TMP_LOG_FILE 2>&1
+        sed -i  "s/Warning: Permanently added.*//g" $TMP_LOG_FILE  # Remove the senstive IP info in the log.
         api_test_result=$(cat $TMP_LOG_FILE )
         rm -f $TMP_LOG_FILE # Clean Up
         echo $api_test_result | grep "$service_normal_sentence" > /dev/null  2>&1
@@ -316,7 +317,7 @@ deploy_ova() {
         echo "[Error] Deploy OVA failed."
         exit 3
     fi
-    ssh-keygen -f "$HOME/.ssh/known_hosts" -R $adminIP
+    ssh-keygen -f "$HOME/.ssh/known_hosts" -R $adminIP > /dev/null 2>&1  # to avoid IP exposing
 }
 
 delete_ova() {

--- a/jobs/build_ova/ova_post_test.groovy
+++ b/jobs/build_ova/ova_post_test.groovy
@@ -11,10 +11,8 @@ node(build_ova_node){
                 }
 
                 withCredentials([
-                    usernamePassword(credentialsId: 'OVA_POST_TEST_ESXI_HOST', 
-                                     passwordVariable: 'ESXI_HOST_IP_AGAIN', 
-                                     usernameVariable: 'ESXI_HOST_IP'),
-                    usernamePassword(credentialsId: '00aa0b00-f027-4791-a539-51bf0181172a',
+                    string(credentialsId: 'OVA_POST_TEST_ESXi_US_IP', variable: 'ESXI_HOST_IP'), 
+                    usernamePassword(credentialsId: 'OVA_POST_TEST_ESXi_US_CRED',
                                      passwordVariable: 'ESXI_PASS',
                                      usernameVariable: 'ESXI_USER'),
                     usernamePassword(credentialsId: 'VCENTER_NT_CREDS', 
@@ -24,7 +22,7 @@ node(build_ova_node){
                     string(credentialsId: 'Deployed_OVA_admin_IP', variable: 'OVA_Admin_IP'), 
                     string(credentialsId: 'Deployed_OVA_admin_GW', variable: 'OVA_Admin_GW'), 
                     string(credentialsId: 'Deployed_OVA_admin_DNS', variable: 'OVA_Admin_DNS'), 
-                    string(credentialsId: 'Deployed_OVA_Datastore', variable: 'ESXI_DataStore')
+                    string(credentialsId: 'Deployed_OVA_Datastore_US', variable: 'ESXI_DataStore')
                     ]) {
                     timeout(90){
                         sh './build-config/jobs/build_ova/ova_post_test.sh'

--- a/jobs/build_ova/ova_post_test.sh
+++ b/jobs/build_ova/ova_post_test.sh
@@ -27,5 +27,7 @@ bash ./build-config/build-release-tools/post_test.sh \
 --ntName ${VCENTER_NT_USER} \
 --ntPass ${VCENTER_NT_PASSWORD} \
 --esxiHost ${ESXI_HOST_IP} \
+--esxiHostUser ${ESXI_USER} \
+--esxiHostPass ${ESXI_PASS} \
 --net "ADMIN"="External Connection" \
 --rackhdVersion $RACKHD_VERSION

--- a/jobs/build_ova/ova_post_test.sh
+++ b/jobs/build_ova/ova_post_test.sh
@@ -1,33 +1,26 @@
 #!/bin/bash +xe
-delete_ova() {
-    ansible esxi -a "./vm_operation.sh -a delete ${ESXI_HOST_IP} 1 ova-for-post-test"
-    if [ $? = 0 ]; then
-      echo "Delete ova-for-post-test successfully!"
-    fi
-}
-echo "Delete old OVA"
-delete_ova
-sleep 10
 
-PACKERDIR="$WORKSPACE/build/packer/"
-OVA="$PACKERDIR/rackhd-${OS_VER}-${RACKHD_VERSION}.ova"
+PACKERDIR="${WORKSPACE}/build/packer/"
+OVA="${PACKERDIR}/rackhd-${OS_VER}-${RACKHD_VERSION}.ova"
 
-echo "Post Test starts "
+echo "Post Test starts : OVA File is $OVA"
 
 bash ./build-config/build-release-tools/post_test.sh \
 --type ova \
---adminIP ${OVA_Admin_IP} \
---adminGateway ${OVA_Admin_GW} \
---adminNetmask 255.255.255.0 \
---adminDNS ${OVA_Admin_DNS} \
 --datastore ${ESXI_DataStore} \
 --deployName ova-for-post-test \
 --ovaFile $OVA \
---vcenterHost ${VCENTER_IP} \
---ntName ${VCENTER_NT_USER} \
---ntPass ${VCENTER_NT_PASSWORD} \
 --esxiHost ${ESXI_HOST_IP} \
 --esxiHostUser ${ESXI_USER} \
 --esxiHostPass ${ESXI_PASS} \
---net "ADMIN"="External Connection" \
+--net "ADMIN"="Admin" \
 --rackhdVersion $RACKHD_VERSION
+# Comment out below lines, for there's DHCP in US ENV,so we use vSphere instead of vCenter
+#--adminIP ${OVA_Admin_IP} \
+#--adminGateway ${OVA_Admin_GW} \
+#--adminNetmask 255.255.255.0 \
+#--adminDNS ${OVA_Admin_DNS} \
+#--vcenterHost ${VCENTER_IP} \
+#--ntName ${VCENTER_NT_USER} \
+#--ntPass ${VCENTER_NT_PASSWORD} \
+


### PR DESCRIPTION
**Background**
Previously, in SH Lab, the IP is static. So we will have to use OVA-pre-config-IP functionality to deploy OVA to vCenter with pre-set IP.
Now, in US Lab, there's DHCP. So we don't need to specify IP anymore.
instead we need to use ```--X:waitForIp``` in ovftool, to retrieve the IP assigned by DHCP server.

So this PR will move the ova-post-test from SH vCenter to US vSphere, **this should be merged before EOB 4/7** to catch up weekend power outage in SH lab and sprint release at that time.
It's relevant to RAC-4442

depends on PR https://github.com/RackHD/RackHD/pull/632

**What's Changed**

--In post-test.sh----
1. in deploy_ova(), use different parameters of ovftool for ESXi vSphere.
2. in header parameter usage, describe two different use-case with DHCP or without DHCP
3. previously, using of "ansible" requires a /etc/ansible/hosts file pre-configured. So I changed ansible to ssh/sshpass, to get rid of the hosts file
4. make "rackhdVersion" checking code  more clear.

--In pipeline jobs/folder----
1. change the creds in groovy to US ESXi values
2. change the parameter in jobs/build_ova/ova_post_test.sh as well

**Test Done**
-- post-test.sh----
Tested on vmslave_packer_ova node, and deploy to US vSphere **.***.**.143
-- pipeline change--
Tested with a private  job http://rackhdci.lss.emc.com/job/Test_OVA_Post_Test/13/console  (it has been removed) which is a partial pipeline job which accepts a OVA as input.

@changev  @yyscamper @anhou  @PengTian0 