### PR TITLE
bugfix: modify continuous test Jenkinsfile to use test_type

### DIFF
--- a/jobs/ContinuousTest/Jenkinsfile
+++ b/jobs/ContinuousTest/Jenkinsfile
@@ -52,13 +52,14 @@ node{
         }
         stage("Test"){
             // Start to run test
+            def test_type = "manifest"
             def TESTS = "${env.TESTS}"
             def repo_dir = pwd() + "/build-config"
             def function_test = load("build-config/jobs/FunctionTest/FunctionTest.groovy")
             try{
-                function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir)
+                function_test.manifestTest(TESTS, env.stash_manifest_name, env.stash_manifest_path, repo_dir, test_type)
             } finally{
-                function_test.archiveArtifactsToTarget("FunctionTest")
+                function_test.archiveArtifactsToTarget("FunctionTest", TESTS, test_type)
             }
         }
     } finally{


### PR DESCRIPTION
Forget to modify continusous test jenkinsfile.

@panpan0000 @PengTian0 