### PR TITLE
RAC-5464: check uncompleted wget download for *.zip

### DIFF
--- a/jobs/FunctionTest/prepare_manifest.sh
+++ b/jobs/FunctionTest/prepare_manifest.sh
@@ -16,8 +16,8 @@ if [ ! -z "${3}" ]; then
   SKIP_PREP_DEP=$3
 fi
 
+########################################
 wget_download(){
-
   argv=($@)
   argc=$#
   retry_time=5
@@ -32,8 +32,17 @@ wget_download(){
   if [ $? -ne 0 ]; then
      echo "[Error]: wget download failed: ${remote_file}"
      exit 2
- else
+  else
      echo "[Info] wget download successfully ${remote_file}"
+  fi
+  local_file=${remote_file##*/}
+  if [[ $remote_file == *zip* ]]; then
+      echo "[Info] Checking zip file integrity for ${remote_file}"
+      zip -T $local_file
+      if [ $? -ne 0 ]; then
+          echo "[Error] the download file(${remote_file}) is incompleted !"
+          exit 3
+      fi
   fi
 
 }

--- a/jobs/FunctionTest/prepare_manifest.sh
+++ b/jobs/FunctionTest/prepare_manifest.sh
@@ -38,7 +38,7 @@ wget_download(){
   local_file=${remote_file##*/}
   if [[ $remote_file == *zip* ]]; then
       echo "[Info] Checking zip file integrity for ${remote_file}"
-      zip -T $local_file
+      unzip -t $local_file
       if [ $? -ne 0 ]; then
           echo "[Error] the download file(${remote_file}) is incompleted !"
           exit 3


### PR DESCRIPTION
Background:
wget common.zip failure will still return 0...
then unzip will complain...

------------
Testing:
(1) positive case
```
[Info] Downloading http://www.colorado.edu/conflict/peace/download/peace.zip
[Info] wget download successfully http://www.colorado.edu/conflict/peace/download/peace.zip
[Info] Checking zip file integrity for http://www.colorado.edu/conflict/peace/download/peace.zip
test of peace.zip OK
```
----------
(2) negative case
```
[Info] Downloading http://*.*.19.21/job/Tools/job/Static-Files-Service/lastSuccessfulBuild/artifact/common/*zip*/common.zip
[Info] wget download successfully http://*.*.19.21/job/Tools/job/Static-Files-Service/lastSuccessfulBuild/artifact/common/*zip*/common.zip
[Info] Checking zip file integrity for http://*.*.19.21/job/Tools/job/Static-Files-Service/lastSuccessfulBuild/artifact/common/*zip*/common.zip
zip error: Zip file structure invalid (common.zip)
+ '[' 3 -ne 0 ']'
[Error] the download file(http://*.*.19.21/job/Tools/job/Static-Files-Service/lastSuccessfulBuild/artifact/common/*zip*/common.zip) is incompleted !
```

@PengTian0 





