### PR TITLE
Modifications made to add support for image service PR gate

### DIFF
--- a/build-config
+++ b/build-config
@@ -28,17 +28,17 @@ else
   rm sed.script
 fi
 
-echo "Generating pre deployment file from template"		
-if [ -e "${REPO_NAME}/pre-deploy.sh.in" ]; then		
-  env | sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > sed.script		
-  cat ${REPO_NAME}/pre-deploy.sh.in | sed -f sed.script > pre-deploy.sh		
-  chmod oug+x pre-deploy.sh		
-  rm sed.script		
-else		
-  env | sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > sed.script		
-  cat pre-deploy.sh.in | sed -f sed.script > pre-deploy.sh		
-  chmod oug+x pre-deploy.sh		
-  rm sed.script		
+echo "Generating pre deployment file from template"
+if [ -e "${REPO_NAME}/pre-deploy.sh.in" ]; then
+  env | sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > sed.script
+  cat ${REPO_NAME}/pre-deploy.sh.in | sed -f sed.script > pre-deploy.sh
+  chmod oug+x pre-deploy.sh
+  rm sed.script
+else
+  env | sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > sed.script
+  cat pre-deploy.sh.in | sed -f sed.script > pre-deploy.sh
+  chmod oug+x pre-deploy.sh
+  rm sed.script
 fi
 
 echo "Generating post deployment file from template"

--- a/build-release-tools/application/nightly_build_clean_up.py
+++ b/build-release-tools/application/nightly_build_clean_up.py
@@ -6,7 +6,7 @@ This is a command line program that clean up the overdue nightly builds.
 
 NOTE:
 The release build will never be deleted by this script.
-because 
+because
 get_build_date_from_version() will return NULL for bintray/dockerhub sub routine, and "continue" to skip deletion.
 for vagrant,  release build starts from 1. and old builds are only two digit(0.1x), so the sub-routine will skip the deletion also.
 
