### PR TITLE
RAC-5105/RAC-5162:  restore PM2 version to older

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -60,14 +60,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.vm.provision "shell", inline: <<-SHELL
           timeout=0
           maxto=30
+          sudo pm2 kill
+          sudo npm remove pm2 -g
+          sudo npm install pm2@2.0.19 -g
+          sudo pm2 --version
+          
           waitForPM2Daemon() {
             while [ ${timeout} != ${maxto} ]; do
               ps aux | grep PM2 | grep Daemon
               if [ $? = 0 ]; then 
                 break
               fi
-              echo "Retry to start PM2 Daemon"
-              pm2 status  # any PM2 command will start PM2 Daemon. and 'pm2 status' is a blocking command.
               sleep 1
               timeout=$((timeout + 1))
             done

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -66,6 +66,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               if [ $? = 0 ]; then 
                 break
               fi
+              echo "Retry to start PM2 Daemon"
+              pm2 status  # any PM2 command will start PM2 Daemon. and 'pm2 status' is a blocking command.
               sleep 1
               timeout=$((timeout + 1))
             done


### PR DESCRIPTION
Motivation:
It's to resolve MasterCI/160 (a workaround)

background:
in vagrant,
PM2 Daemon is off when boot up.
it will be auto started when run any pm2 command , with message as below:
```
[PM2] Spawning PM2 daemon with pm2_home=/home/jenkins/.pm2
[PM2] PM2 Successfully daemonized
```

the first command is         ```     pm2 logs > /home/vagrant/src/build/vagrant.log &```
it will start the daemon.
but in old 0.16 box , there's chance that the daemon will be started both by ```pm2 logs```  and ```pm2 start```. that's why @changev  added the ```waitForPM2Daemon``` function.
when vagrant box upgrade to 0.17,  seems sometimes, 30 secs is not enough for PM2 Daemon to start.. 

and sometimes even it's worse, never started. 

tracked in RAC-5162

so I updated this PR  to restore PM2 to a old version.
at least one run is successful :   http://rackhdci.lss.emc.com/job/on-build-config/307/




@PengTian0  @changev  @iceiilin  @anhou 


