### PR TITLE
More Clean Up in test.sh

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -192,6 +192,12 @@ def functionTest(String test_name, String label_name, String TEST_GROUP, Boolean
                                     }
                                 }
                                 if(result == "FAILURE" && KEEP_FAILURE_ENV == "true"){
+
+                                    // Clean/Unregister the signal handler, which was setup in test.sh
+                                    sh '''#!/bin/bash -x
+                                    trap - SIGINT SIGTERM SIGKILL EXIT
+                                    '''
+
                                     int sleep_mins = Integer.valueOf(KEEP_MINUTES)
                                     def message = "Job Name: ${env.JOB_NAME} \n" + "Build Full URL: ${env.BUILD_URL} \n" + "Status: FAILURE \n" + "Stage: $test_name \n" + "Node Name: $node_name \n" + "Reserve Duration: $sleep_mins minutes \n"
                                     echo "$message"

--- a/test.sh.in
+++ b/test.sh.in
@@ -347,6 +347,23 @@ fetchOVALog(){
     popd
 }
 
+###########################################
+#
+#  Ensure logs are dumpped even build timeout aborted
+#
+#############################################
+general_cleanup(){
+
+    set +e
+    cleanupVMs
+    generateSysLog
+    generateMongoLog
+    vnc_record_stop
+
+}
+
+
+
 ######################################
 #  OVA POST SMOKE TEST RELATED END   #
 ######################################
@@ -421,7 +438,7 @@ if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
     ucsReset
 
     # register the signal handler to clean up( vagrantDestroy ), with process being killed
-    trap cleanupVMs SIGINT SIGTERM SIGKILL
+    trap general_cleanup SIGINT SIGTERM SIGKILL EXIT
     cleanupVMs
 
     # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
@@ -442,9 +459,12 @@ if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
     vnc_record_start
     # Run tests
     runTests
-    generateSysLog
-    generateMongoLog
-    vnc_record_stop
+    # Below Clean Up will be run in signal handler : ```trap general_cleanup EXIT```
+    #generateSysLog
+    #generateMongoLog
+    #vnc_record_stop
+    #cleanupVMs # add it into normal process
+
     # Clean Up below
 
     #shutdown vagrant box and delete all resource (like removing vm disk files in "~/VirtualBox VMs/")

--- a/test.sh.in
+++ b/test.sh.in
@@ -355,10 +355,10 @@ fetchOVALog(){
 general_cleanup(){
 
     set +e
-    cleanupVMs
     generateSysLog
     generateMongoLog
     vnc_record_stop
+    cleanupVMs
 
 }
 


### PR DESCRIPTION
(1) add more steps in clean_up when aborted (using signal EXIT).
(2) add cleanupVMs into end of test.sh.in (general_cleanup). it was not done when script normally exit.


@PengTian0  @changev  @iceiilin @anhou 