### PR TITLE
use vagrant 0.17

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # MONORAIL SERVER
     config.vm.define "dev" do |target|
         target.vm.box = "rackhd/rackhd"
-        target.vm.box_version = "0.16"
+        target.vm.box_version = "0.17"
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
@@ -23,38 +23,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         if ENV['WORKSPACE']
           target.vm.synced_folder "#{ENV['WORKSPACE']}/build-deps", "/home/vagrant/src/"
           target.vm.synced_folder "#{ENV['WORKSPACE']}/build-config", "/home/vagrant/src/build-config"
-          if ENV['MULTI'] =="true"
-            target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/build"
-            for repo in ENV['REPO_NAME'].split(' ')
-              if repo != "rackhd"
-                target.vm.synced_folder "#{ENV['WORKSPACE']}/#{repo}", "/home/vagrant/src/#{repo}"
-              end
-            end
-            if ENV['REPO_NAME'].include? "on-tasks"
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/on-tasks", "/home/vagrant/src/on-taskgraph/node_modules/on-tasks/" 
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/on-tasks", "/home/vagrant/src/on-http/node_modules/on-tasks/" 
-            end
-            if ENV['REPO_NAME'].include? "on-core"
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/on-core", "/home/vagrant/src/on-taskgraph/node_modules/on-core/"  
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/on-core", "/home/vagrant/src/on-http/node_modules/on-core/" 
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/on-core", "/home/vagrant/src/on-tftp/node_modules/on-core/" 
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/on-core", "/home/vagrant/src/on-dhcp-proxy/node_modules/on-core/" 
-            end
-          else
-            if ENV['REPO_NAME']
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/#{ENV['REPO_NAME']}"
-            end
-            if ENV['REPO_NAME'] == "on-tasks"
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/on-taskgraph/node_modules/on-tasks/" 
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/on-http/node_modules/on-tasks/" 
-            end
-            if ENV['REPO_NAME'] == "on-core"
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/on-taskgraph/node_modules/on-core/"  
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/on-http/node_modules/on-core/" 
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/on-tftp/node_modules/on-core/" 
-              target.vm.synced_folder "#{ENV['WORKSPACE']}/build", "/home/vagrant/src/on-dhcp-proxy/node_modules/on-core/" 
-            end
-          end
         end
         
         if ENV['CONFIG_DIR']
@@ -63,21 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['CONFIG_DIR']}", "/home/vagrant/opt/monorail/"
         end
 
-        if ENV['TEST_GROUP']		
-          if ENV['TEST_GROUP'] =~  /esxi-5-5-min-install.v2.0.test/ || ENV['TEST_GROUP'] =~  /esxi-5-5-max-install.v2.0.test/		
-            config.vm.provision "file", source: "./dhcpd.conf", destination: "~/dhcpd.conf"		
-            config.vm.provision "shell" do |s|		
-            s.inline = "cp /home/vagrant/dhcpd.conf /etc/dhcp"		
-            s.privileged = true		
-            end		
-          end		
-        end
         if ENV['PYTHON_REPOS']
-          config.vm.provision "file", source: "./rackhd-pm2-config.yml", destination: "~/rackhd-pm2-config.yml"
-          config.vm.provision "shell" do |s|		
-            s.inline = "apt-get install python-pip -y"		
-            s.privileged = true
-         end
           list = ENV['PYTHON_REPOS'].split(' ')
           list && list.each do |repo|
             config.vm.provision "shell" do |s|		
@@ -86,12 +40,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             end
           end
         end
-        config.vm.provision "file", source: "./mongodb.conf", destination: "~/mongodb.conf"
-        config.vm.provision "shell" do |s|
-        s.inline = "cp /home/vagrant/mongodb.conf /etc"
-        s.privileged = true
-        end
-        
         
         target.vm.network "public_network", ip: "172.31.128.1", bridge: "em1"
         target.vm.network "forwarded_port", guest: 8080, host: 9090
@@ -107,8 +55,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # Default value: false
         target.ssh.forward_agent = true
 
-        target.vm.provision "file", source: "./upgrade_packages.sh", destination: "upgrade_packages.sh"
-        target.vm.provision "file", source: "./blacklist_mongo.txt", destination: "blacklist_mongo.txt"
+        #target.vm.provision "file", source: "./upgrade_packages.sh", destination: "upgrade_packages.sh"
+        #target.vm.provision "file", source: "./blacklist_mongo.txt", destination: "blacklist_mongo.txt"
         target.vm.provision "shell", inline: <<-SHELL
           timeout=0
           maxto=30
@@ -126,7 +74,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               exit 1
             fi
           }
-          /home/vagrant/upgrade_packages.sh > /home/vagrant/upgrade_packages.log
           service isc-dhcp-server start
           service rsyslog stop
           sudo service mongodb restart


### PR DESCRIPTION
https://rackhd.atlassian.net/browse/RAC-4502
About vagrant 0.17
1. Has installed current usc-service requirements, consider the possible updates of requirements, so keep the pip install steps in Vagrantfile.
2. mongodb.conf has been put into this new box.
3. new pm2 yml has been put into this new box.
4. remove mongo blacklist, mongodb version is restricted to 2.4.9 in the box
5. Build with virtualbox v5.0.32

Extra:
1. Remove unused folder sync. In manifest mechanism all repo src has been prepared to the final status. No more extra sync actions are needed.
2. Remove dhcpd.conf for esxi. I checked the injected conf and found it removed the dns config. But tests showed that with dns the esxi os installation still succeeded.
3. Comment out the mongo upgrade. External package version updates introduce a lot of instability to our system. So we disscussed to keep all the external dependency to fixed version. So mongodb version to 2.4.9 in the box. However, this topic is still under discussion, so I just comment out the code snippet.
 
Packer Modification PR: https://github.com/RackHD/RackHD/pull/749