### PR TITLE
RAC-4783: User EMC Internal Artifactory as the Debian Staging

### DIFF
--- a/build-release-tools/application/upload_staging_deb_to_artifactory.py
+++ b/build-release-tools/application/upload_staging_deb_to_artifactory.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# Copyright 2016, EMC, Inc.
+"""
+This is a command line program that upload a rackhd release to artifactory.
+./on-tools/manifest-build-tools/HWIMO-BUILD on-tools/manifest-build-tools/application/release_debian_packages.py --build-directory b/ \
+        --artifactory-credential artifactory \
+        --artifactory-repo rackhd_staging \
+        --artifactory-url  http://afeossand1.cec.lab.emc.com/artifactory \
+        --artifactory-user username \
+        --artifactory-password password \
+        --deb-component staging \
+        --deb-distribution trusty \
+        --deb-architecture amd64 \
+        --debian-depth 3
+        The required parameters:
+        build-directory: A directory where all the repositories are cloned to. 
+        artifactory-credential: The environment variable name of artifactory credential.
+                            For example: artifactory_CREDS=username:api_key
+
+"""
+
+import argparse
+import os
+import requests
+import sys
+
+from ArtifactoryTools  import JFrogArtifactory
+from DebianToolsOnArtifactory import  DebianToolsOnArtifactory
+from DebianToolsOnArtifactory import DebianErrorOnArtifactory
+
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--build-directory',
+                        required=True,
+                        help="Top level directory that stores all the cloned repositories.",
+                        action='store')
+
+    parser.add_argument('--debian-depth',
+                        help="The depth in top level directory that you want"
+                             " this program look into to find debians.",
+                        default=3,
+                        type=int,
+                        action='store')
+
+
+    parser.add_argument('--artifactory-username',
+                        required=True,
+                        help="artifactory credential for CI services: <Credentials>: User Name",
+                        action='store')
+
+    parser.add_argument('--artifactory-password',
+                        required=True,
+                        help="artifactory credential for CI services: <Credentials>: Password",
+                        action='store')
+
+    parser.add_argument('--artifactory-repo',
+                        required=True,
+                        help="the Artifactory repository name",
+                        action='store')
+
+    parser.add_argument('--artifactory-url',
+                        required=True,
+                        help="artifactory URL, like http://afeossand1.cec.lab.emc.com/artifactory",
+                        action='store')
+
+    parser.add_argument('--deb-component',
+                        help="such as: main",
+                        action='store',
+                        default='staging')
+
+    parser.add_argument('--deb-distribution',
+                        help="such as: trusty, xenial",
+                        action='store',
+                        default='trusty')
+
+    parser.add_argument('--deb-architecture',
+                        help="such as: amd64, i386",
+                        action='store',
+                        default='amd64')
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+
+def make_debian_repo(repo_name, description, artifactory):
+    """
+    create an empty debian artifact repository when building step is executed
+     successfully.
+    :param repo_name: the name of the repository that will be created on
+        jfrog artifactory
+    :param description: the description for the created repository.
+    :param artifactory: the artifactory object that will be used to create
+        repository on
+
+    :return:
+        exit on failures
+        none on success
+    """
+    print "[Info] Try make {repo} with\n {arti}".format(repo=repo_name, arti=str(artifactory))
+    try:
+        response = artifactory.new_local_repo(rname=repo_name,
+                                              description=description)
+        if response.status_code != 200:
+            print "[Error] did not create repository successfully, got response code "\
+                  "{code}. \n{detail}"\
+                .format(code=response.status_code, detail=response.text)
+            exit(3)
+    except requests.requestexception as error:
+        print "[Error] found error during request. details as below\n {err}"\
+            .format(err=error)
+        exit(3)
+    else:
+        print "[Info] repository {repo} created successful\n"\
+            .format(repo=repo_name)
+
+
+def upload_debs_to_artifactory(repo_name, top_level_dir, artifactory, depth, distribution, component, architecture ):
+    """
+    Upload all the debians under top level dir to given repository name
+    :param repo_name: The repository name that the debian will be uploaded to
+    :param top_level_dir: The top level directory that contains the debians to
+        be uploaded to.
+    :param artifactory: The artifactory tool with which the upload will be
+        carried over.
+    :param depth: How deep do you want this program to go into top-level-dir
+     to look for debians to upload.
+
+    :return:
+        None on success.
+        Exit on Errors
+    """
+    deb_tool = DebianToolsOnArtifactory(repo_name=repo_name,
+                           top_dir_name=top_level_dir,
+                           artifactory=artifactory,
+                           distribution=distribution,
+                           component=component,
+                           architecture=architecture)
+    if depth != 3:
+        deb_tool.set_walk_depth(depth)
+
+    print "[Info] Try upload all debians under {dir}".format(
+        dir=deb_tool.get_top_dir())
+    print deb_tool
+    try:
+        upload_result = deb_tool.upload_debs()
+        if upload_result.is_good:
+            print "\n[Info] All the debians are uploaded successfully."
+            print upload_result.detail()
+    except DebianErrorOnArtifactory as error:
+        print "[Error] Error encountered when uploading the debs to artifactory:"
+        print error
+        exit(2)
+
+
+
+
+def main():
+    """
+    Upload all the debian packages under top level dir to Artifactory.
+    Exit on encountering any error.
+    :return:
+    """
+    args = parse_args( sys.argv[1:] )
+    try:
+        artifactory_obj = JFrogArtifactory(
+                                             user_cred=(args.artifactory_username, args.artifactory_password),
+                                             artifactory_loc= args.artifactory_url  )
+
+        if  False == artifactory_obj.repo_exists( args.artifactory_repo ): 
+            # Create the remote repo if not exist
+            description = "Repository made for staging debian packages."
+            make_debian_repo( args.artifactory_repo , description, artifactory_obj)
+        else:
+            print "[Info] The remote repo {repo_name} already exist. Skip make_debian_repo step.".format(repo_name=args.artifactory_repo)
+
+        #upload all the deb in top_level_dir, to artifactory
+        upload_debs_to_artifactory( repo_name    = args.artifactory_repo,
+                                    top_level_dir= args.build_directory,
+                                    artifactory  = artifactory_obj,
+                                    depth        = args.debian_depth,
+                                    distribution = args.deb_distribution,
+                                    component    = args.deb_component,
+                                    architecture = args.deb_architecture )
+
+    except Exception, e:
+        print "[Exception Caught]",e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/build-release-tools/lib/ArtifactoryTools.py
+++ b/build-release-tools/lib/ArtifactoryTools.py
@@ -1,0 +1,233 @@
+"""
+This is a module that contains the tool for python to interact with our JFrog
+artifactory API.
+"""
+
+import hashlib
+import json
+import os
+import requests
+
+class JFrogArtifactory(object):
+    """
+    This is a class that holds the interacting method for JFrog Artifactory
+    """
+
+    def __init__(self, user_cred,
+                 artifactory_loc=
+                 "http://afeossand1.cec.lab.emc.com/artifactory"):
+        """
+        Initialize this artifact interaction class
+        :param artifactory_loc: the url for artifactory
+        :param user_cred: the credential that is enough to execute the
+            work required
+        :return:
+        """
+        self.__artifactory_base = artifactory_loc
+        self.__credential = user_cred
+        self.__session = requests.session()
+        self.__session.auth = self.__credential
+
+
+
+    def __del__(self):
+        """
+        Object destroyer, close file IO and HTTP session handler on destroy
+        :return:
+        """
+        self.__session.close()
+
+    def __str__(self):
+        """
+        String representation of this class
+        :return: "Interface to JFrog artifactory with {url}."
+        """
+        str = "Interface to JFrog artifactory at: {url}".\
+            format(url=self.__artifactory_base)
+        return str
+
+    def get_package(self, repo_name, package_type, package_name):
+        """
+        Return the packages list with specific package name
+        :param repo_name:  Artifactory Repo name
+        :param package_type: example, for debian package, it's "deb"
+        :param package_name: example, on-http
+        """
+        uri = "{uri_base}/api/search/prop?{pkg_type}.name={pkg_name}&repos={repo_name}".format(uri_base=self.__artifactory_base, pkg_type=package_type, pkg_name=package_name,repo_name=repo_name)
+
+        response = self.__session.get(uri)
+        if response.status_code != 200:
+            print "Did not get a 200 in your request: ", uri
+            return None
+
+        list = response.json()
+
+        #print "repo list is:\n{0}".format(list)
+        return list
+
+
+    def is_version_exist( self, repo_name, package_type, package_name, version_string ):
+        """
+        Check if a version for specific package exist, by checking remote file names
+        """
+        ret_json = self.get_package( repo_name, package_type, package_name )
+        if ret_json is None:
+            return False
+        pkg_list = ret_json['results']
+        desired_ver = package_name+"_"+version_string # this should align the package file name , instead of the version naming
+        for p in pkg_list:
+            if 'uri' in p.keys() :
+                if desired_ver in str(p['uri']):
+                   return True
+        return False
+
+
+    def get_repo_list(self):
+        uri = "{uri_base}/api/repositories".format(uri_base=self.__artifactory_base)
+
+        response = self.__session.get(uri)
+        if response.status_code != 200:
+            print "Did not get a 200 in your request: ", uri
+            return None
+
+        list = response.json()
+
+        #print "repo list is:\n{0}".format(list)
+        return list
+
+
+    def get_artifactory_url(self):
+        """
+        Getter for artifactory base url
+        :return: string based artifactory url
+        """
+        return self.__artifactory_base
+
+    def repo_exists(self, rname):
+        """
+        Return the existence status of the named repository
+
+        :param rname: name of the repo to check
+        :return: True (if rname exists), False otherwise
+        """
+        repolist = self.get_repo_list();
+        for repo in repolist:
+            if 'key' in repo and repo['key'] == rname:
+                return True
+
+        return False
+
+
+    def new_local_repo(self, rname, description, repo_type="debian"):
+        """
+        Creates a local repo at pre-given artifactory
+        :param rname: repository name
+        :param description: description of the artifactory
+        :param repo_type: optional -- the type of artifactory
+        default to debian
+        :return: return response instance
+                raise and return any other errors if encounters
+        """
+        dict_artifact_config = {
+            "key": rname,
+            "rclass": "local",
+            "packageType": repo_type,
+            "description": description,
+            "enableDebianSupport": True,
+            "snapshotVersionBehavior": "unique",
+            "propertySets":["artifactory"]
+            }
+
+        uri = "{uri_base}/api/repositories/{repo_name}".format(
+            uri_base=self.__artifactory_base, repo_name=rname)
+        print "Trying to PUT\n{data}\nto\n{uri}.\n". \
+            format(data=json.dumps(dict_artifact_config), uri=uri)
+
+        try:
+            response = self.__session.put(
+                uri,
+                data=json.dumps(dict_artifact_config),
+                headers={"Content-Type": "application/json"}
+            )
+            if response.status_code != 200:
+                print "Did not get a 200 in your request: "
+        finally:
+            print "Successfully created new repo at artifactory."
+
+        return response
+
+    def upload_one_file(self, file_path, repository, dir_path,distribution, component, architecture ):
+        """
+        This function uploads one file to target repository in artifactory.
+        :param file_path: The path to the file to be uploaded
+        :param repository: The repository folder name that the file
+                            will be uploaded to
+        :param dir_path: The directory path that will have in artifactory
+                            repository
+
+        :return: instance of response
+        """
+        if os.path.exists(file_path):
+            file_name = os.path.basename(file_path)
+        else:
+            raise ValueError("The file path provided\n\t{path}\n"
+                             "is not a file.".format(path=file_path))
+
+        url = "{uri_base}/{rname}/{dir_path}/{fname}"\
+            .format(uri_base=self.__artifactory_base, rname=repository,
+                    dir_path=dir_path, fname=file_name)
+
+        # Only let debians have metadata
+        if file_path.endswith(".deb"):
+            url += ";deb.distribution={dist};deb.component={comp};" \
+                  "deb.architecture={arch};".format(dist=distribution, comp=component, arch=architecture)
+
+        print "Trying to PUT\n{data}\n\tto\n{uri}".format(
+            data=file_path, uri=url)
+
+        try:
+            with open(file_path, 'rb') as fp:
+                file_data = fp.read()
+        finally:
+            fp.close()
+
+        response = self.__session.put(url, file_data)
+        if response.status_code != 201:
+            print "Did not get a 201 (Successfully Created) in upload request: "
+            return response
+
+        # There is successfully created code returned, verify the hashcodes
+        res_content = response.json()
+        md5 = hashlib.md5(file_data).hexdigest()
+        sha1 = hashlib.sha1(file_data).hexdigest()
+
+        if res_content['checksums']['md5'] != md5 or \
+            res_content['checksums']['sha1'] != sha1:
+            raise ValueError(
+                'Upload failure, the md5 or sha1 code returned'
+                ' does not match the local version.')
+        else:
+            print "{file} is uploaded successfully.".format(file=file_name)
+
+        return response
+
+    def remove_repository(self, repo_name):
+        """
+        remove all the contents under repository.
+        :param repo_name: the repository that will be deleted
+        :return:
+            instance of response
+            Raise any exceptions if encountered
+        """
+        url = "{base}/api/repositories/{repo}"\
+            .format(base=self.__artifactory_base, repo=repo_name)
+
+        response = self.__session.delete(url)
+        if response.status_code == 200:
+            print "Repository {repo} deleted successfully."\
+                .format(repo=repo_name)
+        else:
+            print "Did not delete the repository successfully."
+
+        return response
+

