### PR TITLE
RAC-4852: Docker Post Test Miss Error

### DIFF
--- a/jobs/build_docker/docker_post_test.groovy
+++ b/jobs/build_docker/docker_post_test.groovy
@@ -10,12 +10,17 @@ node(build_docker_node){
                                  usernameVariable: 'SUDO_USER')]
             ){
                 timeout(90){
-                    sh '''#!/bin/bash +xe
+                    sh '''#!/bin/bash
+                    set -e
+                    set +x
+                    #in docker post-test, the workspace/RackHD/docker/files folder will be owned by "root" since it's run as sudo. So it should be removed by root as clean up.
+                    trap "echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER $WORKSPACE/build" SIGINT SIGTERM SIGKILL EXIT
+
+
                     bash $WORKSPACE/build-config/build-release-tools/post_test.sh \
                     --type docker \
                     --RackHDDir $WORKSPACE/build \
                     --buildRecord $WORKSPACE/build_record
-                    echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER $WORKSPACE/build 
                     '''
                 }
             }


### PR DESCRIPTION
original , with "+e" , the post-test failure will always be ignored by pipeline.

and the cleanup work should be invoked by signal handler.


@changev  @PengTian0 

