### PR TITLE
[RAC-5350]add ghtoken pool to do pull work

### DIFF
--- a/build-release-tools/application/merge_freeze.py
+++ b/build-release-tools/application/merge_freeze.py
@@ -6,8 +6,12 @@ import json
 
 def parse_args(args):
     parser = ArgumentParser()
-    parser.add_argument("--ghtoken",
+    parser.add_argument("--admin-ghtoken",
                         help="Github token that have commit status set permission.",
+                        required=True,
+                        action="store")
+    parser.add_argument("--puller-ghtoken-pool",
+                        help="Github token pool that have basic pull permission.",
                         required=True,
                         action="store")
     parser.add_argument("--manifest-file",
@@ -45,7 +49,8 @@ def main():
         repo_name = "/".join(repo_url[:-4].split("/")[-2:])
         repo_list.append(repo_name)
 
-    mf = MergeFreezer(parsed_args.ghtoken, \
+    mf = MergeFreezer(parsed_args.admin_ghtoken, \
+                      parsed_args.puller_ghtoken_pool, \
                       repo_list, \
                       parsed_args.freeze_context, \
                       parsed_args.freeze_desc, \

--- a/jobs/MergeFreezer/merge_freeze.sh
+++ b/jobs/MergeFreezer/merge_freeze.sh
@@ -16,7 +16,8 @@ fi
 # Run MergeFreezer
 run(){
     ./build-release-tools/HWIMO-BUILD ./build-release-tools/application/merge_freeze.py \
-    --ghtoken "$GITHUB_TOKEN" \
+    --admin-ghtoken "$GITHUB_TOKEN" \
+    --puller-ghtoken-pool "$PULLER_GITHUB_TOKEN_POOL" \
     --manifest-file ./build-release-tools/lib/manifest.json \
     --freeze-context "$FREEZE_CONTEXT" \
     --freeze-desc "$FREEZE_DESC" \

--- a/jobs/MergeFreezer/merge_freezer.groovy
+++ b/jobs/MergeFreezer/merge_freezer.groovy
@@ -3,6 +3,7 @@ node {
     checkout scm
     stage("Launch MergeFreezer"){
         withCredentials([string(credentialsId: 'JENKINSRHD_GITHUB_TOKEN', variable: 'GITHUB_TOKEN'),
+                         string(credentialsId: 'PULLER_GITHUB_TOKEN_POOL', variable: 'PULLER_GITHUB_TOKEN_POOL'),
                          usernamePassword(credentialsId: '752052b8-c884-4c2a-95ef-04e0f9fa0bc2', 
                              passwordVariable: 'JENKINS_PASS', 
                              usernameVariable: 'JENKINS_USER')]) {

--- a/jobs/pr_gate/pr_parser.groovy
+++ b/jobs/pr_gate/pr_parser.groovy
@@ -10,13 +10,13 @@ node{
         }
         try{
             env.stash_manifest_path = "manifest"
-            withCredentials([string(credentialsId: 'JENKINSRHD_GITHUB_TOKEN',
-                                    variable: 'GITHUB_TOKEN')]) {
+            withCredentials([string(credentialsId: 'PULLER_GITHUB_TOKEN_POOL',
+                                    variable: 'PULLER_GITHUB_TOKEN_POOL')]) {
                 sh '''#!/bin/bash -ex
                 ./on-build-config/build-release-tools/HWIMO-BUILD ./on-build-config/build-release-tools/application/pr_parser.py \
                 --change-url $ghprbPullLink \
                 --target-branch $ghprbTargetBranch \
-                --ghtoken ${GITHUB_TOKEN} \
+                --puller-ghtoken-pool "${PULLER_GITHUB_TOKEN_POOL}" \
                 --manifest-file-path "${stash_manifest_path}"
                 '''
              }


### PR DESCRIPTION
https://rackhd.atlassian.net/browse/RAC-5350

Now the pull work(doesn't need admin rights) will be done by puller token, which is the tokens of two new github account: rackhdpuller1, rackhdpuller2, we'll add more accounts if necessary

The push work: comments, commit status etc. is still done by JenkinsRHD(admin) token.

@panpan0000 @PengTian0 