### PR TITLE
docker post smoke test

### DIFF
--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -72,11 +72,11 @@ doBuild() {
                 TAG=:${PKG_TAG}
             fi
             echo "Building rackhd/$repo$TAG"
-            repos_tags=$repos_tags$repo$TAG" "
+            repos_tags=$repos_tags"rackhd/"$repo$TAG" "
             cp Dockerfile ../Dockerfile.bak
             if [ "$repo" == "on-imagebuilder" ]; then
                     docker build -t rackhd/files$TAG .
-                    repos_tags=files$TAG" "
+                    repos_tags="rackhd/files"$TAG" "
             elif [ "$repo" != "on-core" ];then
                     #Based on newly build upstream image to build
                     sed -i "/^FROM/ s/:devel/${PRE_TAG}/" Dockerfile

--- a/jobs/FunctionTest/cleanup.sh
+++ b/jobs/FunctionTest/cleanup.sh
@@ -58,6 +58,68 @@ cleanupENVProcess() {
   fi
 }
 
+
+
+clean_up_docker_image(){
+    # parameter : the images keyword to be delete
+    keyword=$1
+    images=`docker images | grep ${keyword} | awk '{print $3}' | sort | uniq`
+    if [ -n "$images" ]; then
+        docker rmi -f $images
+    fi
+}
+
+clean_running_containers() {
+    local containers=$(docker ps -a -q)
+    if [ "$containers" != "" ]; then
+        echo "Clean Up containers : " ${containers}
+        docker stop ${containers}
+        docker rm  ${containers}
+    fi
+}
+
+cleanupDocker(){
+  # Clean UP. (was in Jenkins job post-build, avoid failure impacts build status.)
+  set +e
+  set -x
+  echo "Show local docker images"
+  docker ps
+  docker images
+  echo "Stop & rm all docker running containers " 
+  clean_running_containers
+  echo "Chown rackhd/files volume on hosts"
+  echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER $WORKSPACE/RackHD 
+  echo "Clean Up all docker images in local repo"
+  clean_up_docker_image none
+  # clean images by order, on-core should be last one because others depends on it
+  clean_up_docker_image on-taskgraph
+  clean_up_docker_image on-http
+  clean_up_docker_image on-tftp
+  clean_up_docker_image on-dhcp-proxy
+  clean_up_docker_image on-syslog
+  clean_up_docker_image on-tasks
+  clean_up_docker_image files
+  clean_up_docker_image isc-dhcp-server
+  clean_up_docker_image on-wss
+  clean_up_docker_image on-statsd
+  clean_up_docker_image on-core
+  clean_up_docker_image rackhd
+
+  echo "clean up /var/lib/docker/volumes"
+  docker volume ls -qf dangling=true | xargs -r docker volume rm
+ +
+
+}
+
+# in jobs/build_docker/prepare_docker_post_test.sh the 2 services were stopped
+# run "service start" here to ensure the 2 services is normal after testing
+restart3rdServices(){
+  echo $SUDO_PASSWORD |sudo -S service mongodb start
+  echo $SUDO_PASSWORD |sudo -S service rabbitmq-server start
+}
+
 cleanupVMs
 nodesDelete
 cleanupENVProcess
+cleanupDocker
+restart3rdServices

--- a/jobs/FunctionTest/prepare_common.sh
+++ b/jobs/FunctionTest/prepare_common.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -ex
+export VCOMPUTE=("${NODE_NAME}-Rinjin1","${NODE_NAME}-Rinjin2","${NODE_NAME}-Quanta")
+
+VCOMPUTE="${VCOMPUTE}"
+if [ -z "${VCOMPUTE}" ]; then
+  VCOMPUTE=("jvm-Quanta_T41-1" "jvm-vRinjin-1" "jvm-vRinjin-2")
+fi
+
+
+nodesDelete() {
+  cd ${WORKSPACE}/build-config/deployment/
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    VCOMPUTE+=("${NODE_NAME}-ova-for-post-test")
+    for i in ${VCOMPUTE[@]}; do
+      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},delete,1,${i}_*"
+    done
+  fi
+}
+
+cleanupENVProcess() {
+  # Kill possible socat process left by ova-post-smoke-test
+  # eliminate the effect to other test
+  socat_process=`ps -ef | grep socat | grep -v grep | awk '{print $2}' | xargs`
+  if [ -n "$socat_process" ]; then
+    kill $socat_process
+  fi
+}
+
+clean_running_containers() {
+    local containers=$(docker ps -a -q)
+    if [ "$containers" != "" ]; then
+        echo "Clean Up containers : " ${containers}
+        docker stop ${containers}
+        docker rm  ${containers}
+    fi
+}
+
+if [ "$SKIP_PREP_DEP" == false ] ; then
+  # Prepare the latest dependent repos to be shared with vagrant
+  nodesDelete
+  cleanupENVProcess
+  clean_running_containers
+fi

