### PR TITLE
Add slack notification to start of ContinuousTest and sendResult

### DIFF
--- a/jobs/ContinuousTest/Jenkinsfile
+++ b/jobs/ContinuousTest/Jenkinsfile
@@ -1,4 +1,7 @@
 node{
+    def message = "Job Name: ${env.JOB_NAME} \n" + "Build Full URL: ${env.BUILD_URL} \n" + "Phase: STARTED \n"
+    echo "$message"
+    slackSend "$message"
     deleteDir()
     dir("build-config"){
         checkout scm

--- a/jobs/ShareMethod.groovy
+++ b/jobs/ShareMethod.groovy
@@ -125,6 +125,9 @@ def sendResult(boolean sendJenkinsBuildResults, boolean sendTestResults){
                 currentBuild.result = "SUCCESS"
             }
             step([$class: 'VTestResultsAnalyzerStep', sendJenkinsBuildResults: sendJenkinsBuildResults, sendTestResults: sendTestResults])
+            def message = "Job Name: ${env.JOB_NAME} \n" + "Build Full URL: ${env.BUILD_URL} \n" + "Status: " + currentBuild.result + "\n"
+            echo "$message"
+            slackSend "$message"
         } catch(error){
             echo "Caught: ${error}"
         }


### PR DESCRIPTION
Starting to add more slack notifications to tests so we can transition away from using Zapier.  
This adds it to the start and end of ContinuousFunctionTest so we have a frequently run example that we can tests on.

Example of the a notification sent by the PR gate for this PR:  https://codecommunity.slack.com/archives/C4N0F790T/p1496786218622025