--- a/build-release-tools/lib/DebianBuilder.py
+++ b/build-release-tools/lib/DebianBuilder.py
@@ -95,6 +95,8 @@ class DebianBuilder(object):
             version_path = os.path.abspath(os.path.join(path, version_file))
             if os.path.exists(version_path):
                 task['data']['env_file'] = version_path
+
+            print "[Info] Execute command {0} for repo {1}.".format( command_name, repo )
             tasks.append(task)
 
         return tasks

--- a/build-release-tools/lib/DebianToolsOnArtifactory.py
+++ b/build-release-tools/lib/DebianToolsOnArtifactory.py
@@ -1,0 +1,256 @@
+"""
+This is a directory tool that contains the tool that uploads built debians
+ to the Artifactory.
+"""
+
+import os
+import requests
+
+try:
+    from ArtifactoryTools import JFrogArtifactory
+    from resultTool import RepositoryResult
+except ImportError as import_err:
+    print import_err
+    exit(1)
+
+class DebianToolsOnArtifactory(object):
+    """
+    A class that holds the tools that checks the debian and upload them to
+     correct repository.
+    """
+    def __init__(self, repo_name, top_dir_name, artifactory, distribution="trusty", component="main", architecture="amd64"):
+        """
+        Initializer of all the class variables.
+
+        :param repo_name: The repository that is already built on the
+            artifactory.
+        :param top_dir_name: The directory where all the build repositories
+            are cloned.
+        :param artifactory: the artifactory instance of ArtifactoryTools
+
+        :return: None on success.
+        """
+        self.set_repo_name(repo_name)
+        self.set_top_dir(top_dir_name)
+        self.set_artifactory(artifactory)
+        self.set_walk_depth(3)
+        self.set_debian_property( {"distribution":distribution,
+                                   "component":component,
+                                   "architecture":architecture} )
+
+    def __str__(self):
+        """
+        String representation of this class
+        :return: "Debian processor that uploads debians under\n {top_level_dir}
+         \nto\n{repository} \nat\n {artifact_loc}\n"
+        """
+        str = "Debian uploader work on {top_dir} \nto\n" \
+              "{rname} \n at \n {art_loc}\n"\
+            .format(top_dir=self.__top_dir, rname=self.__repo_name,
+                    art_loc=self.__artifactory.get_artifactory_url())
+        return str
+
+
+    def get_debian_property(self):
+        """
+        Getter of the debian package property
+        return: map based property list
+        """
+        return self.__deb_property
+
+    def set_debian_property(self, property_list ):
+        """
+        Setter for the debian package property
+        :param property_list  : the "distribution","component","architecture" proprety of the debian packages
+        :return None on success
+        """
+        self.__deb_property = property_list
+
+    def get_repo_name(self):
+        """
+        Getter of the repository name.
+        :return: string based repository name to upload to.
+        """
+        return self.__repo_name
+
+    def get_top_dir(self):
+        """
+        Getter of the top level directory.
+        :return: string based top level directory that it will work on.
+        """
+        return self.__top_dir
+
+    def set_repo_name(self, repo_name):
+        """
+        Setter for the repository name
+        :param repo_name: The repository that is already built on the
+            artifactory.
+
+        :return: None on success
+        """
+        self.__repo_name = repo_name
+
+    def set_top_dir(self, top_dir_name):
+        """
+        Setter for top level dir
+        :param top_dir_name: The directory where all the build repositories
+            are cloned.
+
+        :return: None on success.
+        """
+        self.__top_dir = os.path.abspath(top_dir_name)
+
+    def set_artifactory(self, artifactory):
+        """
+        Setter of the artifactory
+        :param artifactory: the instance of Artifactory Tools
+        :return: None on success
+        """
+        if isinstance(artifactory, JFrogArtifactory):
+            self.__artifactory = artifactory
+        else:
+            raise ValueError("artifactory should be an instance of Artifactory"
+                             " Tools")
+
+    def set_walk_depth(self, depth):
+        """
+        Set how deep you want the DebianTools to look into the top-level-dir
+         to look for debians
+
+        :param depth: integer for level of directories to look into.
+        :return: None on success
+        """
+        if depth > 0:
+            self.__walk_depth = depth
+        else:
+            raise ValueError("Please provide a positive integer for how depth "
+                             "do you want DebianTool to look into the top "
+                             "level directory")
+
+    def __upload_a_deb(self, deb_path):
+        """
+        Uploads a debian after encountered.
+        :param deb_path: absolute path of the debian file
+        :return: boolean is_good
+                True on successfully uploaded the debian file to artifactory.
+                False on otherwise
+        """
+        file_name = os.path.basename(deb_path)
+        repo_path = 'pool/'+file_name[0]
+        try:
+            response = self.__artifactory.upload_one_file(
+                deb_path,
+                self.__repo_name,
+                repo_path,
+                self.__deb_property["distribution"],
+                self.__deb_property["component"],
+                self.__deb_property["architecture"]  )
+
+            if response.status_code == 201:
+                print "status:{code}\ndetail:{detail}\n"\
+                    .format(code=response.status_code, detail=response.text)
+        except (IOError, ValueError, requests.RequestException) as err:
+            print "Error encountered during the uploading."
+            print err
+            return False
+
+        return True
+
+    def __upload_debs_in_a_repo(self, dir_repo):
+        """
+        Upload the debian under one repository directory.
+
+        It assumes that if a debian exists in the folder, then it must be
+        a successful build.
+
+        :param dir_repo: the location where the repository is cloned and the
+         debian(s) is/are built inside
+
+        :return:
+            (return_is_success, return_dict_detial)
+            return_is_success = True/False
+            return_dict_detail = {
+                <found_debian_name> : "Success"/"Fail"
+                                }
+                or {} if no debian is found.
+        """
+        return_is_success = True
+        return_dict_detail = {}
+        has_deb = False
+        top_dir_depth = dir_repo.count(os.path.sep) #How deep is at starting point
+        for root, dirs, files in os.walk(dir_repo, topdown=True):
+            root_depth = root.count(os.path.sep)
+            if (root_depth - top_dir_depth) <= self.__walk_depth:
+                for file_itr in files:
+                    if file_itr.endswith(".deb"):
+                        has_deb = True
+                        abs_file = os.path.abspath(os.path.join(root, file_itr))
+                        file_name = os.path.basename(file_itr)
+
+                        if self.__upload_a_deb(abs_file) is False:
+                            return_dict_detail[file_name] = "Fail"
+                            return_is_success = False
+                        else:
+                            return_dict_detail[file_name] = "Success"
+   
+            else:
+                dirs = [] # Stop iteration
+
+        if not has_deb:
+            print "No debians found under {dir}".format(dir=dir_repo)
+
+        return return_is_success, return_dict_detail
+
+    def upload_debs(self):
+        """
+        Iterate through the top-level-dir and check if there is debian
+        successful made then upload it to self.__repo_name and put it
+        under corresponding folder (/pool/<initial_alphabet>/).
+
+        It assumes that if a debian exists in the folder, then it is
+        a successful build. This code will not be called unless all the
+        per-directory build and test steps are succeed.
+
+        :return:
+            Instance of result class with a short is_success and a detail
+             dictionary here.
+            Raise other exceptions if encountered.
+        """
+        os.chdir(self.__top_dir)
+        repo_list = os.listdir(self.__top_dir)
+        print "Find following list of repository directories under {top}:" \
+              "{dir_list}".format(top=self.__top_dir, dir_list=repo_list)
+        return_is_okay = True
+        return_dict_detail = {}
+
+        for repo_itr in repo_list:
+            absp_repo = os.path.abspath(repo_itr)
+            repo_name = os.path.basename(repo_itr)
+            print "Checking {rname} at {pname}"\
+                .format(rname=repo_name, pname=absp_repo)
+            (itr_is_okay, itr_dict_detail) = \
+                self.__upload_debs_in_a_repo(absp_repo)
+            if itr_is_okay:
+                return_dict_detail[repo_name] = itr_dict_detail
+            else:
+                # If the upload is fail return immediately
+                return_is_okay = itr_is_okay
+                return_dict_detail[repo_name] = itr_dict_detail
+                raise DebianError(
+                    "Upload Failure at {deb}.\nDetails:{detail}"
+                    .format(deb=repo_itr, detail=itr_dict_detail))
+        result = RepositoryResult(return_is_okay, return_dict_detail)
+
+        return result
+
+class DebianErrorOnArtifactory(Exception):
+    """
+    Exception Class for raise when there is issue.
+    """
+    def __init__(self, msg):
+        super(DebianError, self).__init__(self)
+        self.msg = msg
+
+    def __str__(self):
+        return repr(self.msg)
+

