### PR TITLE
Add slack notifications for start of MasterCI and SprintRelease

### DIFF
--- a/jobs/MasterCI/MasterCI
+++ b/jobs/MasterCI/MasterCI
@@ -14,6 +14,9 @@ node{
         "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
         "PUBLISH=${env.PUBLISH}"
     ]){
+        def message = "Job Name: ${env.JOB_NAME} \n" + "Build Full URL: ${env.BUILD_URL} \n" + "Phase: STARTED \n"
+        echo "$message"
+        slackSend "$message"
         deleteDir()
         checkout scm
         def shareMethod = load("jobs/ShareMethod.groovy")

--- a/jobs/SprintRelease/Jenkinsfile
+++ b/jobs/SprintRelease/Jenkinsfile
@@ -18,6 +18,9 @@ node{
         "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
         "BINTRAY_REPO=binary"])
     {
+        def message = "Job Name: ${env.JOB_NAME} \n" + "Build Full URL: ${env.BUILD_URL} \n" + "Phase: STARTED \n"
+        echo "$message"
+        slackSend "$message"
         deleteDir()
         checkout scm
         def shareMethod = load("jobs/ShareMethod.groovy")


### PR DESCRIPTION
Continuous Functional test slack notifications seem to be working so I am now adding the start notifications for MasterCI and SprintRelease.  This completes the slack notifications that are currently be relayed by Zapier.