### PR TITLE
RAC-5160 :add double check if copy archive from PACKER_CACHE_BUILD job successful

### DIFF
--- a/jobs/build_vagrant/build_vagrant.groovy
+++ b/jobs/build_vagrant/build_vagrant.groovy
@@ -41,10 +41,14 @@ lock("vagrant_build"){
                     def branch = "${env.RACKHD_COMMIT}"
                     def targetDir = "build"
                     shareMethod.checkout(url, branch, targetDir)
-                
-                    step ([$class: 'CopyArtifact',
-                    projectName: 'VAGRANT_CACHE_BUILD',
-                    target: 'cache_image']);
+                    try{
+                        step ([$class: 'CopyArtifact',
+                        projectName: 'VAGRANT_CACHE_BUILD',
+                        target: 'cache_image']);
+                    } catch(error) {
+                         echo "Copy Artifacts from VAGRANT_CACHE_BUILD:  Caught: ${error}"
+                    }
+
                     
                     timeout(180){
                         withEnv(["WORKSPACE=${current_workspace}"]){

--- a/jobs/build_vagrant/build_vagrant.sh
+++ b/jobs/build_vagrant/build_vagrant.sh
@@ -21,9 +21,11 @@ cleanup()
        set -e
     fi
 }
-
-mv $WORKSPACE/cache_image/RackHD/packer/* $WORKSPACE/build/packer/
-ls $WORKSPACE/build/packer/*
+if [ -d  $WORKSPACE/cache_image/RackHD/packer/ ] ; then
+     echo "Copy Cache images from PACKER_CACHE_BUILD job archiving"
+     mv $WORKSPACE/cache_image/RackHD/packer/* $WORKSPACE/build/packer/
+     ls $WORKSPACE/build/packer/*
+fi
 
 pushd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
 sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main#" main.yml


### PR DESCRIPTION
there's some possibility (like a sandbox jenkins env) , the PACKER_CACHE_BUILD is not ready yet.
so the folder will not exist. although there's set +e, but adding a check is preferred .


@hohene  @anhou  @iceiilin 
 