--- a/jobs/FunctionTest/prepare_manifest.sh
+++ b/jobs/FunctionTest/prepare_manifest.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -ex
-export VCOMPUTE=("${NODE_NAME}-Rinjin1","${NODE_NAME}-Rinjin2","${NODE_NAME}-Quanta")
 REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog")
 
 HTTP_STATIC_FILES="${HTTP_STATIC_FILES}"
@@ -75,11 +74,10 @@ preparePackages() {
         popd
     done
 
-
     cp -r build-deps/RackHD .
     if [ -d "build-deps/on-build-config" ]; then
-      # on-build-config from manifest has high priority
-      cp -r build-deps/on-build-config build-config
+        # on-build-config from manifest has high priority
+        cp -r build-deps/on-build-config build-config
     fi
     popd
 }
@@ -90,37 +88,7 @@ prepareDeps(){
   dlHttpFiles
 }
 
-VCOMPUTE="${VCOMPUTE}"
-if [ -z "${VCOMPUTE}" ]; then
-  VCOMPUTE=("jvm-Quanta_T41-1" "jvm-vRinjin-1" "jvm-vRinjin-2")
-fi
-
-
-nodesDelete() {
-  cd ${WORKSPACE}/build-config/deployment/
-  if [ "${USE_VCOMPUTE}" != "false" ]; then
-    if [ $TEST_TYPE == "ova" ]; then
-      VCOMPUTE+=("${NODE_NAME}-ova-for-post-test")
-    fi
-    for i in ${VCOMPUTE[@]}; do
-      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},delete,1,${i}_*"
-    done
-  fi
-}
-
-cleanupENVProcess() {
-  # Kill possible socat process left by ova-post-smoke-test
-  # eliminate the effect to other test
-  socat_process=`ps -ef | grep socat | grep -v grep | awk '{print $2}' | xargs`
-  if [ -n "$socat_process" ]; then
-    kill $socat_process
-  fi
-}
-
 if [ "$SKIP_PREP_DEP" == false ] ; then
   # Prepare the latest dependent repos to be shared with vagrant
   prepareDeps
-  nodesDelete
-  cleanupENVProcess
 fi
-

--- a/jobs/MasterCI/MasterCI
+++ b/jobs/MasterCI/MasterCI
@@ -32,6 +32,7 @@ node{
 
             def repo_dir = pwd()
             def TESTS = "${env.TESTS}"
+            def test_type = "manifest"
             // Create an instance of UnitTest/UnitTest.groovy
             def unit_test = load("jobs/UnitTest/UnitTest.groovy")
             // Create an instance of FunctionTest/FunctionTest.groovy
@@ -44,11 +45,11 @@ node{
                 }
                 stage("Function Test"){
                     // Call the function run to run function test
-                    function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir)
+                    function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir, test_type)
                 }
             } finally{
                 unit_test.archiveArtifactsToTarget("UnitTest")
-                function_test.archiveArtifactsToTarget("FunctionTest")
+                function_test.archiveArtifactsToTarget("FunctionTest", TESTS, test_type)
             }
             Boolean create_tag = false
             Boolean publish = PUBLISH.toBoolean()

