### PR TITLE
RAC4816: Remove wait/sleep messages from the console logs

### DIFF
--- a/jobs/function_test/function_test.groovy
+++ b/jobs/function_test/function_test.groovy
@@ -1,6 +1,5 @@
 def function_test(String test_name, String label_name, String TEST_GROUP, Boolean RUN_FIT_TEST, Boolean RUN_CIT_TEST){
     def shareMethod = load("jobs/shareMethod.groovy")
-    shareMethod.waitForFreeResource(label_name,1)
     lock(label:label_name,quantity:1){
         // The locked resources of the build
         def lock_resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())

--- a/jobs/shareMethod.groovy
+++ b/jobs/shareMethod.groovy
@@ -14,16 +14,6 @@ def checkout(String url){
     checkout(url, "master")
 }
 
-def waitForFreeResource(label_name,quantity){
-    int free_count=0
-    while(free_count<quantity){
-        free_count = org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getFreeResourceAmount(label_name)
-        if(free_count == 0){
-            sleep 5
-        }
-    }
-}
-
 def getLockedResourceName(resources,label_name){
     // Get the resource name whose label contains the parameter label_name
     def resources_name=[]
@@ -47,7 +37,6 @@ def buildAndPublish(){
             load("jobs/build_debian/build_debian.groovy")
         }
     }
-    waitForFreeResource("docker",1)
     // lock a docker resource from build to release
     lock(label:"docker",quantity:1){
         def lock_resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())       

--- a/jobs/unit_test/unit_test.groovy
+++ b/jobs/unit_test/unit_test.groovy
@@ -1,6 +1,5 @@
 def unit_test(String repo_name, String label_name, ArrayList<String> used_resource){
     def shareMethod = load("build-config/jobs/shareMethod.groovy")
-    shareMethod.waitForFreeResource(label_name,1)
     def node_name=""
     lock(label:label_name,quantity:1){
         def lock_resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())


### PR DESCRIPTION
**Background**
The ```waitForFreeResource``` is a workaround for the issue  [JENKINS-38266](https://issues.jenkins-ci.org/browse/JENKINS-38266): Lock released, but waiting acquirers won't continue to work
In order to make the ```lock``` works as expected, we add ```waitForFreeResource``` to ```sleep``` until there is free resource.
That leads to many ```sleep``` in our console log when a pipeline has to wait for free resource([RAC-4574](https://rackhd.atlassian.net/browse/RAC-4574)).

**Fixed**
Now the issue is fixed in release 1.11.2 of plugin [lockable resource plugin](https://wiki.jenkins-ci.org/display/JENKINS/Lockable+Resources+Plugin) and we just updated it to release 1.11.2 .
This PR removes the workaround and there will not be many ```sleep`` in  our console log.
[
RAC4816](https://rackhd.atlassian.net/browse/RAC-4816)