--- a/build-release-tools/lib/resultTool.py
+++ b/build-release-tools/lib/resultTool.py
@@ -1,0 +1,86 @@
+"""
+This is a tool class holds the result of the iterating work of making
+    debians and uploading the debians during Jenkins build process.
+"""
+
+import json
+
+class RepositoryResult(object):
+    """
+    This is a tool class holds the result of the iterating work of making
+    debians and uploading the debians during Jenkins build process.
+    """
+    def __init__(self, bool_is_good, dict_detail):
+        """
+        Initializer of this class
+        :param bool_is_good: boolean whether this result means good or not.
+        :param dict_detail: dictionary representation of all the repositories
+        :return:
+        """
+        if type(bool_is_good).__name__ == "bool" \
+                and type(dict_detail).__name__ == "dict":
+            self.is_good = bool_is_good
+            self.dict_detail = dict_detail
+        else:
+            raise ResultException(
+                "Result need to be composed by a boolean value and dictionary "
+                "detail")
+
+    def __str__(self):
+        """
+        String representation of this result
+        :return: str_detail
+        """
+        if self.is_good:
+            return "Success"
+        else:
+            return "Fail"
+
+    @staticmethod
+    def str_detail(dict_res):
+        """
+        Static method to convert dictionary of detail result that used in
+        DebianTools and build_artifacts to a human friendly result string.
+
+        :param dict_detail: The 2 level result detail dictionary:
+            {
+            lev1_key : {
+                lev2_key : status
+                }
+            }
+
+            example:
+                in blind_build_all():
+                {
+                'on-cli' : {
+                    'HWIMO-TEST':'pass'/'fail'/'None',
+                    'HWIMO-BUILD':'pass'/'fail'/'None'
+                    }
+                }
+
+                in upload_debs():
+                {
+                'on-cli':{
+                    'a.deb':'Success',
+                    'b.deb':'Fail'
+                    },
+                'on-http': {}
+                }
+
+        :return: JSON string based representation of the dictionary
+        """
+        return json.dumps(dict_res, sort_keys=True, indent=4)
+
+    def detail(self):
+        return self.str_detail(self.dict_detail)
+
+class ResultException(Exception):
+    """
+    Exception Class to raise when there is issue.
+    """
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return repr(self.msg)
+