--- a/jobs/ShareMethod.groovy
+++ b/jobs/ShareMethod.groovy
@@ -79,7 +79,7 @@ def buildImages(String repo_dir){
             load(repo_dir + "/jobs/build_vagrant/vagrant_post_test.groovy")
         }, 'ova post test loader':{
             load(repo_dir + "/jobs/build_ova/ova_post_test.groovy")
-        }, 'docker post test':{
+        }, 'docker post test loader':{
             load(repo_dir + "/jobs/build_docker/docker_post_test.groovy")
         }
     }
@@ -107,26 +107,14 @@ def createTag(String repo_dir){
 
 def buildAndPublish(Boolean publish, Boolean tag, String repo_dir){
     buildPackage(repo_dir)
-    // lock a docker resource from build to release
-    lock(label:"docker",quantity:1){
-        def lock_resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())       
-        docker_resources_name = getLockedResourceName(lock_resources,"docker")
-        if(docker_resources_name.size>0){
-            env.build_docker_node = docker_resources_name[0]
-        }
-        else{
-            echo "Failed to find resource with label docker"
-            currentBuild.result="FAILURE"
-        }
 
-        buildImages(repo_dir)
+    buildImages(repo_dir)
 
-        if(tag){
-            createTag(repo_dir)
-        }
-        if(publish){
-            publishImages(repo_dir)
-        }
+    if(tag){
+        createTag(repo_dir)
+    }
+    if(publish){
+        publishImages(repo_dir)
     }
 }
 

--- a/jobs/SprintRelease/Jenkinsfile
+++ b/jobs/SprintRelease/Jenkinsfile
@@ -46,6 +46,7 @@ node{
 
             def repo_dir = pwd()
             def TESTS = "${env.TESTS}"
+            def test_type = "manifest"
             // Create an instance of UnitTest/UnitTest.groovy   
             def unit_test = load("jobs/UnitTest/UnitTest.groovy")
             // Create an instance of FunctionTest/FunctionTest.groovy
@@ -57,11 +58,11 @@ node{
                 }
                 stage("Function Test"){
                     // Call the function run to run function test
-                    function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir)
+                    function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir, test_type)
                 }
             } finally{
                 unit_test.archiveArtifactsToTarget("UnitTest")
-                function_test.archiveArtifactsToTarget("FunctionTest")
+                function_test.archiveArtifactsToTarget("FunctionTest", TESTS, test_type)
             }
             Boolean create_tag = TAG.toBoolean()
             Boolean publish = PUBLISH.toBoolean()
@@ -71,4 +72,3 @@ node{
         }
     }
 }
-

--- a/jobs/SprintTag/Jenkinsfile
+++ b/jobs/SprintTag/Jenkinsfile
@@ -21,7 +21,7 @@ node{
     def unit_test = load("jobs/UnitTest/UnitTest.groovy")
     // Create an instance of FunctionTest/FunctionTest.groovy
     def function_test = load("jobs/FunctionTest/FunctionTest.groovy")
-
+    def test_type = "manifest"
     def retry_times = Integer.valueOf(env.Test_Time);
     int failed_times = 0
     for (int i=0; i < retry_times; i++) {
@@ -31,14 +31,14 @@ node{
                 unit_test.runTest(env.stash_manifest_name, env.stash_manifest_path, repo_dir)
             }
             stage("Function Test${i}"){
-                function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir)
+                function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir, test_type)
             }
         } catch(error){
             echo "Caught: ${error}"
             failed_times += 1
         } finally{
             unit_test.archiveArtifactsToTarget("UnitTest${i}")
-            function_test.archiveArtifactsToTarget("FunctionTest${i}")
+            function_test.archiveArtifactsToTarget("FunctionTest${i}", TESTS, test_type)
         }
     }
 

