### PR TITLE
[WIP] vBMC Deployment: revert to snapshot instead of re-deploy it everytime

### DIFF
--- a/build-config
+++ b/build-config
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 REPO_NAME="$1"
 

--- a/deployment/vm_control.sh
+++ b/deployment/vm_control.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +x
 operation_file="vm_operation.sh"
 Usage()
 {
@@ -12,7 +13,7 @@ Usage()
     echo "    ip       : the IP address of ESXi server"
     echo "    user_name: the user name of ESXi server"
     echo "    password : the password of ESXi server."
-    echo "    action   : the action should be taken on the specific VM. power_on,power_off and delete are supported"
+    echo "    action   : the action should be taken on the specific VM. power_on,power_off , take_snapshot, revert_last_snapshot and delete are supported"
     echo "    duration :the duration time between the action, the unit is second(s)"
     echo "    vm_name  : the name of VM which will be operated. Regular Expression is supported"
 }
@@ -37,7 +38,7 @@ to_array() #transform input to a array using the given IFS
 {
     IFS=$2
     result=($1)
-    i=0
+    local i=0
     result_num=${#result[@]}
     while [ $i -lt $result_num ]
     do
@@ -152,13 +153,13 @@ do
     else
         server_password=${node_info[2]}
     fi
-    ./scp_transfer.exp $server_ip $server_user_name $server_password $operation_file
+    ./scp_transfer.exp $server_ip $server_user_name $server_password $operation_file > /dev/null 2>&1
     ./check_scp.exp $server_ip $server_user_name $server_password $operation_file > /dev/null 2>&1
     if [ $? -ne 0 ];then
         echo "ERROR: file $operation_file scp fails"
         continue
     fi
-    echo "power_on power_off reset delete" | grep -w ${node_info[3]} > /dev/null 2>&1
+    echo "vm_getid power_on power_off reset delete take_snapshot revert_last_snapshot" | grep -w ${node_info[3]} > /dev/null 2>&1
     if [ $? -ne 0 ];then
         echo "ERROR: value of action ${node_info[3]} is not expected"
         continue

--- a/deployment/vm_operation.sh
+++ b/deployment/vm_operation.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh +x
 Usage()
 {
     echo "this script is used to operate VM, including power_on, power_off and delete"
@@ -14,10 +14,14 @@ vm_getid() #get the id of VM via the name, RE is supported, the return value is 
     else
         id_string=`vim-cmd vmsvc/getallvms | grep -w "${vm_name}" | awk '{print $1}'`
     fi
-    if [ -z $id_string ];then
-        return 1
+    if [ $? -ne 0 ]; then
+        return -1
     fi
-    echo $id_string
+# below three lines are commented out by Peter. they don't make sense
+#    if [ -z $id_string ];then
+#        return 1
+#    fi
+    echo ${id_string} # echo the result as a return value
     return 0
 }
 
@@ -32,6 +36,45 @@ vm_getname() #get the name of VM via ID, return ID if fails
     echo $vm_name
     return 0
 }
+
+
+take_snapshot() # parameter: vm_id
+{
+    duration=$1
+    shift 1
+    for vmid in $@
+    do
+        vm_name=`vm_getname $vmid`
+        SNAPSHOTNAME=${vm_name}$(date +%Y-%m-%d:%H:%M:%S)
+        echo "[ESX] Creating Snapshot for $vm_name, named $SNAPSHOTNAME"
+        vim-cmd  vmsvc/snapshot.create $vmid   $SNAPSHOTNAME
+        sleep $duration 
+    done
+}
+
+revert_last_snapshot() #parameter: vm_id
+{
+    duration=$1
+    shift 1
+    for vmid in $@
+    do
+        vm_name=`vm_getname $vmid`
+        last_snapshot_id=$(  vim-cmd  vmsvc/snapshot.get ${vmid}|   grep "Snapshot Id"|  tail -1|awk '{print $NF}')
+        last_snapshot_name=$(vim-cmd  vmsvc/snapshot.get ${vmid}| grep "Snapshot Name"|  tail -1|awk '{print $NF}')
+        if [ "$last_snapshot_id" == "" ]; then
+            echo "[ESX] no Snapshot ever taken. force take a snapshot"
+            take_snapshot $duration $vmid
+            last_snapshot_id=$(  vim-cmd  vmsvc/snapshot.get ${vmid}|   grep "Snapshot Id"|  tail -1|awk '{print $NF}')
+            last_snapshot_name=$(vim-cmd  vmsvc/snapshot.get ${vmid}| grep "Snapshot Name"|  tail -1|awk '{print $NF}')
+        fi
+        echo "[ESX] Revert VM ${vm_name} to last snapshot : ${last_snapshot_name} "
+        suppressPowerOn=false
+        vim-cmd  vmsvc/snapshot.revert  $vmid   $last_snapshot_id $suppressPowerOn
+        sleep $duration 
+    done
+
+}
+
 
 power_action() #id_string action(on/off/reset)
 {
@@ -121,11 +164,22 @@ shift 2
 for vm in $@
 do
     vm_ids=`vm_getid $vm`
+    echo "[DEBUG] vm_ids==${vm_ids}"
     if [ $? -ne 0 ];then
         echo "ERROR: can't get the VM ID via the name ${vm}"
         continue
     fi
     case $vm_action in
+        "vm_getid")  
+            ret_msg=$(vm_getid $vm )
+            if [ -n "$ret_msg" ]; then
+                 echo "return_from_vm_getid $ret_msg"
+             else
+                 echo "return_from_vm_getid : Not Found "
+             fi
+            ;;
+        "take_snapshot") take_snapshot $duration $vm_ids;;
+        "revert_last_snapshot") revert_last_snapshot $duration $vm_ids;;
         "power_on") power_action "on" $duration $vm_ids;;
         "power_off") power_action "off" $duration $vm_ids;;
         "reset") power_action "reset" $duration $vm_ids;;

