### PR TITLE
pipeline for cache ova and vagrant from a pre-build image

### DIFF
--- a/jobs/PackerCacheBuild/Jenkinsfile
+++ b/jobs/PackerCacheBuild/Jenkinsfile
@@ -20,25 +20,29 @@ def cacheBuild(ArrayList<String> used_resources, String BUILD_TYPE){
                 withEnv([
                     "OS_VER=${env.OS_VER}",
                     "BUILD_STAGE=BUILD_TEMPLATE",
-                    "BUILD_TYPE=$BUILD_TYPE"
+                    "BUILD_TYPE=$BUILD_TYPE",
+                    "PACKER_CACHE_DIR=$HOME/packer_cache"
                 ]){
-                    try{
-                        sh '''#!/bin/bash -x
-                        set +e
-                        pushd RackHD/packer
-                        pkill packer
-                        rm ~/VirtualBox\\ VMs/rackhd-${OS_VER} -rf
-                        set -e
-                        ./HWIMO-BUILD
-                        popd
-                        '''
-                        archiveArtifacts "RackHD/packer/output-*/*.*"
-                    } finally{
-                        sh '''#!/bin/bash -x
-                        set +e
-                        pkill packer
-                        rm ~/VirtualBox\\ VMs/rackhd-${OS_VER} -rf
-                        '''
+                    timeout(70){
+                        try{
+                            sh '''#!/bin/bash -x
+                            set +e
+                            pushd RackHD/packer
+                            pkill packer
+                            rm ~/VirtualBox\\ VMs/rackhd-${OS_VER} -rf
+                            set -e
+                            ./HWIMO-BUILD
+                            popd
+                            '''
+                        } finally{
+                            archiveArtifacts "RackHD/packer/output-*/*.*"
+                            sh '''#!/bin/bash -x
+                            set +e
+                            pkill packer
+                            rm ~/VirtualBox\\ VMs/rackhd-${OS_VER} -rf
+                            rm -rf $WORKSPACE/RackHD/packer/output-*
+                            '''
+                        }
                     }
                 }
             }

--- a/jobs/PackerCacheBuild/Jenkinsfile
+++ b/jobs/PackerCacheBuild/Jenkinsfile
@@ -1,0 +1,64 @@
+import groovy.transform.Field;
+@Field def shareMethod
+node{
+    deleteDir()
+    checkout scm
+    shareMethod = load("jobs/ShareMethod.groovy")
+}
+
+def cacheBuild(ArrayList<String> used_resources, String BUILD_TYPE){
+    String label_name = "packer"
+    lock(label:label_name,quantity:1){
+        String node_name = shareMethod.occupyAvailableLockedResource(label_name, used_resources)
+        try{
+            node(node_name){
+                deleteDir()
+                def url = "https://github.com/RackHD/RackHD.git"
+                def branch = "master"
+                def targetDir = "RackHD"
+                shareMethod.checkout(url, branch, targetDir)
+                withEnv([
+                    "OS_VER=${env.OS_VER}",
+                    "BUILD_STAGE=BUILD_TEMPLATE",
+                    "BUILD_TYPE=$BUILD_TYPE"
+                ]){
+                    try{
+                        sh '''#!/bin/bash -x
+                        set +e
+                        pushd RackHD/packer
+                        pkill packer
+                        rm ~/VirtualBox\\ VMs/rackhd-${OS_VER} -rf
+                        set -e
+                        ./HWIMO-BUILD
+                        popd
+                        '''
+                        archiveArtifacts "RackHD/packer/output-*/*.*"
+                    } finally{
+                        sh '''#!/bin/bash -x
+                        set +e
+                        pkill packer
+                        rm ~/VirtualBox\\ VMs/rackhd-${OS_VER} -rf
+                        '''
+                    }
+                }
+            }
+        } finally{
+            used_resources.remove(node_name)
+        }
+    }
+}
+
+timestamps{
+    stage("Cache Packer"){
+        def build_branches = [:]
+        def used_resources = []
+
+        build_branches["Cache Virtualbox"] = {
+            cacheBuild(used_resources, "virtualbox")
+        }
+        build_branches["Cache Vmware"] = {
+            cacheBuild(used_resources, "vmware")
+        }
+        parallel build_branches
+    }
+}

--- a/jobs/PackerCacheBuild/Jenkinsfile
+++ b/jobs/PackerCacheBuild/Jenkinsfile
@@ -2,6 +2,19 @@ import groovy.transform.Field;
 @Field def shareMethod
 node{
     deleteDir()
+
+    // checkout RackHD and check if there is change under RackHD/packer
+    checkout(
+    [
+        $class: 'GitSCM',
+        branches: [[name: 'master']],
+        doGenerateSubmoduleConfigurations: false,
+        extensions: [[$class: 'PathRestriction', excludedRegions: '', includedRegions: 'packer/(.*/)?.*']],
+        submoduleCfg: [],
+        userRemoteConfigs: [[url: 'https://github.com/RackHD/RackHD/']]
+    ]
+    )
+
     checkout scm
     shareMethod = load("jobs/ShareMethod.groovy")
 }

--- a/jobs/ShareMethod.groovy
+++ b/jobs/ShareMethod.groovy
@@ -14,8 +14,10 @@ def checkout(String url){
     checkout(url, "master")
 }
 
-def getLockedResourceName(resources,String label_name){
+def getLockedResourceName(String label_name){
     // Get the resource name whose label contains the parameter label_name
+    // The locked resources of the build
+    def resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())
     def resources_name=[]
     for(int i=0;i<resources.size();i++){
         String labels = resources[i].getLabels();
@@ -30,10 +32,8 @@ def getLockedResourceName(resources,String label_name){
 }
 
 def occupyAvailableLockedResource(String label_name, ArrayList<String> used_resources){
-    // The locked resources of the build
-    def lock_resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())
      // The locked resources whose label contains the parameter label_name
-    resources = getLockedResourceName(lock_resources,label_name)
+    resources = getLockedResourceName(label_name)
     def available_resources = resources - used_resources
     if(available_resources.size > 0){
         used_resources.add(available_resources[0])
@@ -55,8 +55,7 @@ def buildAndPublish(){
     }
     // lock a docker resource from build to release
     lock(label:"docker",quantity:1){
-        def lock_resources=org.jenkins.plugins.lockableresources.LockableResourcesManager.class.get().getResourcesFromBuild(currentBuild.getRawBuild())       
-        docker_resources_name = getLockedResourceName(lock_resources,"docker")
+        docker_resources_name = getLockedResourceName("docker")
         if(docker_resources_name.size>0){
             env.build_docker_node = docker_resources_name[0]
         }

--- a/jobs/build_ova/build_ova.groovy
+++ b/jobs/build_ova/build_ova.groovy
@@ -1,5 +1,21 @@
-node(build_ova_node){ws{
-    lock("packer_bri"){
+import groovy.transform.Field;
+@Field def shareMethod
+node{
+    deleteDir()
+    checkout scm
+    shareMethod = load("jobs/ShareMethod.groovy")
+}
+
+String label_name = "packer_vagrant"
+lock(label:label_name,quantity:1){
+    resources_name = shareMethod.getLockedResourceName(label_name)
+    if(resources_name.size>0){
+        node_name = resources_name[0]
+    }
+    else{
+        error("Failed to find resource with label " + label_name)
+    }
+    node(node_name){ws{
         timestamps{
             withEnv([
                 "RACKHD_COMMIT=${env.RACKHD_COMMIT}",
@@ -16,19 +32,21 @@ node(build_ova_node){ws{
                 "BINTRAY_ARCHITECTURE=amd64"]){
                 def current_workspace = pwd()
                 deleteDir()
-                def shareMethod
-                dir("Build_OVA_JFiles"){
+                dir("on-build-config"){
                     checkout scm
-                    shareMethod = load("jobs/ShareMethod.groovy")
                 }
+ 
                 def url = "https://github.com/RackHD/RackHD.git"
                 def branch = "${env.RACKHD_COMMIT}"
                 def targetDir = "build"
                 shareMethod.checkout(url, branch, targetDir)
+                step ([$class: 'CopyArtifact',
+                projectName: 'PACKER_CACHE_BUILD',
+                target: 'cache_image']);
 
                 timeout(180){
                     withEnv(["WORKSPACE=${current_workspace}"]){
-                        sh './Build_OVA_JFiles/jobs/build_ova/build_ova.sh'
+                        sh './on-build-config/jobs/build_ova/build_ova.sh'
                     }
                 }
                 archiveArtifacts 'build/packer/*.ova, build/packer/*.log, build/packer/*.md5, build/packer/*.sha'

--- a/jobs/build_ova/build_ova.groovy
+++ b/jobs/build_ova/build_ova.groovy
@@ -6,7 +6,7 @@ node{
     shareMethod = load("jobs/ShareMethod.groovy")
 }
 
-String label_name = "packer_vagrant"
+String label_name = "packer_ova"
 lock(label:label_name,quantity:1){
     resources_name = shareMethod.getLockedResourceName(label_name)
     if(resources_name.size>0){
@@ -35,7 +35,6 @@ lock(label:label_name,quantity:1){
                 dir("on-build-config"){
                     checkout scm
                 }
- 
                 def url = "https://github.com/RackHD/RackHD.git"
                 def branch = "${env.RACKHD_COMMIT}"
                 def targetDir = "build"

--- a/jobs/build_ova/build_ova.sh
+++ b/jobs/build_ova/build_ova.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/bin/bash -x
+
 set +e
-#sudo cp ${HOME}/bin/packer   /usr/bin
-#sudo apt-get install -y  jq
+mv $WORKSPACE/cache_image/RackHD/packer/* $WORKSPACE/build/packer/
+ls $WORKSPACE/build/packer/*
+vmware -v
 
 cd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main#" main.yml
@@ -9,16 +11,24 @@ sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#https://dl.bintray.co
 cd ..
 pkill packer
 pkill vmware
-set -x
-cd $WORKSPACE/build/packer 
-export PACKER_CACHE_DIR=$HOME/.packer_cache
-export BUILD_TYPE=vmware
+
+set -e
+cd $WORKSPACE/build/packer
 #export vars to build ova
 if [ "${IS_OFFICIAL_RELEASE}" == true ]; then
     export ANSIBLE_PLAYBOOK=rackhd_release
 else
     export ANSIBLE_PLAYBOOK=rackhd_ci_builds
 fi
+
+if [ "$BUILD_TYPE" == "vmware" ] &&  [ -f output-vmware-iso/*.vmx ]; then
+     echo "Build from template cache"
+     export BUILD_STAGE=BUILD_FINAL
+else
+     echo "Build from begining"
+     export BUILD_STAGE=BUILD_ALL
+fi
+
 export RACKHD_VERSION=$RACKHD_VERSION
 #export end
 

--- a/jobs/build_vagrant/build_vagrant.groovy
+++ b/jobs/build_vagrant/build_vagrant.groovy
@@ -6,7 +6,7 @@ node{
     shareMethod = load("jobs/ShareMethod.groovy")
 }
 
-String label_name = "packer_ova"
+String label_name = "packer_vagrant"
 lock(label:label_name,quantity:1){
     resources_name = shareMethod.getLockedResourceName(label_name)
     if(resources_name.size>0){

--- a/jobs/build_vagrant/build_vagrant.groovy
+++ b/jobs/build_vagrant/build_vagrant.groovy
@@ -1,5 +1,21 @@
-node(build_vagrant_node){
-    lock("packer_usa"){
+import groovy.transform.Field;
+@Field def shareMethod
+node{
+    deleteDir()
+    checkout scm
+    shareMethod = load("jobs/ShareMethod.groovy")
+}
+
+String label_name = "packer_ova"
+lock(label:label_name,quantity:1){
+    resources_name = shareMethod.getLockedResourceName(label_name)
+    if(resources_name.size>0){
+        node_name = resources_name[0]
+    }
+    else{
+        error("Failed to find resource with label " + label_name)
+    }
+    node(node_name){
         timestamps{
             withEnv([
                 "RACKHD_COMMIT=${env.RACKHD_COMMIT}",
@@ -16,19 +32,21 @@ node(build_vagrant_node){
                 "BINTRAY_ARCHITECTURE=amd64"]){
                 def current_workspace = pwd()
                 deleteDir()
-                def shareMethod
-                dir("Build_Vagrant_JFiles"){
+                dir("on-build-config"){
                     checkout scm
-                    shareMethod = load("jobs/ShareMethod.groovy")
                 }
                 def url = "https://github.com/RackHD/RackHD.git"
                 def branch = "${env.RACKHD_COMMIT}"
                 def targetDir = "build"
                 shareMethod.checkout(url, branch, targetDir)
                 
+                step ([$class: 'CopyArtifact',
+                projectName: 'PACKER_CACHE_BUILD',
+                target: 'cache_image']);
+                
                 timeout(180){
                     withEnv(["WORKSPACE=${current_workspace}"]){
-                        sh './Build_Vagrant_JFiles/jobs/build_vagrant/build_vagrant.sh'
+                        sh './on-build-config/jobs/build_vagrant/build_vagrant.sh'
                     }
                 }
                 archiveArtifacts 'build/packer/*.box, build/packer/*.log'

--- a/jobs/build_vagrant/build_vagrant.sh
+++ b/jobs/build_vagrant/build_vagrant.sh
@@ -1,17 +1,28 @@
-#!/bin/bash
-ifconfig
+#!/bin/bash -x
 set +e
+ifconfig
 packer -v
 vagrant -v
+
+mv $WORKSPACE/cache_image/RackHD/packer/* $WORKSPACE/build/packer/
+ls $WORKSPACE/build/packer/*
 
 cd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main#" main.yml
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main#" main.yml
 pkill packer
-cd ..
-cd $WORKSPACE/build/packer 
-#export vars to build virtualbox
-export PACKER_CACHE_DIR=$HOME/.packer_cache
+
+set -e
+cd $WORKSPACE/build/packer
+
+if [ "$BUILD_TYPE" == "virtualbox" ] &&  [ -f output-virtualbox-iso/*.ovf ]; then
+     echo "Build from template cache"
+     export BUILD_STAGE=BUILD_FINAL
+else
+     echo "Build from begining"
+     export BUILD_STAGE=BUILD_ALL
+fi
+
 if [ "${IS_OFFICIAL_RELEASE}" == "true" ]; then
     export ANSIBLE_PLAYBOOK=rackhd_release
 else

--- a/jobs/build_vagrant/build_vagrant.sh
+++ b/jobs/build_vagrant/build_vagrant.sh
@@ -36,7 +36,7 @@ export RACKHD_VERSION=$RACKHD_VERSION
 ./HWIMO-BUILD
 
 PACKERDIR="$WORKSPACE/build/packer/"
-BOX="$PACKERDIR/packer_virtualbox-iso_virtualbox.box"
+BOX="$PACKERDIR/rackhd-${OS_VER}.box"
 if [ -e "$BOX" ]; then
   mv "$BOX" "$PACKERDIR/rackhd-${OS_VER}-${RACKHD_VERSION}.box"
 fi

--- a/jobs/build_vagrant/vagrant_post_test.groovy
+++ b/jobs/build_vagrant/vagrant_post_test.groovy
@@ -1,14 +1,29 @@
-node(build_vagrant_node){
-    lock("packer_bri"){
-         timestamps{           
-            withEnv([
-                "WORKSPACE=${env.VAGRANT_WORKSPACE}"]){
-                dir("build-config"){
-                    checkout scm
-                }
-                timeout(90){
-                    sh './build-config/jobs/build_vagrant/vagrant_post_test.sh'
-                }
+import groovy.transform.Field;
+@Field def shareMethod
+node{
+    deleteDir()
+    checkout scm
+    shareMethod = load("jobs/ShareMethod.groovy")
+}
+
+String label_name = "packer_vagrant"
+lock(label:label_name,quantity:1){
+    resources_name = shareMethod.getLockedResourceName(label_name)
+    if(resources_name.size>0){
+        node_name = resources_name[0]
+    }
+    else{
+        error("Failed to find resource with label " + label_name)
+    }
+    node(node_name){
+        timestamps{
+            deleteDir()
+            unstash "vagrant"
+            dir("build-config"){
+                checkout scm
+            }
+            timeout(90){
+                sh './build-config/jobs/build_vagrant/vagrant_post_test.sh'
             }
         }
     }


### PR DESCRIPTION
Pipeline for cache ova and vagrant.
1. Add a pipeline: PackerCacheBuild/Jenkinsfile
    This pipeline will build a template VMX and OVF which OS installed and all RackHD dependency installed.
2. Change the pipelines : build_ova.groovy and build_vagrant.groovy.
     The 2 pipelines support build image from the above VMX and OVF.

The PR depends on: https://github.com/RackHD/RackHD/pull/704

