### PR TITLE
RAC-5460 using docker stack config in Docker-Post-Test

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -343,7 +343,7 @@ def runTest(TESTS, test_type, repo_dir, test_stack){
 
 def dockerPostTest(TESTS, docker_stash_name, docker_stash_path, docker_record_stash_path, repo_dir, test_type){
     setDocker(docker_stash_name, docker_stash_path, docker_record_stash_path)
-    test_stack = "-stack vagrant"
+    test_stack = "-stack docker"
     runTest(TESTS, test_type, repo_dir, test_stack)
 }
 


### PR DESCRIPTION
Hot fix for Master CI #249
------

Docker-Post-Test was using vagrant as a FIT-stack-config
it will fail new test  test_rackhd20_api_notifications	
so let's replace it with stack=docker. 


Thanks to @hohene 


Test:

http://rackhdci.lss.emc.com/job/MasterCI4/ is running now to verify the docker-post-test can pass