--- a/jobs/build_docker/build_docker.groovy
+++ b/jobs/build_docker/build_docker.groovy
@@ -27,9 +27,14 @@ node(build_docker_node){
                         sh './build-config/jobs/build_docker/build_docker.sh'
                     }
                 }
+                archiveArtifacts 'rackhd_docker_images.tar, build_record'
+                stash name: 'docker', includes: 'rackhd_docker_images.tar, build_record'
+                env.DOCKER_WORKSPACE="${current_workspace}"
+                env.DOCKER_STASH_NAME="docker"
+                env.DOCKER_STASH_PATH="rackhd_docker_images.tar"
+                env.DOCKER_RECORD_STASH_PATH="build_record"
             }
             env.DOCKER_WORKSPACE="${current_workspace}"
         }
     }
 }
-

--- a/jobs/build_docker/build_docker.sh
+++ b/jobs/build_docker/build_docker.sh
@@ -40,6 +40,15 @@ popd
 echo $SUDO_PASSWORD |sudo -S apt-get --yes --force-yes remove on-imagebuilder
 
 #docker images build
-cd build-config/build-release-tools/
+pushd build-config/build-release-tools/
 ./docker_build.sh $WORKSPACE/$CLONE_DIR $IS_OFFICIAL_RELEASE
-mv $WORKSPACE/$CLONE_DIR/build_record $WORKSPACE
+cp $WORKSPACE/$CLONE_DIR/build_record $WORKSPACE
+popd
+
+# save docker image to tar
+image_list=`cat $WORKSPACE/$CLONE_DIR/build_record | xargs`
+
+docker save -o rackhd_docker_images.tar $image_list
+
+# copy build_record to current directory for stash
+cp $WORKSPACE/$CLONE_DIR/build_record .

