### PR TITLE
Fix: RAC-5054: Timed out waiting for RackHD API service

### DIFF
--- a/generate-sol-log.sh.in
+++ b/generate-sol-log.sh.in
@@ -25,13 +25,13 @@ while [ ${timeout} != ${maxto} ]; do
                     echo "ipmi cmd: ipmitool -I lanplus -H $ip -U XXXXX -P XXXXX -R 1 -N 3 chassis power status"
                     ipmitool -I lanplus -H $ip -U ${bmc%:*} -P ${bmc#*:} -R 1 -N 3 chassis power status |grep on
                     if [ $? == 0 ]; then
-                        #raw logs saved in /home/vagrant/src/, which is the $WORKSPACE/build-deps of host.
+                        #raw logs saved in /home/vagrant/log/, which is the $WORKSPACE/build-log of host.
                         #in post-deploy raw logs are convert into html by ansi2html tool
                         cmd='ipmitool -I lanplus -H ${bmc_ip} -U ${bmc_user} -P ${bmc_password} sol activate |
                                     tr 'A-Z' 'a-z' |
                                     while IFS= read -r line; do 
                                         echo "$(date) $line"; 
-                                    done > /home/vagrant/src/${vnode_num}.sol.log.raw'
+                                    done > /home/vagrant/log/${vnode_num}.sol.log.raw'
                         #dump cmd to cmd.sh, replace vars with actual value.
                         echo -e "bmc_ip=$ip\nbmc_user=${bmc%:*}\nbmc_password=${bmc#*:}\nvnode_num=${vnode_num}"|\
                         sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > sed.script

--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -149,10 +149,6 @@ def functionTest(String test_name, String label_name, String TEST_GROUP, Boolean
                                 set +e
                                 mkdir '''+"$artifact_dir"+'''
                                 ./build-config/post-deploy.sh
-                                files=$( ls build-deps/*.log )
-                                if [ ! -z "$files" ];then
-                                    cp build-deps/*.log '''+"$artifact_dir"+'''
-                                fi
                                 files=$( ls build-deps/*.flv )
                                 if [ ! -z "$files" ];then
                                     cp build-deps/*.flv '''+"$artifact_dir" +'''
@@ -161,11 +157,14 @@ def functionTest(String test_name, String label_name, String TEST_GROUP, Boolean
                                 if [ ! -z "$files" ];then
                                     cp RackHD/test/*.xml '''+"$artifact_dir" +'''
                                 fi
-                                if [ -d build-deps/mongodb ];then
-                                    cp -r build-deps/mongodb '''+"$artifact_dir" +'''
+                                files=$( ls build-log/*.log )
+                                if [ ! -z "$files" ];then
+                                    cp build-log/*.log '''+"$artifact_dir"+'''
+                                fi
+                                if [ -d build-log/mongodb ];then
+                                    cp -r build-log/mongodb '''+"$artifact_dir" +'''
                                 fi
                                 '''
-                            
                                 def junitFiles = findFiles glob: 'RackHD/test/*.xml'
                                 boolean exists = junitFiles.length > 0
                                 if (exists){

--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -37,6 +37,6 @@ for repo_tag in $image_list; do
     sed -i "s#${repo}.*#${repo_tag}#g" docker-compose-mini.yml
 done
 
-mkdir -p $WORKSPACE/build-deps
-docker-compose -f docker-compose-mini.yml up > $WORKSPACE/build-deps/vagrant.log &
+mkdir -p $WORKSPACE/build-log
+docker-compose -f docker-compose-mini.yml up > $WORKSPACE/build-log/vagrant.log &
 

--- a/on-core/post-deploy.sh.in
+++ b/on-core/post-deploy.sh.in
@@ -10,13 +10,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
 fi
 
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/on-dhcp-proxy/post-deploy.sh.in
+++ b/on-dhcp-proxy/post-deploy.sh.in
@@ -9,13 +9,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/on-http/post-deploy.sh.in
+++ b/on-http/post-deploy.sh.in
@@ -9,13 +9,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/on-syslog/post-deploy.sh.in
+++ b/on-syslog/post-deploy.sh.in
@@ -9,13 +9,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/on-taskgraph/post-deploy.sh.in
+++ b/on-taskgraph/post-deploy.sh.in
@@ -9,13 +9,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/on-tasks/post-deploy.sh.in
+++ b/on-tasks/post-deploy.sh.in
@@ -9,13 +9,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/on-tftp/post-deploy.sh.in
+++ b/on-tftp/post-deploy.sh.in
@@ -9,13 +9,13 @@ if [ "${RUN_AUTOTEST}" = "true" ]; then
   done
 fi
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/post-deploy.sh
+++ b/post-deploy.sh
@@ -2,12 +2,12 @@
 echo "Running post-deploy script"
 
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     # decode to utf-8 before, because ansi2html will broke when finding invalid char
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
-    ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+    ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
 done

--- a/post-deploy.sh.in
+++ b/post-deploy.sh.in
@@ -2,14 +2,14 @@
 echo "Running post-deploy script"
 
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
     # decode to utf-8 before, because ansi2html will broke when finding invalid char
     iconv -f "windows-1252" -t "UTF-8" $file -o new_$file
     if [ -f new_$file ];then
-      ansi2html < new_$file > $WORKSPACE/build-deps/${file%.*}
+      ansi2html < new_$file > $WORKSPACE/build-log/${file%.*}
     fi
 done

--- a/pre-deploy.sh
+++ b/pre-deploy.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 echo "Running pre-deploy script"
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
+    ansi2html < $file > $WORKSPACE/build-log/${file%.*}
 done
+

--- a/pre-deploy.sh.in
+++ b/pre-deploy.sh.in
@@ -1,10 +1,11 @@
 #!/bin/bash
 echo "Running pre-deploy script"
 
-#raw sol logs saved in WORKSPACE/build-deps
+#raw sol logs saved in WORKSPACE/build-log
 #this script convert them into html by ansi2html tool
-#and move them to 'build' folder for publishing
-cd $WORKSPACE/build-deps
+#and move them to 'build-log' folder for publishing
+cd $WORKSPACE/build-log
 for file in `ls *sol.log.raw`; do
-    ansi2html < $file > $WORKSPACE/build/${file%.*}
+    ansi2html < $file > $WORKSPACE/build-log/${file%.*}
 done
+

--- a/test.sh.in
+++ b/test.sh.in
@@ -162,6 +162,7 @@ CONFIG_PATH=${CONFIG_PATH-build-config/vagrant/config/mongo}
 vagrantUp() {
   cd ${WORKSPACE}/RackHD/example
   cp -rf ${WORKSPACE}/build-config/vagrant/* .
+  mkdir -p ${WORKSPACE}/build-log
   result=0
   for i in {1..2}
   do
@@ -238,13 +239,13 @@ generateSolLog(){
 
 generateSysLog(){
   cd ${WORKSPACE}/RackHD/example
-  vagrant ssh -c 'dmesg > /home/vagrant/src/dmesg.log'
-  vagrant ssh -c 'cp /var/log/syslog /home/vagrant/src/syslog.log'
+  vagrant ssh -c 'dmesg > /home/vagrant/log/dmesg.log'
+  vagrant ssh -c 'cp /var/log/syslog /home/vagrant/log/syslog.log'
 }
 
 generateMongoLog(){
   cd ${WORKSPACE}/RackHD/example
-  vagrant ssh -c 'cp -r /var/log/mongodb /home/vagrant/src/'
+  vagrant ssh -c 'cp -r /var/log/mongodb /home/vagrant/log'
 }
 
 setupVirtualEnv(){
@@ -339,9 +340,9 @@ fetchOVALog(){
     pushd $ansible_workspace
       echo "ova-post-test ansible_host=$OVA_INTERNAL_IP ansible_user=$OVA_USER ansible_ssh_pass=$OVA_PASSWORD ansible_become_pass=$OVA_PASSWORD" > hosts
       ansible-playbook -i hosts main.yml --tags "after-test"
-      mkdir -p ${WORKSPACE}/build-deps
+      mkdir -p ${WORKSPACE}/build-log
       for log in `ls *.log | xargs` ; do
-        cp $log ${WORKSPACE}/build-deps
+        cp $log ${WORKSPACE}/build-log
       done
     popd
 }

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -21,7 +21,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # your network.
         # target.vm.network :public_network
         if ENV['WORKSPACE']
-          target.vm.synced_folder "#{ENV['WORKSPACE']}/build-deps", "/home/vagrant/src/"
+          target.vm.synced_folder "#{ENV['WORKSPACE']}/build-deps", "/home/vagrant/src/", type: "rsync"
+          target.vm.synced_folder "#{ENV['WORKSPACE']}/build-log", "/home/vagrant/log"
           target.vm.synced_folder "#{ENV['WORKSPACE']}/build-config", "/home/vagrant/src/build-config"
         end
         
@@ -84,9 +85,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           sudo service mongodb restart
           echo manual | sudo tee /etc/init/rsyslog.override
           if [ "#{ENV['MULTI']}" ]; then
-            pm2 logs > /home/vagrant/src/build/vagrant.log &
+            pm2 logs > /home/vagrant/log/build/vagrant.log &
           else
-            pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
+            pm2 logs > /home/vagrant/log/"#{ENV['REPO_NAME']}"/vagrant.log &
           fi
           waitForPM2Daemon
           pm2 start rackhd-pm2-config.yml


### PR DESCRIPTION
1) Change the synced folder type of /home/vagrant/src from VirtualBox shared folders to RSync
2) Create directory /home/vagrant/log in guest machine to sync ${WORKSPACE}/build-log in host machine
3) Redirect all logs to /home/vagrant/log and ${WORKSPACE}/build-log

The link of the RAC is https://rackhd.atlassian.net/browse/RAC-5054

After testing `vagrant up` on Jenkins Slave in Shanghai with different types, times for `waitForAPI` are shown as below.
These data are just for reference.
* the VirtualBox shared folder: ~130s
* the VirtualBox shared folder and copy another src for use: ~30s
* NFS: ~40s
* RSync: ~10s