### PR TITLE
[skip ci]Fix: failed to publish in MasterCI

### DIFF
--- a/jobs/ShareMethod.groovy
+++ b/jobs/ShareMethod.groovy
@@ -85,7 +85,7 @@ def buildImages(String repo_dir){
     }
 }
 
-def publish(String repo_dir){
+def publishImages(String repo_dir){
     stage("Publish"){
         parallel 'Publish Debian':{
             load(repo_dir + "/jobs/release/release_debian.groovy")
@@ -125,7 +125,7 @@ def buildAndPublish(Boolean publish, Boolean tag, String repo_dir){
             createTag(repo_dir)
         }
         if(publish){
-            publish(repo_dir)
+            publishImages(repo_dir)
         }
     }
 }


### PR DESCRIPTION
MasterCI #134 failed:
org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: unclassified method java.lang.Boolean call java.lang.String

Root cause:
There is a Boolean variable and method with the same name ```publish```