--- a/jobs/build_docker/docker_post_test.groovy
+++ b/jobs/build_docker/docker_post_test.groovy
@@ -1,30 +1,26 @@
-node(build_docker_node){
+node{
     timestamps{
-        withEnv(["WORKSPACE=${env.DOCKER_WORKSPACE}"]){
-            dir("build-config"){
-                checkout scm
-            }
-            withCredentials([
-                usernamePassword(credentialsId: 'ff7ab8d2-e678-41ef-a46b-dd0e780030e1',
-                                 passwordVariable: 'SUDO_PASSWORD',
-                                 usernameVariable: 'SUDO_USER')]
-            ){
-                timeout(90){
-                    sh '''#!/bin/bash
-                    set -e
-                    set +x
-                    #in docker post-test, the workspace/RackHD/docker/files folder will be owned by "root" since it's run as sudo. So it should be removed by root as clean up.
-                    trap "echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER $WORKSPACE/build" SIGINT SIGTERM SIGKILL EXIT
-
-
-                    bash $WORKSPACE/build-config/build-release-tools/post_test.sh \
-                    --type docker \
-                    --RackHDDir $WORKSPACE/build \
-                    --buildRecord $WORKSPACE/build_record
-                    '''
+            checkout scm
+            def function_test = load("jobs/FunctionTest/FunctionTest.groovy")
+            def repo_dir = pwd()
+            def TESTS = "${env.DOCKER_POST_TESTS}"
+            def test_type = "docker"
+            try {
+                withCredentials([
+                    usernamePassword(credentialsId: 'ff7ab8d2-e678-41ef-a46b-dd0e780030e1',
+                                    passwordVariable: 'SUDO_PASSWORD',
+                                    usernameVariable: 'SUDO_USER')]
+                ){
+                    def DOCKER_STASH_NAME = "${env.DOCKER_STASH_NAME}"
+                    def DOCKER_STASH_PATH = "${env.DOCKER_STASH_PATH}"
+                    def DOCKER_RECORD_STASH_PATH = "${env.DOCKER_RECORD_STASH_PATH}"
+                    function_test.dockerPostTest(TESTS, DOCKER_STASH_NAME, DOCKER_STASH_PATH, DOCKER_RECORD_STASH_PATH, repo_dir, test_type)
                 }
+            } catch(error){
+                echo "Caught: ${error}"    
+                currentBuild.result = "FAILURE"
+            } finally{
+                function_test.archiveArtifactsToTarget("DOCKER_POST_SMOKE_TEST", TESTS, test_type)
             }
-        }
     }
 }
-

--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash 
+set -x
+set -e
+
+# Stop host mongo and rabbitmq service
+# otherwise mongo and rabbitmq service won't run normally
+# use host mongo and rabbitmq is a chioce but the coverage may be decreased.
+# services will be restart in cleanup.sh, which script will always be executed.
+echo $SUDO_PASSWORD |sudo -S service mongodb stop
+echo $SUDO_PASSWORD |sudo -S service rabbitmq-server stop
+
+rackhd_docker_images=`ls ${DOCKER_PATH}`
+build_record=`ls ${DOCKER_RECORD_PATH}`
+
+# load docker images
+docker load -i $rackhd_docker_images
+image_list=`head -n 1 $build_record`
+
+pushd $BUILD_CONFIG_DIR
+find ./ -type f -exec sed -i -e "s/172.31.128.1/$DOCKER_RACKHD_IP/g" {} \;
+popd
+
+pushd $RackHD_DIR/test
+# in vagrant or ova， rackhd ip are all default  172.31.128.1
+# but for docker containers it‘s hard to virtualize such a IP
+# so replace it with DOCKER_RACKHD_IP which is usually the eth1 IP of vmslave
+find ./ -type f -exec sed -i -e "s/172.31.128.1/$DOCKER_RACKHD_IP/g" {} \;
+popd
+
+# this step must behind sed replace
+cd $RackHD_DIR/docker
+# replace default config json with the one which is for test.
+cp -f ${WORKSPACE}/build-config/vagrant/config/mongo/config.json ./monorail/config.json
+#if clone file name is not repo name, this scirpt should be edited.
+for repo_tag in $image_list; do
+    repo=${repo_tag%:*}
+    sed -i "s#${repo}.*#${repo_tag}#g" docker-compose-mini.yml
+done
+
+mkdir -p $WORKSPACE/build-deps
+docker-compose -f docker-compose-mini.yml up > $WORKSPACE/build-deps/vagrant.log &
+

--- a/jobs/build_ova/ova_post_test.groovy
+++ b/jobs/build_ova/ova_post_test.groovy
@@ -10,18 +10,26 @@ node(){
             checkout scm
             def function_test = load("jobs/FunctionTest/FunctionTest.groovy")
             def repo_dir = pwd()
-            withCredentials([
-                usernamePassword(credentialsId: 'OVA_CREDS', 
-                                    passwordVariable: 'OVA_PASSWORD', 
-                                    usernameVariable: 'OVA_USER'),
-                string(credentialsId: 'vCenter_IP', variable: 'VCENTER_IP'), 
-                string(credentialsId: 'Deployed_OVA_INTERNAL_IP', variable: 'OVA_INTERNAL_IP')
-                ]) {
-                // Start to run test
-                def TESTS = "${env.OVA_POST_TESTS}"
-                def OVA_STASH_NAME = "${env.OVA_STASH_NAME}"
-                def OVA_STASH_PATH = "${env.OVA_PATH}"
-                function_test.ovaPostTest(TESTS, OVA_STASH_NAME, OVA_STASH_PATH, repo_dir)
+            def TESTS = "${env.OVA_POST_TESTS}"
+            def test_type = "ova"
+            try{
+                withCredentials([
+                    usernamePassword(credentialsId: 'OVA_CREDS', 
+                                        passwordVariable: 'OVA_PASSWORD', 
+                                        usernameVariable: 'OVA_USER'),
+                    string(credentialsId: 'vCenter_IP', variable: 'VCENTER_IP'), 
+                    string(credentialsId: 'Deployed_OVA_INTERNAL_IP', variable: 'OVA_INTERNAL_IP')
+                    ]) {
+                    // Start to run test
+                    def OVA_STASH_NAME = "${env.OVA_STASH_NAME}"
+                    def OVA_STASH_PATH = "${env.OVA_PATH}"
+                    function_test.ovaPostTest(TESTS, OVA_STASH_NAME, OVA_STASH_PATH, repo_dir, test_type)
+                }
+            }catch(error){
+                echo "Caught: ${error}"    
+                currentBuild.result = "FAILURE"
+            }finally{
+                function_test.archiveArtifactsToTarget("OVA_POST_TEST", TESTS, test_type)
             }
         }
     }

--- a/jobs/pr_gate/Jenkinsfile
+++ b/jobs/pr_gate/Jenkinsfile
@@ -6,7 +6,8 @@ node{
     def repo_dir = pwd()
     def prgate_unit_test = load("jobs/UnitTest/PRGateUnitTest.groovy")
     def function_test = load("jobs/FunctionTest/FunctionTest.groovy")
-
+    def TESTS = "${env.TESTS}"
+    def test_type = "manifest"
     try{
         stage("Parse Pull Request"){
             load("jobs/pr_gate/pr_parser.groovy")
@@ -16,15 +17,14 @@ node{
         }
         stage("Function Test"){
             // Start to run test
-            def TESTS = "${env.TESTS}"
-            function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir)
+            function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir, test_type)
         }
     } catch(error){
         echo "Caught: ${error}"    
         currentBuild.result = "FAILURE"
     } finally{
         unit_test.archiveArtifactsToTarget("UnitTest")
-        function_test.archiveArtifactsToTarget("FunctionTest")
+        function_test.archiveArtifactsToTarget("FunctionTest", TESTS, test_type)
         stage("Write Back"){
             load("jobs/write_back_github/write_back_github.groovy")
         }

--- a/jobs/release/release_docker.groovy
+++ b/jobs/release/release_docker.groovy
@@ -3,6 +3,9 @@ node(build_docker_node){
         dir("on-build-config"){
             checkout scm
         }
+        dir("DOCKER"){
+            unstash env.DOCKER_STASH_NAME
+        }
         withCredentials([
             usernamePassword(credentialsId: 'da1e60c6-f23a-429d-b0f5-19e3b287f5dc', 
                              passwordVariable: 'DOCKERHUB_PASS', 

--- a/jobs/release/release_docker.sh
+++ b/jobs/release/release_docker.sh
@@ -3,20 +3,21 @@ set -e
 # Environmental requirement:
 # docker service running and docker have already logged with Rackhd Dockerhub ID,
 #     cmd 'docker login', if not logged then can't push images to dockerhub
-
+cd DOCKER
+docker load -i $DOCKER_STASH_PATH
 docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASS
 
 while read -r LINE; do
         echo $LINE
         for repo_tag in $LINE; do
                 echo "Pushing rackhd/$repo_tag"
-        docker push rackhd/$repo_tag
+        docker push $repo_tag
         if [ $? != 0 ]; then
                 echo "Failed to push rackhd/$repo_tag"
             exit 1
         fi
     done
-done < $WORKSPACE/build_record
+done < $DOCKER_RECORD_STASH_PATH
 
 # Clean UP. (was in Jenkins job post-build, avoid failure impacts build status.)
 set +e

--- a/test.sh.in
+++ b/test.sh.in
@@ -207,6 +207,7 @@ generateSysLog(){
   vagrant ssh -c 'dmesg > /home/vagrant/src/dmesg.log'
   vagrant ssh -c 'cp /var/log/syslog /home/vagrant/src/syslog.log'
 }
+
 setupVirtualEnv(){
   pushd ${WORKSPACE}/RackHD/test
   rm -rf .venv/on-build-config
@@ -280,11 +281,11 @@ waitForAPI() {
 portForwarding(){
     # forward ova to localhost
     # according to vagrant/mongo/config.json and cit/fit config
-    socat TCP4-LISTEN:9091,forever,reuseaddr,fork TCP4:${OVA_INTERNAL_IP}:5672 &
-    socat TCP4-LISTEN:9090,forever,reuseaddr,fork TCP4:${OVA_INTERNAL_IP}:8080 &
-    socat TCP4-LISTEN:9092,forever,reuseaddr,fork TCP4:${OVA_INTERNAL_IP}:9080 &
-    socat TCP4-LISTEN:9093,forever,reuseaddr,fork TCP4:${OVA_INTERNAL_IP}:8443 &
-    socat TCP4-LISTEN:2222,forever,reuseaddr,fork TCP4:${OVA_INTERNAL_IP}:22 &
+    socat TCP4-LISTEN:9091,forever,reuseaddr,fork TCP4:$1:5672 &
+    socat TCP4-LISTEN:9090,forever,reuseaddr,fork TCP4:$1:8080 &
+    socat TCP4-LISTEN:9092,forever,reuseaddr,fork TCP4:$1:9080 &
+    socat TCP4-LISTEN:9093,forever,reuseaddr,fork TCP4:$1:8443 &
+    socat TCP4-LISTEN:2222,forever,reuseaddr,fork TCP4:$1:22 &
     echo "Finished ova -> localhost port forwarding"
     echo "5672->9091"
     echo "8080->9090"
@@ -318,7 +319,7 @@ if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
     
     # Prepare RackHD
     # Forward local host port to ova
-    portForwarding
+    portForwarding ${OVA_INTERNAL_IP}
 
     # We setup the virtual-environment here, since once we
     # call "nodesOn", it's a race to get to the first test
@@ -339,6 +340,36 @@ if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
     # Remedial work
     # Specific remedial work
     fetchOVALog
+
+    # Clean Up below
+
+    #shutdown vagrant box and delete all resource (like removing vm disk files in "~/VirtualBox VMs/")
+    cleanupVMs
+    nodesDelete
+  elif [ "$TEST_TYPE" == "docker" ]; then
+    # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
+    
+    nodesCreate
+    
+    # Prepare RackHD
+    # Forward local host port to ova
+    portForwarding localhost
+
+    # We setup the virtual-environment here, since once we
+    # call "nodesOn", it's a race to get to the first test
+    # before the nodes get booted far enough to start being
+    # seen by RackHD. Logically, it would be better IN runTests.
+    # We do it between the vagrant and waitForAPI to use the
+    # time to make the env instead of doing sleeps...
+    setupVirtualEnv
+    waitForAPI
+    nodesOn &
+    # Doesn't support ova smoke test now
+    # generateSolLog
+    # Run tests
+    runTests
+    # exit venv
+    deactivate
 
     # Clean Up below
 


### PR DESCRIPTION
### Background
In CD the outputs ova/vatgrantbox/docker images should be tested to prove validity.
Now we only have some light weight test: rackhd version check ,services check etc. This is not enough.
post-smoke-test must be added.

### PR Details:
This PR implements docker-post-smoke-test with the  best possible use of the current jenkins test resources.
Current test workflow setup rackhd with manifest  downloading src and vagrant. rackhd vagrant is bridged to jenkins slave.
In docker-post-test, this similar rackhd setup step is replaced by ```docker load && docker-compose up``` and config. 
With port forwarding, the test framework can not tell the difference between vagrant and docker rackhd.
@panpan0000 @PengTian0 