--- a/jobs/MasterCI/MasterCI
+++ b/jobs/MasterCI/MasterCI
@@ -12,7 +12,6 @@ node{
             "TESTS=${env.TESTS}",
             "OVA_POST_TESTS=${env.OVA_POST_TESTS}",
             "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-            "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
             "PUBLISH=${env.PUBLISH}",
             "OVA_CACHE_BUILD=true"
         ]){

--- a/jobs/MasterCI/PostTestDocker
+++ b/jobs/MasterCI/PostTestDocker
@@ -18,7 +18,6 @@ node{
         "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
         "TESTS=${env.TESTS}",
         "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-        "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
         "PUBLISH=${env.PUBLISH}"
         ])
     {

--- a/jobs/MasterCI/PostTestOVA
+++ b/jobs/MasterCI/PostTestOVA
@@ -18,8 +18,6 @@ node{
         "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
         "TESTS=${env.TESTS}",
         "OVA_POST_TESTS=${env.OVA_POST_TESTS}",
-        "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-        "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
         "PUBLISH=${env.PUBLISH}",
         "OVA_CACHE_BUILD=false"])
     {

--- a/jobs/SprintRelease/Jenkinsfile
+++ b/jobs/SprintRelease/Jenkinsfile
@@ -16,7 +16,6 @@ node{
             "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
             "OS_VER=${env.OS_VER}",
             "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-            "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
             "BINTRAY_REPO=binary"])
         {
             def message = "Job Name: ${env.JOB_NAME} \n" + "Build Full URL: ${env.BUILD_URL} \n" + "Phase: STARTED \n"

--- a/jobs/build_debian/build_debian.groovy
+++ b/jobs/build_debian/build_debian.groovy
@@ -5,6 +5,8 @@ node(build_debian_node){
             "IS_OFFICIAL_RELEASE=${env.IS_OFFICIAL_RELEASE}",
             "ARTIFACTORY_URL=${env.ARTIFACTORY_URL}",
             "STAGE_REPO_NAME=${env.STAGE_REPO_NAME}",
+            "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
+            "BINTRAY_REPO=debian",
             "DEB_COMPONENT=${env.DEB_COMPONENT}",
             "DEB_DISTRIBUTION=trusty",
             "DEB_ARCHITECTURE=amd64"]) {

--- a/jobs/build_debian/build_debian.groovy
+++ b/jobs/build_debian/build_debian.groovy
@@ -3,13 +3,11 @@ node(build_debian_node){
         withEnv([
             "MANIFEST_FILE_URL=${env.MANIFEST_FILE_URL}",
             "IS_OFFICIAL_RELEASE=${env.IS_OFFICIAL_RELEASE}",
-            "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-            "BINTRAY_REPO=debian",
-            "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
-            "CI_BINTRAY_REPO=debian",
-            "BINTRAY_COMPONENT=main",
-            "BINTRAY_DISTRIBUTION=trusty", 
-            "BINTRAY_ARCHITECTURE=amd64"]) {
+            "ARTIFACTORY_URL=${env.ARTIFACTORY_URL}",
+            "STAGE_REPO_NAME=${env.STAGE_REPO_NAME}",
+            "DEB_COMPONENT=${env.DEB_COMPONENT}",
+            "DEB_DISTRIBUTION=trusty",
+            "DEB_ARCHITECTURE=amd64"]) {
             deleteDir()
             dir("on-build-config"){
                 checkout scm
@@ -17,6 +15,10 @@ node(build_debian_node){
 
             // credentials are binding to Jenkins Server
             withCredentials([
+                usernamePassword(credentialsId: 'MN_ARTIFACTORY_CRED',
+                                 passwordVariable: 'ARTIFACTORY_PWD',
+                                 usernameVariable: 'ARTIFACTORY_USR'),
+
                 usernameColonPassword(credentialsId: "ff7ab8d2-e678-41ef-a46b-dd0e780030e1", 
                                       variable: "SUDO_CREDS"),
                 usernameColonPassword(credentialsId: "a94afe79-82f5-495a-877c-183567c51e0b", 

--- a/jobs/build_debian/build_debian.sh
+++ b/jobs/build_debian/build_debian.sh
@@ -2,9 +2,12 @@
 set -ex
 pushd $WORKSPACE
 
+LOCAL_BUILD_DIR=b
+echo "using Artifactory: " $ARTIFACTORY_URL
+
 curl --user $BINTRAY_CREDS -L "$MANIFEST_FILE_URL" -o rackhd-manifest
 ./on-build-config/build-release-tools/HWIMO-BUILD on-build-config/build-release-tools/application/make_debian_packages.py \
---build-directory b \
+--build-directory $LOCAL_BUILD_DIR \
 --manifest-file  rackhd-manifest \
 --sudo-credential SUDO_CREDS \
 --parameter-file downstream_file \
@@ -13,16 +16,22 @@ curl --user $BINTRAY_CREDS -L "$MANIFEST_FILE_URL" -o rackhd-manifest
 --is-official-release $IS_OFFICIAL_RELEASE \
 --bintray-credential BINTRAY_CREDS \
 --bintray-subject $BINTRAY_SUBJECT \
---bintray-repo $BINTRAY_REPO
+--bintray-repo $BINTRAY_REPO \
+--artifactory-url $ARTIFACTORY_URL \
+--artifactory-repo $STAGE_REPO_NAME \
+--artifactory-username $ARTIFACTORY_USR \
+--artifactory-password $ARTIFACTORY_PWD \
 
 
-./on-build-config/build-release-tools/HWIMO-BUILD on-build-config/build-release-tools/application/release_debian_packages.py \
---build-directory b/ \
---bintray-credential BINTRAY_CREDS \
---bintray-subject $CI_BINTRAY_SUBJECT \
---bintray-repo $CI_BINTRAY_REPO \
---bintray-component $BINTRAY_COMPONENT \
---bintray-distribution $BINTRAY_DISTRIBUTION \
---bintray-architecture $BINTRAY_ARCHITECTURE
+./on-build-config/build-release-tools/HWIMO-BUILD on-build-config/build-release-tools/application/upload_staging_deb_to_artifactory.py \
+--build-directory ${LOCAL_BUILD_DIR}/ \
+--artifactory-url $ARTIFACTORY_URL \
+--artifactory-repo $STAGE_REPO_NAME \
+--artifactory-username $ARTIFACTORY_USR \
+--artifactory-password $ARTIFACTORY_PWD \
+--deb-distribution $DEB_DISTRIBUTION \
+--deb-component  $DEB_COMPONENT \
+--deb-architecture $DEB_ARCHITECTURE
+
 
 popd

--- a/jobs/build_docker/build_docker.groovy
+++ b/jobs/build_docker/build_docker.groovy
@@ -2,13 +2,10 @@ node(build_docker_node){
     withEnv([
         "MANIFEST_FILE_URL=${env.MANIFEST_FILE_URL}",
         "IS_OFFICIAL_RELEASE=${env.IS_OFFICIAL_RELEASE}",
-        "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-        "BINTRAY_REPO=debian",
-        "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
-        "CI_BINTRAY_REPO=debian",
-        "BINTRAY_COMPONENT=main",
-        "BINTRAY_DISTRIBUTION=trusty",
-        "BINTRAY_ARCHITECTURE=amd64",
+        "ARTIFACTORY_URL=${env.ARTIFACTORY_URL}",
+        "STAGE_REPO_NAME=${env.STAGE_REPO_NAME}",
+        "DEB_COMPONENT=${env.DEB_COMPONENT}",
+        "DEB_DISTRIBUTION=trusty",
         "CLONE_DIR=b"]){
         deleteDir()
         def current_workspace = pwd()

--- a/jobs/build_docker/build_docker.sh
+++ b/jobs/build_docker/build_docker.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #download manifest
 curl --user $BINTRAY_CREDS -L "$MANIFEST_FILE_URL" -o rackhd-manifest
+echo using artifactory : $ARTIFACTORY_URL
 
 #clone
 ./build-config/build-release-tools/HWIMO-BUILD ./build-config/build-release-tools/application/reprove.py \

--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -44,7 +44,7 @@ find ./ -type f -exec sed -i -e "s/172.31.128.1/$DOCKER_RACKHD_IP/g" {} \;
 popd
 
 # this step must behind sed replace
-cd $RackHD_DIR/docker
+pushd $RackHD_DIR/docker
 # replace default config json with the one which is for test.
 cp -f ${WORKSPACE}/build-config/vagrant/config/mongo/config.json ./monorail/config.json
 #if clone file name is not repo name, this scirpt should be edited.
@@ -60,4 +60,4 @@ docker pull rabbitmq:management
 set -e
 
 docker-compose -f docker-compose-mini.yml up > $WORKSPACE/build-log/vagrant.log &
-
+popd

--- a/jobs/build_ova/build_ova.groovy
+++ b/jobs/build_ova/build_ova.groovy
@@ -25,13 +25,10 @@ lock("ova_build"){
                     "OVA_CACHE_BUILD=${env.OVA_CACHE_BUILD}",
                     "OS_VER=${env.OS_VER}",
                     "BUILD_TYPE=vmware", 
-                    "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-                    "BINTRAY_REPO=debian",
-                    "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
-                    "CI_BINTRAY_REPO=debian", 
-                    "BINTRAY_COMPONENT=main", 
-                    "BINTRAY_DISTRIBUTION=trusty", 
-                    "BINTRAY_ARCHITECTURE=amd64"]){
+                    "ARTIFACTORY_URL=${env.ARTIFACTORY_URL}",
+                    "STAGE_REPO_NAME=${env.STAGE_REPO_NAME}",
+                    "DEB_COMPONENT=${env.DEB_COMPONENT}",
+                    "DEB_DISTRIBUTION=trusty"]) {
                     def current_workspace = pwd()
                     deleteDir()
                     dir("on-build-config"){

--- a/jobs/build_ova/build_ova.sh
+++ b/jobs/build_ova/build_ova.sh
@@ -11,15 +11,24 @@ fi
 
 vmware -v
 
-cd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
-sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main#" main.yml
-sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main#" main.yml
-cd ..
+echo using artifactory : $ARTIFACTORY_URL
+
+pushd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
+sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
+sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
+popd
+
+echo "kill previous running packer instances"
+
+set +e
 pkill packer
 pkill vmware
-
 set -e
-cd $WORKSPACE/build/packer
+
+pushd $WORKSPACE/build/packer 
+echo "Start to packer build .."
+
+export PACKER_CACHE_DIR=$HOME/.packer_cache
 #export vars to build ova
 if [ "${IS_OFFICIAL_RELEASE}" == true ]; then
     export ANSIBLE_PLAYBOOK=rackhd_release
@@ -41,4 +50,6 @@ export RACKHD_VERSION=$RACKHD_VERSION
 ./HWIMO-BUILD
 
 mv rackhd-${OS_VER}.ova rackhd-${OS_VER}-${RACKHD_VERSION}.ova
+
+popd
 

--- a/jobs/build_ova/build_ova.sh
+++ b/jobs/build_ova/build_ova.sh
@@ -13,6 +13,15 @@ vmware -v
 
 echo using artifactory : $ARTIFACTORY_URL
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/../../shareMethod.sh
+# check variable readiness
+if   ! check_empty_variable "STAGE_REPO_NAME" ||  ! check_empty_variable "DEB_DISTRIBUTION"   || ! check_empty_variable "DEB_COMPONENT"  ; then
+    echo "[Error] Parameter Missing , refer error message as above.."
+    exit 2
+fi
+
+
 pushd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml

--- a/jobs/build_ova/prepare_ova_post_test.sh
+++ b/jobs/build_ova/prepare_ova_post_test.sh
@@ -7,7 +7,8 @@
 #   2. Gateway, connect to external net through $OVA_NET_INTERFACE(eth1) with $OVA_GATEWAY IP
 
 set -x
-source ${WORKSPACE}/build-config/shareMethod.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/../../shareMethod.sh
 # If using a passed in ova file from an external http server and bypassing ova build,
 # use the path as is, else get the path via ls
 if [[ "${OVA_PATH}" == "http"* ]]; then

--- a/jobs/build_vagrant/build_vagrant.groovy
+++ b/jobs/build_vagrant/build_vagrant.groovy
@@ -6,7 +6,6 @@ node{
     shareMethod = load("jobs/ShareMethod.groovy")
 }
 
-
 lock("vagrant_build"){
     String label_name = "packer_vagrant"
     lock(label:label_name,quantity:1){
@@ -23,14 +22,11 @@ lock("vagrant_build"){
                 "RACKHD_VERSION=${env.RACKHD_VERSION}",
                 "IS_OFFICIAL_RELEASE=${env.IS_OFFICIAL_RELEASE}",
                 "OS_VER=${env.OS_VER}",
+                "ARTIFACTORY_URL=${env.ARTIFACTORY_URL}",
+                "STAGE_REPO_NAME=${env.STAGE_REPO_NAME}",
                 "BUILD_TYPE=virtualbox",
-                "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-                "BINTRAY_REPO=debian",
-                "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
-                "CI_BINTRAY_REPO=debian",
-                "BINTRAY_COMPONENT=main", 
-                "BINTRAY_DISTRIBUTION=trusty", 
-                "BINTRAY_ARCHITECTURE=amd64"]){
+                "DEB_COMPONENT=${env.DEB_COMPONENT}",
+                "DEB_DISTRIBUTION=trusty"]){
                 def current_workspace = pwd()
                 deleteDir()
                 dir("on-build-config"){

--- a/jobs/build_vagrant/build_vagrant.sh
+++ b/jobs/build_vagrant/build_vagrant.sh
@@ -30,6 +30,18 @@ if [ -d  $WORKSPACE/cache_image/RackHD/packer/ ] ; then
      ls $WORKSPACE/build/packer/*
 fi
 
+
+echo using artifactory : $ARTIFACTORY_URL
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${DIR}/../../shareMethod.sh
+# check variable readiness
+if   ! check_empty_variable "STAGE_REPO_NAME" ||  ! check_empty_variable "DEB_DISTRIBUTION"   || ! check_empty_variable "DEB_COMPONENT"  ; then
+        echo "[Error] Parameter Missing , refer error message as above.."
+        exit 2
+fi
+
+
 pushd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml

--- a/jobs/pr_gate/on-build-config/Jenkinsfile
+++ b/jobs/pr_gate/on-build-config/Jenkinsfile
@@ -15,7 +15,6 @@ node{
         "TESTS=${env.TESTS}",
         "OVA_POST_TESTS=${env.OVA_POST_TESTS}",
         "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
-        "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
         "PUBLISH=false"
     ]){
         deleteDir()

--- a/shareMethod.sh
+++ b/shareMethod.sh
@@ -39,5 +39,26 @@ execWithTimeout() {
     fi
     set -e
 }
+####################################3
+#
+# To Check if a Shell Variable or Env Variable is empty or null (Jenkins Parameter but not set)
+#
+# $1; the variable name
+#
+# return 0: not empty
+# return 1: empty or null
+###################################
+check_empty_variable(){
+    if [ -n "$1" ] ; then
+          # ${!1} will dereference the variable value
+          if [ "${!1}" == "" ] || [ "${!1}" == "null" ]; then
+              echo "[Error] Env Variable $1 is missing "
+              return 1
+          fi
+    else
+          echo "[Warning] Wrong usage of $0"
+    fi
+    return 0
+}
 
 


### PR DESCRIPTION
depends on https://github.com/RackHD/on-build-config/pull/258

reopen for https://github.com/RackHD/on-build-config/pull/156



**Background**
https://rackhd.atlassian.net/browse/RAC-4783

in pipeline, Between deb-build and ova/vagrant-build, there should be somewhere to store the temp debian packages.
aka, after deb-build done, the build packages should be in a deb repo registry,
so in next ova or vagrant build, they can apt-get install the packages from above deb repo registry.
![image](https://cloud.githubusercontent.com/assets/14049268/25330622/de2dc69a-2912-11e7-975f-02bab7747dae.png)

Previously, bintray rackhd-mirror is used to serve this purpose. but it's not how bintray should be used.

**Solution**
use EMC Internal MN Lab Artifactory as the replacement.
say, 
(a) after deb-build done, upload packages to artifactory
(b) during packer build, use artifactory as the apt-source


**Review Tips**
soooo long PR to be review ?? No....

(1) Below files are **copied** from original OnRack EOS2GitHub repo (```OnRack/release-tools/lib```) 😁 
```
build-release-tools/lib/ArtifactoryTools.py
build-release-tools/lib/DebianToolsOnArtifactory.py
build-release-tools/lib/resultTool.py
```
add a is_version_exist() function in  ArtifactoryTools.py


(2) below files is modified based on ```OnRack/release-tools/bin/make-debian-release.py```
```build-release-tools/application/upload_staging_deb_to_artifactory.py```

(3) below two files are modified to use new script of above and new creds of MN artifactory
```
jobs/build_debian/build_debian.groovy
jobs/build_debian/build_debian.sh
```



(4) Modify OVA/vagrant/docker where  the staging apt resource are configured
"Hack" ansible steps of packer provision, to intercept the apt source to Artifactory.
because EMC Artifactory CA setup, it requires additional steps to add CA cetification.
```
jobs/build_docker/build_docker.groovy
jobs/build_docker/build_docker.sh
jobs/build_ova/build_ova.groovy
jobs/build_ova/build_ova.sh
jobs/build_vagrant/build_vagrant.groovy
jobs/build_vagrant/build_vagrant.sh
```

(5) the *deb cache* should also be changed.
![image](https://cloud.githubusercontent.com/assets/14049268/25331056/4a2fe0de-2914-11e7-81b0-4d6f0b1528ac.png)
code change in 
```
build-release-tools/application/make_debian_packages.py
```

**Test Done**
Experimental pipeline running on SH Jenkins sandbox  http://10.**.**.175:8080/job/Master-CI-RAC-4783/
it has been run for 8 days , about ~50 runs (good builds starts from build 66, the errors of later builds are due to different reason like sandbox vagrant issue . but the apt-tmp-repo functions are all good.)


**Reviewer**
@PengTian0  @changev   @johren 