### PR TITLE
RAC-5335 optimize os install smoke

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -87,6 +87,7 @@ def functionTest(String test_name, String label_name, String TEST_GROUP, Boolean
                         "TEST_TYPE=$test_type",
                         "TEST_STACK=$test_stack",
                         "EXTRA_HW=$extra_hw",
+                        "LABEL=$label_name",
                         "KEEP_FAILURE_ENV=${env.KEEP_FAILURE_ENV}",
                         "KEEP_MINUTES=${env.KEEP_MINUTES}"]
                     ){

--- a/test.sh.in
+++ b/test.sh.in
@@ -272,7 +272,11 @@ runTests() {
              tstack="-stack vagrant_ucs"
          fi
      done
-     python run_tests.py -test deploy/rackhd_stack_init.py ${tstack} -xunit
+     if [ ${LABEL} == "os_install" ]; then
+         python run_tests.py -test util/apply_obm_settings.py ${tstack} -xunit
+     else
+         python run_tests.py -test deploy/rackhd_stack_init.py ${tstack} -xunit
+     fi
      if [ $? -ne 0 ]; then
          echo "Test FIT failed running deploy/rackhd_stack_init.py"
          exit 1

--- a/test.sh.in
+++ b/test.sh.in
@@ -273,6 +273,7 @@ runTests() {
          fi
      done
      if [ ${LABEL} == "os_install" ]; then
+         python run_tests.py -test util/load_sku_packs.py ${tstack} -xunit
          python run_tests.py -test util/apply_obm_settings.py ${tstack} -xunit
      else
          python run_tests.py -test deploy/rackhd_stack_init.py ${tstack} -xunit


### PR DESCRIPTION
Optimized OS installs by not running stack init routine, runs SKU pack installer, then OBM settings instead. This will reduce execution time for OS installs.

@hohene @johren @derrickostertag 