### PR TITLE
[RAC-4767]add more info in commit status in PR Gate: UTC Time.

### DIFF
--- a/build-release-tools/application/commit_status_setter.py
+++ b/build-release-tools/application/commit_status_setter.py
@@ -6,6 +6,7 @@ import os
 from github import Github
 from manifest import Manifest
 from urlparse import urlparse
+import time
 
 # jenkins-url is not suggested for our internal Jenkins
 def parse_args(args):
@@ -57,7 +58,10 @@ def set_commit_status(repo, pull_id, status, description, build_url = None):
     print "Set commit status for {0} pull {1} successfully".format(repo, pull_id)
 
 def set_commit_status_bat(pr_list, status, build_url = None):
-    description = "Build finished."
+    gmt = time.gmtime()
+    gmtStr = time.strftime("%b %d, %Y, %I:%M:%S %p ", gmt) + 'GMT'
+    description = "Build finished. " + gmtStr
+
     if len(pr_list) > 1:
         description = description + "[interdependent]"
     for pr in pr_list:


### PR DESCRIPTION
currently, only "Jenkins — Build finished."
but people want to tell the last successful run was yesterday or 3 month ago for a old PR...
So I add the UTC timestamp in the commit status.
Please review my code. Thanks.
@anhou @iceiilin @changev @leoyjchang 