### PR TITLE
[WIP] using NFS instead of rsync

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -160,6 +160,9 @@ vagrantSuspendAll() {
 
 CONFIG_PATH=${CONFIG_PATH-build-config/vagrant/config/mongo}
 vagrantUp() {
+  sudo apt-get -y install nfs-kernel-server
+  sudo service nfs-kernel-server start
+
   cd ${WORKSPACE}/RackHD/example
   cp -rf ${WORKSPACE}/build-config/vagrant/* .
   mkdir -p ${WORKSPACE}/build-log

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -20,8 +20,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # Bridged networks make the machine appear as another physical device on
         # your network.
         # target.vm.network :public_network
+        
+        target.vm.network "public_network", ip: "172.31.128.1", bridge: "em1"
+        target.vm.network "private_network",ip: "192.168.1.111" 
+         
         if ENV['WORKSPACE']
-          target.vm.synced_folder "#{ENV['WORKSPACE']}/build-deps", "/home/vagrant/src/", type: "rsync"
+          target.vm.synced_folder "#{ENV['WORKSPACE']}/build-deps", "/home/vagrant/src/", type: "nfs"
           target.vm.synced_folder "#{ENV['WORKSPACE']}/build-log", "/home/vagrant/log"
           target.vm.synced_folder "#{ENV['WORKSPACE']}/build-config", "/home/vagrant/src/build-config"
         end
@@ -42,7 +46,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           end
         end
         
-        target.vm.network "public_network", ip: "172.31.128.1", bridge: "em1"
         target.vm.network "forwarded_port", guest: 8080, host: 9090
         target.vm.network "forwarded_port", guest: 5672, host: 9091
         target.vm.network "forwarded_port", guest: 9080, host: 9092


### PR DESCRIPTION
**Background**
in SH Sandbox , rsync(vagrant mount src folder) suffered from failure from time to time. example faiure:
```
Guest path: /home/vagrant/src
Command: "rsync" "--verbose" "--archive" "--delete" "-z" "--copy-links" "--no-owner" "--no-group" "--rsync-path" "sudo rsync" "-e" "ssh -p 2222 -o LogLevel=FATAL  -o ControlMaster=auto -o ControlPath=/tmp/ssh.829 -o ControlPersist=10m  -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i '/home/****/workspace/Master-CI-RAC-4783/RackHD/example/.vagrant/machines/dev/virtualbox/private_key'" "--exclude" ".vagrant/" "/home/****/workspace/Master-CI-RAC-4783/build-deps/" "vagrant@127.0.0.1:/home/vagrant/src"
Error: rsync: [sender] write error: Broken pipe (32)
rsync error: error in rsync protocol data stream (code 12) at io.c(837) [sender=3.1.0]
script returned exit code 1
```

so that's why I tried "NFS" instead

**Details**
using NFS in vagrant requires below steps:
(1) Install NFS Server on slave
```
sudo apt-get install -y nfs-kernel-server
sudo service nfs-kernel-server start
```
(2) adding a private network in Vagrantfile acting as NFS server
```target.vm.network "private_network", ip: "192.168.1.1"```
(3) add below into ```/etc/sudoers``` of slave 
```
Cmnd_Alias VAGRANT_EXPORTS_CHOWN = /bin/chown 0\:0 /tmp/*
Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/* /etc/exports
Cmnd_Alias VAGRANT_NFSD_CHECK = /etc/init.d/nfs-kernel-server status
Cmnd_Alias VAGRANT_NFSD_START = /etc/init.d/nfs-kernel-server start
Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
%sudo ALL=(root) NOPASSWD: VAGRANT_EXPORTS_CHOWN, VAGRANT_EXPORTS_MV, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY
```
unlucky, I didn't find a way to do it in a script...

(4) install nfs client inside vagrant box( it's nice to do it during box creation to save time)

**TestDone**
run on Sandbox.
SH Sandbox : http://..**.175:8080/job/ContinuousTest/656/



**Reviewer**
@anhou  @lanchongyizu  @PengTian0  @changev 