--- a/jobs/FunctionTest/prepare_common.sh
+++ b/jobs/FunctionTest/prepare_common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 export VCOMPUTE=("${NODE_NAME}-Rinjin1","${NODE_NAME}-Rinjin2","${NODE_NAME}-Quanta")
 
 VCOMPUTE="${VCOMPUTE}"
@@ -7,7 +7,11 @@ if [ -z "${VCOMPUTE}" ]; then
 fi
 
 
+
+
+
 nodesDelete() {
+  echo "[prepare_common.sh] nodesDelete"
   cd ${WORKSPACE}/build-config/deployment/
   if [ "${USE_VCOMPUTE}" != "false" ]; then
     VCOMPUTE+=("${NODE_NAME}-ova-for-post-test")
@@ -18,6 +22,7 @@ nodesDelete() {
 }
 
 cleanupENVProcess() {
+  echo "[prepare_common.sh] cleanupENVProcess"
   # Kill possible socat process left by ova-post-smoke-test
   # eliminate the effect to other test
   socat_process=`ps -ef | grep socat | grep -v grep | awk '{print $2}' | xargs`
@@ -27,6 +32,7 @@ cleanupENVProcess() {
 }
 
 clean_running_containers() {
+    echo "[prepare_common.sh]  clean_running_containers"
     local containers=$(docker ps -a -q)
     if [ "$containers" != "" ]; then
         echo "Clean Up containers : " ${containers}
@@ -35,9 +41,11 @@ clean_running_containers() {
     fi
 }
 
+echo "[prepare_common.sh]  --- start ---"
 if [ "$SKIP_PREP_DEP" == false ] ; then
   # Prepare the latest dependent repos to be shared with vagrant
-  nodesDelete
+  #nodesDelete
   cleanupENVProcess
   clean_running_containers
 fi
+echo "[prepare_common.sh]  --- ends ---"

--- a/jobs/FunctionTest/prepare_manifest.sh
+++ b/jobs/FunctionTest/prepare_manifest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog")
 
 HTTP_STATIC_FILES="${HTTP_STATIC_FILES}"
@@ -40,6 +40,7 @@ wget_download(){
 
 
 dlHttpFiles() {
+  echo "[prepare_manifest.sh] dlHttpFiles"
   dir=${WORKSPACE}/build-deps/on-http/static/http/common
   mkdir -p ${dir} && cd ${dir}
   if [ -n "${INTERNAL_HTTP_ZIP_FILE_URL}" ]; then
@@ -62,6 +63,7 @@ dlHttpFiles() {
 }
 
 dlTftpFiles() {
+  echo "[prepare_manifest.sh] dlTftpFiles"
   dir=${WORKSPACE}/build-deps/on-tftp/static/tftp
   mkdir -p ${dir} && cd ${dir}
   if [ -n "${INTERNAL_TFTP_ZIP_FILE_URL}" ]; then
@@ -83,6 +85,7 @@ dlTftpFiles() {
 }
 
 preparePackages() {
+    echo "[prepare_manifest.sh] preparePackages"
     pushd ${WORKSPACE}
     ./build-config/build-release-tools/HWIMO-BUILD ./build-config/build-release-tools/application/reprove.py \
     --manifest ${MANIFEST_FILE} \

--- a/test.sh.in
+++ b/test.sh.in
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-export VCOMPUTE=("${NODE_NAME}-Rinjin1","${NODE_NAME}-Rinjin2","${NODE_NAME}-Quanta")
+export VCOMPUTE=("${NODE_NAME}-Rinjin1" "${NODE_NAME}-Rinjin2" "${NODE_NAME}-Quanta")
 export UCSPE=("${NODE_NAME}-UCSPE")
 RUN_FIT_TEST="${RUN_FIT_TEST}"
 if [ ! -z "${4}" ]; then
@@ -12,6 +12,11 @@ fi
 MODIFY_API_PACKAGE="${MODIFY_API_PACKAGE}"
 
 cleanupVMs(){
+    set +e
+    if [ -f ${WORKSPACE}/RackHD/example/Vagrantfile ]; then
+        vnc_record_stop
+    fi
+
     vagrantDestroy
     # Suspend any other running vagrant boxes
     vagrantSuspendAll
@@ -76,7 +81,7 @@ execWithTimeout() {
   fi
   echo "execWithTimeout() retry count is $retry"
   echo "execWithTimeout() timeout is set to $timeout"
-  i=1
+  local i=1
   while [[ $i -le $retry ]]
   do
     expect -c "set timeout $timeout; spawn -noecho $cmd; expect timeout { exit 1 } eof { exit 0 }"
@@ -139,14 +144,75 @@ nodesDelete() {
   fi
 }
 
-nodesCreate() {
+nodesRevertSnapshot() {
   cd ${WORKSPACE}/build-config/deployment/
   if [ "${USE_VCOMPUTE}" != "false" ]; then
-    for i in {1..2}
-    do
-      execWithTimeout "ovftool --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE}  --name='${NODE_NAME}-Rinjin${i}' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vRinjin-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+    for i in ${VCOMPUTE[@]}; do
+      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},revert_last_snapshot,1,${i}_*"
     done
-    execWithTimeout "ovftool  --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE} --name='${NODE_NAME}-Quanta' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vQuanta-T41-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+  fi
+
+}
+
+#######################
+# Param1:   the vm_name to be searched
+#
+# Return:   0 means exist, 1 means not-found 
+######################
+nodeExistCheck(){
+    vm_name=$1
+    if [ "$vm_name" == "" ]; then
+        return 1
+    fi
+    get_vmid_output=$(./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},vm_getid,0,${vm_name}")
+
+    echo "${get_vmid_output}" | grep "return_from_vm_getid" |grep "Not Found"; # use $? to check grep result
+    #it's a bad implementation. it assumes the output of above command will contain a line: "return_from_vm_getid : Not Found"
+
+    if [ $? -eq 0 ]; then  # there's output for above grep
+        return 1
+    else
+        return 0
+    fi
+
+}
+
+#########################
+# deploy vBMC if not exist, and revert to last snapshot if vBMC already deployed
+#
+########################
+nodesCreate() {
+  cd ${WORKSPACE}/build-config/deployment/
+
+  VM_OVA_FILE_LIST=("${HOME}/isofarm/OVA/vRinjin-Haswell.ova" "${HOME}/isofarm/OVA/vRinjin-Haswell.ova" "${HOME}/isofarm/OVA/vQuanta-T41-Haswell.ova")
+
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    local i=0
+    for vm_name in "${VCOMPUTE[@]}"
+    do
+        set +e
+        nodeExistCheck $vm_name
+        if [ $? -eq 0 ]; then # VM Name Found
+             echo "[ESX] vNode (name=$vm_name) already in place, skip the ova deployment."
+             echo "[ESX] revert vNode (name=$vm_name) to its last VM snapshot."
+             set -e
+             nodesRevertSnapshot
+        else
+             ova_file=${VM_OVA_FILE_LIST[${i}]}
+             if [ ! -f $ova_file ]; then
+                 echo "[Error] OVA File Not Found (file=$ova_file), Abort!"
+                 exit 2
+             fi
+             echo "[ESX] Newly deploy OVA image($ova_file) with vm name $vm_name"
+             set -e
+             execWithTimeout "ovftool --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE}  --name='${vm_name}' --net:'${NIC}=${NODE_NAME}-switch' '${ova_file}'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+             if [ $? -ne 0 ]; then
+                 echo "[Error] Deploy vNode failed($vm_name). Aborted!"
+                 exit 3
+             fi
+        fi
+        i=$(( $i + 1 ))
+    done
   else
     nodesOff
   fi
@@ -221,11 +287,14 @@ vnc_record_start(){
   # including vagrant ssh -c "bash xx.sh " &
   nohup vagrant ssh -c "cd /home/vagrant/src/build-config/;   bash vnc_record.sh /home/vagrant/log/ $fname_prefix" &
   #/home/vagrant/log/ will be mapped to host(outside vagrant)'s $WORKSPACE/build-log
+  popd
 }
 
 vnc_record_stop(){
   #sleep 2 sec to ensure FLV finishes the disk I/O before VM destroyed
+  pushd ${WORKSPACE}/RackHD/example 
   vagrant ssh -c 'set +e ;    pkill flvrec.py;  sleep 2 ' 
+  popd
 
 }
 


### PR DESCRIPTION
**Background**
per @changev, in SH Jenkins Sandbox. it's observed the parallel vBMC ova deployment  will hang for a long time and cause timeout .
so using snapshot management instead of re-deployment is another option.

**Detail**
in test.sh
1.  will use ```nodeExistCheck``` to check if the vBMC already deployed
2. if no , use ```"ovftool``` to deploy the OVA from isofarm
3. if vBMC already in place, call ```nodesRevertSnapshot``` to revert it to a snapshot
4. then ```revert_last_snapshot``` will be invoked. if there was any snapshot taken, revert the VM to last snapshot. else, force the VM to take a snapshot , then revert to it .

**TestDone**
SH Sandbox :   http://**.**.**.175:8080/job/ContinuousTest/656/

