### PR TITLE
add dh-virtualenv

### DIFF
--- a/vmslave-config/ansible/roles/install-package-for-build/tasks/main.yml
+++ b/vmslave-config/ansible/roles/install-package-for-build/tasks/main.yml
@@ -1,7 +1,14 @@
+- name: add dh-virtualenv repository
+  apt_repository:
+    repo: 'ppa:spotify-jyrki/dh-virtualenv'
+
 - name: Install packages for build deb
   become: true
-  apt: name={{item}} state=present
+  apt: name={{item}} state=present update_cache=yes
   with_items:
     - devscripts 
     - build-essential 
     - debhelper
+    - dh-virtualenv
+
+


### PR DESCRIPTION
Add dh-virtualenv to the debian build slave.  This is needed to build the ucs-service debian package.
@RackHD/corecommitters @RackHD/veyron 