@@ -119,7 +119,7 @@ def parse_args(args):
     return parsed_args
 
 RACKHD_REPOS = ["on-imagebuilder", "on-core", "on-syslog", "on-dhcp-proxy", "files", "on-tftp", \
-                "on-wss", "on-statsd", "on-tasks", "on-taskgraph", "on-http", "rackhd", "ucs-service"]
+                "on-wss", "on-statsd", "on-tasks", "on-taskgraph", "on-http", "rackhd", "ucs-service", "image-service"]
 
 def clean_bintray_nightly_builds(bintray_cred, bintray_subject, bintray_repo, date_range):
     """
@@ -160,7 +160,7 @@ def clean_atlas_nightly_builds(atlas_cred, atlas_name, atlas_url, date_range):
     for version in versions:
         version_segments = [i for i in version.split(".")]
         if len(version_segments) < 3:
-        # atlas support version like 0.16 , but nightly builds are all 0.x.y 
+        # atlas support version like 0.16 , but nightly builds are all 0.x.y
             continue
         y = version_segments[1]
         if int(y) == 0:

--- a/build-release-tools/application/parse_manifest.py
+++ b/build-release-tools/application/parse_manifest.py
@@ -49,7 +49,7 @@ def write_downstream_parameters(repos_under_test, parameters_file):
 
     repos_need_unit_test = []
     for repo_name in repos_under_test:
-        if repo_name in ["on-core", "on-tasks", "on-http", "on-tftp", "on-dhcp-proxy", "on-taskgraph", "on-syslog"]:
+        if repo_name in ["on-core", "on-tasks", "on-http", "on-tftp", "on-dhcp-proxy", "on-taskgraph", "on-syslog", "image-service"]:
             repos_need_unit_test.append(repo_name)
 
         if repo_name == "on-core":

--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -34,7 +34,7 @@ tagCalculate() {
     else
         CHANGELOG_VERSION=$RACKHD_CHANGELOG_VERSION
     fi
-    
+
     #generate real TAG
     if [ "$IS_OFFICIAL_RELEASE" == "true" ]; then
         PKG_TAG="$CHANGELOG_VERSION"
@@ -47,10 +47,11 @@ tagCalculate() {
 }
 
 doBuild() {
-    # List order is important, on-tasks image build is based on on-core image, 
-    # on-http and on-taskgraph ard based on on-tasks image 
+    # List order is important, on-tasks image build is based on on-core image,
+    # on-http and on-taskgraph ard based on on-tasks image
     # others are based on on-core image
-    repos=$(echo "on-imagebuilder on-core on-syslog on-dhcp-proxy on-tftp on-wss on-statsd on-tasks on-taskgraph on-http ucs-service")
+    repos=$(echo "on-imagebuilder on-core on-syslog on-dhcp-proxy on-tftp on-wss on-statsd on-tasks
+    on-taskgraph on-http ucs-service")
     #Record all repo:tag for post-pushing
     repos_tags=""
     #Set an empty TAG before each build
@@ -90,12 +91,12 @@ doBuild() {
                 "on-tasks")
                     PRE_TAG=$TAG
                     ;;
-            esac 
+            esac
             mv ../Dockerfile.bak Dockerfile
         popd
     done
 
-    # write build list to a file for guiding image push. 
+    # write build list to a file for guiding image push.
     pushd $WORKDIR
     echo "Imagename:tag list of this build is $repos_tags"
     echo $repos_tags >> build_record

--- a/build-release-tools/lib/manifest-pr-gate.json
+++ b/build-release-tools/lib/manifest-pr-gate.json
@@ -49,7 +49,7 @@
             "repository": "https://github.com/RackHD/RackHD.git"
         }, 
         {
-            "branch": "", 
+            "branch": "",
             "commit-id": "",
             "repository": "https://github.com/RackHD/on-build-config.git"
         },
@@ -57,7 +57,11 @@
             "branch": "",
             "commit-id": "",
             "repository": "https://github.com/RackHD/ucs-service.git"
+        },
+        {
+            "branch": "",
+            "commit-id": "",
+            "repository": "https://github.com/RackHD/image-service.git"
         }
-
     ]
 }

--- a/image-service/test.sh.in
+++ b/image-service/test.sh.in
@@ -1,0 +1,455 @@
+#!/bin/bash -ex
+export VCOMPUTE=("${NODE_NAME}-Rinjin1","${NODE_NAME}-Rinjin2","${NODE_NAME}-Quanta")
+export UCSPE=("${NODE_NAME}-UCSPE")
+RUN_FIT_TEST="${RUN_FIT_TEST}"
+if [ ! -z "${4}" ]; then
+  RUN_FIT_TEST=$4
+fi
+RUN_CIT_TEST="${RUN_CIT_TEST}"
+if [ ! -z "${5}" ]; then
+  RUN_FIT_TEST=$5
+fi
+MODIFY_API_PACKAGE="${MODIFY_API_PACKAGE}"
+
+cleanupVMs(){
+    vagrantDestroy
+    # Suspend any other running vagrant boxes
+    vagrantSuspendAll
+
+    # Delete any running VMs
+    virtualBoxDestroyAll
+
+    rm -rf "$HOME/VirtualBox VMs"
+}
+
+apiPackageModify() {
+    pushd ${WORKSPACE}/build-deps/on-http/extra
+    sed -i "s/.*git symbolic-ref.*/ continue/g" make-deb.sh
+    sed -i "/build-package.bash/d" make-deb.sh
+    sed -i "/GITCOMMITDATE/d" make-deb.sh
+    sed -i "/mkdir/d" make-deb.sh
+    bash make-deb.sh
+    popd
+    for package in ${API_PACKAGE_LIST}; do
+      sudo pip uninstall -y ${package//./-} || true
+      pushd ${WORKSPACE}/build-deps/on-http/$package
+        fail=true
+        while $fail; do
+          python setup.py install
+          if [ $? -eq 0 ];then
+        	  fail=false
+          fi
+        done
+      popd
+    done
+}
+
+VCOMPUTE="${VCOMPUTE}"
+if [ -z "${VCOMPUTE}" ]; then
+  VCOMPUTE=("jvm-Quanta_T41-1" "jvm-vRinjin-1" "jvm-vRinjin-2")
+fi
+
+TEST_GROUP="${TEST_GROUP}"
+if [ -z "${TEST_GROUP}" ]; then
+   TEST_GROUP="smoke-tests"
+fi
+
+execWithTimeout() {
+  set +e
+  # $1 command to execute
+  # $2 timeout
+  # $3 retries on timeout
+  if [ -z "${1}" ]; then
+     echo "execWithTimeout() Command not specified"
+     exit 2
+  fi
+  cmd="/bin/sh -c \"$1\""
+  #timeout default to one minute
+  timeout=90
+  retry=3
+  result=0
+  if [ ! -z "${2}" ]; then
+    timeout=$2
+  fi
+  if [ ! -z "${3}" ]; then
+    retry=$3
+  fi
+  echo "execWithTimeout() retry count is $retry"
+  echo "execWithTimeout() timeout is set to $timeout"
+  i=1
+  while [[ $i -le $retry ]]
+  do
+    expect -c "set timeout $timeout; spawn -noecho $cmd; expect timeout { exit 1 } eof { exit 0 }"
+    result=$?
+    echo "execWithTimeout() exit code $result"
+    if [ $result = 0 ] ; then
+       break
+    fi
+    ((i = i + 1))
+  done
+  if [ $result = 1 ] ; then
+       echo "execWithTimeout() command timed out $retry times after $timeout seconds"
+       exit 1
+  fi
+  set -e
+}
+
+ucsReset() {
+  cd ${WORKSPACE}/build-config/deployment/
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    for i in ${UCSPE[@]}; do
+      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},reset,1,${i}_*"
+    done
+  fi
+}
+
+nodesOff() {
+  cd ${WORKSPACE}/build-config/deployment/
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    for i in ${VCOMPUTE[@]}; do
+      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},power_off,1,${i}_*"
+    done
+  else
+     ./telnet_sentry.exp ${SENTRY_HOST} ${SENTRY_USER} ${SENTRY_PASS} off ${OUTLET_NAME}
+     sleep 5
+  fi
+}
+
+nodesOn() {
+  cd ${WORKSPACE}/build-config/deployment/
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    for i in ${VCOMPUTE[@]}; do
+      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},power_on,1,${i}_*"
+    done
+  else
+     ./telnet_sentry.exp ${SENTRY_HOST} ${SENTRY_USER} ${SENTRY_PASS} on ${OUTLET_NAME}
+     sleep 5
+  fi
+}
+
+nodesDelete() {
+  cd ${WORKSPACE}/build-config/deployment/
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    if [ ${OVA_POST_TEST} == "true" ]; then
+      VCOMPUTE+=("${NODE_NAME}-ova-for-post-test")
+    fi
+    for i in ${VCOMPUTE[@]}; do
+      ./vm_control.sh "${ESXI_HOST},${ESXI_USER},${ESXI_PASS},delete,1,${i}_*"
+    done
+  fi
+}
+
+nodesCreate() {
+  cd ${WORKSPACE}/build-config/deployment/
+  if [ "${USE_VCOMPUTE}" != "false" ]; then
+    for i in {1..2}
+    do
+      execWithTimeout "ovftool --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE}  --name='${NODE_NAME}-Rinjin${i}' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vRinjin-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+    done
+    execWithTimeout "ovftool  --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE} --name='${NODE_NAME}-Quanta' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vQuanta-T41-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+  else
+    nodesOff
+  fi
+}
+
+vagrantSuspendAll() {
+ for box in `vagrant global-status --prune | awk '/running/{print $1}'`; do
+     vagrant suspend ${box}
+ done
+}
+
+CONFIG_PATH=${CONFIG_PATH-build-config/vagrant/config/mongo_image_service}
+vagrantUp() {
+  cd ${WORKSPACE}/RackHD/example
+  cp -rf ${WORKSPACE}/build-config/vagrant/* .
+  mkdir -p ${WORKSPACE}/build-log
+  result=0
+  for i in {1..2}
+  do
+      CONFIG_DIR=${CONFIG_PATH} WORKSPACE=${WORKSPACE} vagrant up --provision
+      result=$?
+      if [ $result -ne 0 ]; then
+          echo "Vagrant up failed!! retry one more time"
+          vagrant destroy -f
+          #suspend all running instance
+          vagrantSuspendAll
+          #rmeove all VMs before retying
+          rm -rf "$HOME/VirtualBox VMs"
+          rm "$HOME/.config/VirtualBox/VirtualBox.xml"
+      else
+          echo "Vagrant up passed."
+          break
+      fi
+  done
+  if [ $result -ne 0 ]; then
+      echo "Vagrant up failed."
+      exit 1
+  fi
+}
+
+vagrantDestroy() {
+  cd ${WORKSPACE}/RackHD/example
+  vagrant destroy -f
+}
+
+vagrantHalt() {
+  cd ${WORKSPACE}/RackHD/example
+  vagrant halt
+}
+
+virtualBoxDestroyAll() {
+  set +e
+  for uuid in `vboxmanage list vms | awk '{print $2}' | tr -d '{}'`; do
+    echo "shutting down vm ${uuid}"
+    vboxmanage controlvm ${uuid} poweroff
+    echo "deleting vm ${uuid}"
+    vboxmanage unregistervm ${uuid}
+  done
+  set -e
+}
+
+vnc_record_start(){
+  pushd ${WORKSPACE}/RackHD/example # to use the Vagrantfile in it
+  export fname_prefix="vNode"
+  if [ ! -z $BUILD_ID ]; then
+      export fname_prefix=${fname_prefix}_b${BUILD_ID}
+  fi
+
+  #http://stackoverflow.com/questions/25331758/vagrant-ssh-c-and-keeping-a-background-process-running-after-connection-closed/27327955
+  #trying various ways to  detach the process from the shell,  but all not working 
+  # including vagrant ssh -c "nohup bash xx.sh & "
+  # including vagrant ssh -c "bash xx.sh " &
+  nohup vagrant ssh -c "cd /home/vagrant/src/build-config/;   bash vnc_record.sh /home/vagrant/log/ $fname_prefix" &
+  #/home/vagrant/log/ will be mapped to host(outside vagrant)'s $WORKSPACE/build-log
+}
+
+vnc_record_stop(){
+  #sleep 2 sec to ensure FLV finishes the disk I/O before VM destroyed
+  vagrant ssh -c 'set +e ;    pkill flvrec.py;  sleep 2 ' 
+
+}
+
+
+
+generateSolLog(){
+  cd ${WORKSPACE}/RackHD/example
+  vagrant ssh -c 'cd /home/vagrant/src/build-config/; \
+        bash generate-sol-log.sh' > ${WORKSPACE}/sol.log &
+}
+
+generateSysLog(){
+  cd ${WORKSPACE}/RackHD/example
+  vagrant ssh -c 'dmesg > /home/vagrant/log/dmesg.log'
+  vagrant ssh -c 'cp /var/log/syslog /home/vagrant/log/syslog.log'
+}
+
+generateMongoLog(){
+  cd ${WORKSPACE}/RackHD/example
+  vagrant ssh -c 'cp -r /var/log/mongodb /home/vagrant/log'
+}
+
+setupVirtualEnv(){
+  pushd ${WORKSPACE}/RackHD/test
+  rm -rf .venv/on-build-config
+  ./mkenv.sh on-build-config
+  source myenv_on-build-config
+  popd
+  if [ "$MODIFY_API_PACKAGE" == true ] ; then
+      apiPackageModify
+  fi
+}
+
+BASE_REPO_URL="${BASE_REPO_URL}"
+runTests() {
+  set +e
+  if [ "$RUN_FIT_TEST" == true ] ; then
+     cd ${WORKSPACE}/RackHD/test
+     #TODO Parameterize FIT args
+     python run_tests.py -test deploy/rackhd_stack_init.py -stack vagrant  -port 9090 -xunit
+     if [ $? -ne 0 ]; then
+         echo "Test FIT failed running deploy/rackhd_stack_init.py"
+         exit 1
+     fi
+     python run_tests.py -test tests -group imageservice -stack vagrant -extra imageservice_config.json -port 9090 -v 9 -xunit
+     if [ $? -ne 0 ]; then
+         echo "Test FIT failed running smoke test"
+         exit 1
+     fi
+     mkdir -p ${WORKSPACE}/xunit-reports
+     cp *.xml ${WORKSPACE}/xunit-reports
+  fi
+  if [ "$RUN_CIT_TEST" == true ] ; then
+     read array<<<"${TEST_GROUP}"
+     args=()
+     group=" --group="
+     for item in $array; do
+        args+="${group}${item}"
+     done
+     cp -f ${WORKSPACE}/build-config/config.ini ${WORKSPACE}/RackHD/test/config
+     cd ${WORKSPACE}/RackHD/test
+     RACKHD_BASE_REPO_URL=${BASE_REPO_URL} RACKHD_TEST_LOGLVL=INFO \
+     python run.py ${args} --with-xunit
+     mkdir -p ${WORKSPACE}/xunit-reports
+     cp *.xml ${WORKSPACE}/xunit-reports
+  fi
+  set -e
+}
+
+waitForAPI() {
+  timeout=0
+  maxto=60
+  set +e
+  url=http://localhost:9090/api/2.0/nodes
+  while [ ${timeout} != ${maxto} ]; do
+    wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue ${url}
+    if [ $? = 0 ]; then 
+      break
+    fi
+    sleep 10
+    timeout=`expr ${timeout} + 1`
+  done
+  set -e
+  if [ ${timeout} == ${maxto} ]; then
+    echo "Timed out waiting for RackHD API service (duration=`expr $maxto \* 10`s)."
+    exit 1
+  fi
+}
+
+######################################
+#    OVA POST SMOKE TEST RELATED     #
+######################################
+portForwarding(){
+    # forward ova to localhost
+    # according to vagrant/mongo/config.json and cit/fit config
+    socat TCP4-LISTEN:9091,forever,reuseaddr,fork TCP4:$1:5672 &
+    socat TCP4-LISTEN:9090,forever,reuseaddr,fork TCP4:$1:8080 &
+    socat TCP4-LISTEN:9092,forever,reuseaddr,fork TCP4:$1:9080 &
+    socat TCP4-LISTEN:9093,forever,reuseaddr,fork TCP4:$1:8443 &
+    socat TCP4-LISTEN:2222,forever,reuseaddr,fork TCP4:$1:22 &
+    echo "Finished ova -> localhost port forwarding"
+    echo "5672->9091"
+    echo "8080->9090"
+    echo "9080->9092"
+    echo "8443->9093"
+    echo "22->2222"
+}
+
+fetchOVALog(){
+    ansible_workspace=${WORKSPACE}/build-config/jobs/build_ova/ansible
+    # fetch rackhd log
+    pushd $ansible_workspace
+      echo "ova-post-test ansible_host=$OVA_INTERNAL_IP ansible_user=$OVA_USER ansible_ssh_pass=$OVA_PASSWORD ansible_become_pass=$OVA_PASSWORD" > hosts
+      ansible-playbook -i hosts main.yml --tags "after-test"
+      mkdir -p ${WORKSPACE}/build-log
+      for log in `ls *.log | xargs` ; do
+        cp $log ${WORKSPACE}/build-log
+      done
+    popd
+}
+
+######################################
+#  OVA POST SMOKE TEST RELATED END   #
+######################################
+
+if [ "$RUN_CIT_TEST" == true ] || [ "$RUN_FIT_TEST" == true ] ; then
+  if [ "$TEST_TYPE" == "ova" ]; then
+    # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
+    
+    nodesCreate
+    
+    # Prepare RackHD
+    # Forward local host port to ova
+    portForwarding ${OVA_INTERNAL_IP}
+
+    # We setup the virtual-environment here, since once we
+    # call "nodesOn", it's a race to get to the first test
+    # before the nodes get booted far enough to start being
+    # seen by RackHD. Logically, it would be better IN runTests.
+    # We do it between the vagrant and waitForAPI to use the
+    # time to make the env instead of doing sleeps...
+    setupVirtualEnv
+    waitForAPI
+    nodesOn &
+    # Doesn't support ova smoke test now
+    # generateSolLog
+    # Run tests
+    runTests
+    # exit venv
+    deactivate
+
+    # Remedial work
+    # Specific remedial work
+    fetchOVALog
+
+    # Clean Up below
+
+    #shutdown vagrant box and delete all resource (like removing vm disk files in "~/VirtualBox VMs/")
+    #cleanupVMs
+    #nodesDelete
+  elif [ "$TEST_TYPE" == "docker" ]; then
+    # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
+    
+    nodesCreate
+    
+    # Prepare RackHD
+    # Forward local host port to ova
+    portForwarding localhost
+
+    # We setup the virtual-environment here, since once we
+    # call "nodesOn", it's a race to get to the first test
+    # before the nodes get booted far enough to start being
+    # seen by RackHD. Logically, it would be better IN runTests.
+    # We do it between the vagrant and waitForAPI to use the
+    # time to make the env instead of doing sleeps...
+    setupVirtualEnv
+    waitForAPI
+    nodesOn &
+    # Doesn't support ova smoke test now
+    # generateSolLog
+    # Run tests
+    runTests
+    # exit venv
+    deactivate
+
+    # Clean Up below
+
+    #shutdown vagrant box and delete all resource (like removing vm disk files in "~/VirtualBox VMs/")
+    #cleanupVMs
+    #nodesDelete
+  else
+    # rese the UCSPE emulators 
+    ucsReset
+
+    # register the signal handler to clean up( vagrantDestroy ), with process being killed
+    trap cleanupVMs SIGINT SIGTERM SIGKILL
+    cleanupVMs
+
+    # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
+    
+    nodesCreate
+    # Power on vagrant box and nodes 
+    vagrantUp
+    # We setup the virtual-environment here, since once we
+    # call "nodesOn", it's a race to get to the first test
+    # before the nodes get booted far enough to start being
+    # seen by RackHD. Logically, it would be better IN runTests.
+    # We do it between the vagrant and waitForAPI to use the
+    # time to make the env instead of doing sleeps...
+    setupVirtualEnv
+    waitForAPI
+    nodesOn &
+    generateSolLog
+    vnc_record_start
+    # Run tests
+    runTests
+    generateSysLog
+    generateMongoLog
+    vnc_record_stop
+    # Clean Up below
+
+    #shutdown vagrant box and delete all resource (like removing vm disk files in "~/VirtualBox VMs/")
+    #cleanupVMs
+    #nodesDelete
+  fi
+
+fi

--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -54,12 +54,23 @@ def functionTest(String test_name, String TEST_GROUP, Boolean RUN_FIT_TEST, Bool
             try{
                 timeout(90){
                     // run test script
-                    sh '''#!/bin/bash -x
-                    pushd build-config
-                    ./build-config
-                    popd
-                    ./build-config/test.sh
-                    '''
+                    def repos = env.REPOS_UNDER_TEST.tokenize(',')
+                        if(repos.contains("image-service")){
+                            sh '''#!/bin/bash -x
+                                pushd build-config
+                                ./build-config image-service
+                                popd
+                                ./build-config/test.sh
+                                '''
+                        }
+                        else{
+                            sh '''#!/bin/bash -x
+                                pushd build-config
+                                ./build-config 
+                                popd
+                                ./build-config/test.sh
+                                '''
+                        }
                 }
             } finally{
                 def result = "FAILURE"

--- a/jobs/UnitTest/UnitTest.groovy
+++ b/jobs/UnitTest/UnitTest.groovy
@@ -7,7 +7,7 @@ String stash_manifest_name
 String stash_manifest_path
 String repo_dir
 @Field label_name = "unittest"
-@Field def test_repos = ["on-core", "on-tasks", "on-http", "on-taskgraph", "on-dhcp-proxy", "on-tftp", "on-syslog"]
+@Field def test_repos = ["on-core", "on-tasks", "on-http", "on-taskgraph", "on-dhcp-proxy", "on-tftp", "on-syslog", "image-service"]
 def setManifest(String manifest_name, String manifest_path){
     this.stash_manifest_name = manifest_name
     this.stash_manifest_path = manifest_path

--- a/jobs/UnitTest/unit_test.sh
+++ b/jobs/UnitTest/unit_test.sh
@@ -2,8 +2,8 @@
 
 start_depends_services(){
     set +e
-    echo $SUDO_PASSWORD |sudo -S service mongodb start
-    echo $SUDO_PASSWORD |sudo -S service rabbitmq-server start
+    echo ${SUDO_PASSWORD} |sudo -S service mongodb start
+    echo ${SUDO_PASSWORD} |sudo -S service rabbitmq-server start
     set -e
 }
 
@@ -35,7 +35,8 @@ unit_test(){
     set +e
     ./node_modules/.bin/istanbul report lcov
     npm install --save-dev mocha-sonar-reporter
-    npm_package_config_mocha_sonar_reporter_classname="Tests_build.spec" npm_package_config_mocha_sonar_reporter_outputfile=test/$1.xml ./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha -- $(find spec -name '*-spec.js') -R mocha-sonar-reporter --require spec/helper.js -t 10000
+    npm_package_config_mocha_sonar_reporter_classname="Tests_build.spec"
+    echo ${SUDO_PASSWORD} |sudo -S npm_package_config_mocha_sonar_reporter_outputfile=test/$1.xml ./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha -- $(find spec -name '*-spec.js') -R mocha-sonar-reporter --require spec/helper.js -t 10000
     set -e
 }
 
@@ -44,4 +45,5 @@ prepare_deps $1
 pushd ${WORKSPACE}/build-deps/$1
 unit_test $1
 cp test/$1.xml ${WORKSPACE}/xunit-reports
+sudo chown -R ${USER}:${USER} test coverage static
 popd

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -49,6 +49,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.vm.network "forwarded_port", guest: 8443, host: 9093
         #usc-service
         target.vm.network "forwarded_port", guest: 7080, host: 7080
+        #image-service
+        target.vm.network "forwarded_port", guest: 7070, host: 7070
+        target.vm.network "forwarded_port", guest: 8060, host: 8060
         #mongoDb service
         target.vm.network "forwarded_port", guest: 27017, host: 37017
         
@@ -90,7 +93,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             pm2 logs > /home/vagrant/log/"#{ENV['REPO_NAME']}"/vagrant.log &
           fi
           waitForPM2Daemon
+          if (echo "#{ENV['REPOS_UNDER_TEST']}"|grep -q "image-service"); then
+            cp /home/vagrant/src/build-config/vagrant/rackhd-pm2-config-image-service.yml rackhd-pm2-config.yml
+          fi
           pm2 start rackhd-pm2-config.yml
+
         SHELL
 
 

--- a/vagrant/Vagrantfile.in
+++ b/vagrant/Vagrantfile.in
@@ -99,7 +99,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             pm2 logs > /home/vagrant/src/"#{ENV['REPO_NAME']}"/vagrant.log &
           fi
           waitForPM2Daemon
-          pm2 start rackhd-pm2-config.yml
+          if (echo "#{ENV['REPOS_UNDER_TEST']}"|grep -q "image-service"); then
+            cp /home/vagrant/src/build-config/vagrant/rackhd-pm2-config-image-service.yml rackhd-pm2-config.yml
+          fi
+        pm2 start rackhd-pm2-config.yml
         SHELL
 
 

--- a/vagrant/config/mongo_image_service/config.json
+++ b/vagrant/config/mongo_image_service/config.json
@@ -1,0 +1,67 @@
+{
+    "CIDRNet": "172.31.128.0/22",
+    "amqp": "amqp://localhost",
+    "apiServerAddress": "172.31.128.1",
+    "apiServerPort": 9080,
+    "broadcastaddr": "172.31.131.255",
+    "dhcpGateway": "172.31.128.1",
+    "dhcpProxyBindAddress": "172.31.128.1",
+    "dhcpProxyBindPort": 4011,
+    "dhcpSubnetMask": "255.255.252.0",
+    "gatewayaddr": "172.31.128.1",
+    "httpEndpoints": [
+        {
+            "address": "0.0.0.0",
+            "port": 8080,
+            "httpsEnabled": false,
+            "proxiesEnabled": true,
+            "authEnabled": false,
+            "httpsCert": "data/dev-cert.pem",
+            "httpsKey": "data/dev-key.pem",
+            "routers": "northbound-api-router"
+        },
+        {
+            "address": "0.0.0.0",
+            "port": 8443,
+            "httpsEnabled": true,
+            "proxiesEnabled": true,
+            "authEnabled": true,
+            "routers": "northbound-api-router"
+        },
+        {
+            "address": "172.31.128.1",
+            "port": 9080,
+            "httpsEnabled": false,
+            "proxiesEnabled": true,
+            "authEnabled": false,
+            "routers": "southbound-api-router"
+        }
+    ],
+    "httpDocsRoot": "./build/apidoc",
+    "httpFileServiceRoot": "./static/files",
+    "httpFileServiceType": "FileSystem",
+    "httpProxies": [{
+        "localPath": "/repo/",
+        "server": "http://10.240.19.193",
+        "remotePath": "/repo/"
+    }],
+    "httpStaticRoot": "/opt/monorail/static/http",
+    "authUsername": "admin",
+    "authPasswordHash": "KcBN9YobNV0wdux8h0fKNqi4uoKCgGl/j8c6YGlG7iA0PB3P9ojbmANGhDlcSBE0iOTIsYsGbtSsbqP4wvsVcw==",
+    "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
+    "authTokenSecret": "RackHDRocks!",
+    "authTokenExpireIn": 86400,
+    "mongo": "mongodb://localhost/pxe",
+    "sharedKey": "qxfO2D3tIJsZACu7UA6Fbw0avowo8r79ALzn+WeuC8M=",
+    "statsd": "127.0.0.1:8125",
+    "subnetmask": "255.255.252.0",
+    "syslogBindAddress": "172.31.128.1",
+    "syslogBindPort": 514,
+    "fileServerAddress": "172.31.128.1",
+    "fileServerPort": 8060,
+    "fileServerPath": "/",
+    "tftpBindAddress": "172.31.128.1",
+    "tftpBindPort": 69,
+    "tftpRoot": "./static/tftp",
+    "minLogLevel": 0
+}

--- a/vagrant/rackhd-pm2-config-image-service.yml
+++ b/vagrant/rackhd-pm2-config-image-service.yml
@@ -1,0 +1,22 @@
+apps:
+   - script: index.js
+     name: on-taskgraph
+     cwd: ./src/on-taskgraph
+   - script: index.js
+     name: on-http
+     cwd: ./src/on-http
+   - script: index.js
+     name: on-dhcp
+     cwd: ./src/on-dhcp-proxy
+   - script: index.js
+     name: on-syslog
+     cwd: ./src/on-syslog
+   - script: index.js
+     name: on-tftp
+     cwd: ./src/on-tftp
+   - script: app.py
+     name: ucs-service
+     cwd: ./src/ucs-service
+   - script: index.js
+     name: image-service
+     cwd: ./src/image-service


### PR DESCRIPTION
Make code change to on-build-config, so that it could support image service PR gate. @PengTian0 @changev @panpan0000 @linlynn @anhou 

What this PR does:
1. remove some unnecessary blank space at the end of lines;
2. Add image-service repo to some scripts
3. Add some specific test scripts and configuration files to image service, and put it under a folder called image-service. All image service related testing are generated from image-service/test.sh.in, in this case, the testing environment won't be polluted
4. Add jenkins confidential to unittest
5. As for image-service, only  users with root previledge could execute the mount command, add sudo to the command before unittest. And change the UID and GID of all generated files to normal so that they could be deleted when the next round of execution comes.
6. Change the yml file to start pm2: "pm2 start rackhd-pm2-config.yml". Before the code change, the rackhd-pm2-config.yml is hardcoded in vagrant box, after the code change, rackhd-pm2-config.yml are copied from the source file, so that the latest code change code be applied.
7. Add image service related configuration to the config, and make it a separate file so that it is independent with the original configuration, preventing the pollution of other tests.