### PR TITLE
RAC-4790: Clean Up Docker Volumes after release-docker-step

### DIFF
--- a/jobs/release/release_docker.sh
+++ b/jobs/release/release_docker.sh
@@ -62,4 +62,7 @@ clean_up on-statsd
 clean_up on-core
 clean_up rackhd
 
+echo "clean up /var/lib/docker/volumes"
+docker volume ls -qf dangling=true | xargs -r docker volume rm
+
 exit 0 # this is a workaround. to avoid the cleanup failure makes whole workflow fail.don't worry, the set -e will ensure failure captured for necessary steps(those lines before set +e)


### PR DESCRIPTION
**Background**
As https://rackhd.atlassian.net/browse/RAC-4790, for every docker-build, the volume is never cleaned.
and eat up the space at the end.
so add this command to remove unused volumes after every docker-pipeline ends.


** Test **
this command has been manually run on vmslave-docker-1, and it has achieved the goal.


@PengTian0   @changev   