### PR TITLE
pass vm_operation.sh to esxi instead keep the script in esxi

### DIFF
--- a/build-release-tools/post_test.sh
+++ b/build-release-tools/post_test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 ############################################
 # Post-Test scripts for ova, vagrantBox and docker.
 # This script will up/deploy ova, box and docker images,
@@ -321,7 +320,9 @@ deploy_ova() {
 }
 
 delete_ova() {
-    sshpass -p ${esxiHostPass} ssh ${esxiHostUser}@${esxiHost}  -o StrictHostKeyChecking=no   "./vm_operation.sh -a delete ${esxiHost} 1 $deployName"
+    pushd ./build-config/deployment/
+    ./vm_control.sh "${esxiHost},${esxiHostUser},${esxiHostPass},delete,1,$deployName"
+    popd
     if [ $? = 0 ]; then
       echo "Delete $deployName successfully!"
     else


### PR DESCRIPTION
http://rackhdci.lss.emc.com/blue/organizations/jenkins/MasterCI/detail/MasterCI/90/pipeline/489

After ova post test succeed, the ova should be delete, and the delete work depends on a shell  script stored in ”/” of esxi.
However the shell was deleted by unknown today, so pipeline broke.


this is a leftover problem, the needed script should be passed to esxi but not stored in it.