### PR TITLE
RAC-5347 Add stages for Docker Post test pipeline

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -142,9 +142,18 @@ def functionTest(String test_name, String label_name, String TEST_GROUP, Boolean
 
                                 if(test_type == "docker"){
                                     // env vars in this sh are defined in jobs/build_ova/ova_post_test.groovy
-                                    unstash "$docker_stash_name"
-                                    env.DOCKER_PATH = "$docker_stash_path"
-                                    env.DOCKER_RECORD_PATH = "$docker_record_stash_path"
+                                    if (env.USE_PREBUILT_IMAGES == "true"){
+                                        if (env.DOCKER_IMAGES.contains("http")){
+                                            sh 'wget -c -nv -O rackhd_docker_images.tar $DOCKER_IMAGES'
+                                            env.DOCKER_PATH = pwd() + "/rackhd_docker_images.tar"
+                                        } else {
+                                            env.DOCKER_PATH = "$env.DOCKER_IMAGES"
+                                        } 
+                                    } else {
+                                        unstash "$docker_stash_name"
+                                        env.DOCKER_PATH = "$docker_stash_path"
+                                        env.DOCKER_RECORD_PATH = "$docker_record_stash_path"
+                                    }
                                     sh './build-config/jobs/build_docker/prepare_docker_post_test.sh'
                                 }
 
@@ -343,7 +352,7 @@ def runTest(TESTS, test_type, repo_dir, test_stack){
 
 def dockerPostTest(TESTS, docker_stash_name, docker_stash_path, docker_record_stash_path, repo_dir, test_type){
     setDocker(docker_stash_name, docker_stash_path, docker_record_stash_path)
-    test_stack = "-stack vagrant"
+    test_stack = "-stack docker"
     runTest(TESTS, test_type, repo_dir, test_stack)
 }
 

--- a/jobs/MasterCI/PostTestDocker
+++ b/jobs/MasterCI/PostTestDocker
@@ -1,0 +1,89 @@
+node{
+    // MasterDocker Jenkins test pipeline
+    // This Pipeline optionally build Docker images, Start container, Run Post Tests
+    // This Pipeline uses these jenkins credentials:
+    // BINTRAY_CREDS, SUDO_CREDS (Debian), vCenter_IP
+    // This Pipeline uses these jenkins parameters:
+    // DOCKER_STASH_NAME, MANIFEST_FILE_URL, DOCKER_RACKHD_IP, USE_PREBUILT_IMAGES
+    // DOCKER_IMAGES, DOCKER_BUILD_RECORD
+    
+    withEnv([
+        "branch=${env.branch}",
+        "IS_OFFICIAL_RELEASE=false",
+        "date=current",
+        "timezone=-0500",
+        "OS_VER=${env.OS_VER}",
+        "TFTP_STATIC_FILES=${env.TFTP_STATIC_FILES}",
+        "HTTP_STATIC_FILES=${env.HTTP_STATIC_FILES}",
+        "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
+        "TESTS=${env.TESTS}",
+        "BINTRAY_SUBJECT=${env.BINTRAY_SUBJECT}",
+        "CI_BINTRAY_SUBJECT=${env.CI_BINTRAY_SUBJECT}",
+        "PUBLISH=${env.PUBLISH}"
+        ])
+    {
+        deleteDir()
+        dir("build-config"){
+            checkout scm
+        }
+        def shareMethod = load("build-config/jobs/ShareMethod.groovy")
+        try{
+            stage("Process Manifest"){
+                // Generate a manifest file according to branch, date and timezone if manifest file url is null
+                if("${MANIFEST_FILE_URL}" == null || "${MANIFEST_FILE_URL}" == "null" || "${MANIFEST_FILE_URL}" == ""){
+                    timestamps{
+                        withEnv([
+                            "branch=${env.branch}",
+                            "date=current",
+                            "timezone=-0500"
+                        ]){
+                            sh '''#!/bin/bash -ex
+                            pushd $WORKSPACE
+                            ./build-config/build-release-tools/HWIMO-BUILD build-config/build-release-tools/application/generate_manifest.py \
+                            --branch "$branch" \
+                            --date "$date" \
+                            --timezone "$timezone" \
+                            --builddir b \
+                            --force \
+                            --jobs 8
+
+                            arrBranch=($(echo $branch | tr "/" "\n"))
+                            slicedBranch=${arrBranch[-1]}
+                            manifest_file=$(find -maxdepth 1 -name "$slicedBranch-[0-9]*" -printf "%f\n")
+                            mv $manifest_file manifest
+                            '''
+                        }
+                    }
+                }
+                else{
+                    sh 'curl -L $MANIFEST_FILE_URL -o manifest'
+                }
+            }
+            stage("Generate Docker"){
+                stash name: "masterci_manifest", includes: "manifest"
+                env.stash_manifest_name = "masterci_manifest"
+                env.stash_manifest_path = "manifest"
+                
+                def repo_dir = pwd() + "/build-config"
+                def TESTS = "${env.TESTS}"
+                def test_type = "manifest"
+
+                // Never publish results
+                Boolean create_tag = false
+                Boolean publish = false
+                // Use pre built docker images or build docker images from manifest
+                if(env.USE_PREBUILT_IMAGES == "true"){
+                  stage("Docker POST Test"){
+                    shareMethod.testDocker(repo_dir)
+                  }
+                } else {
+                    shareMethod.buildandtestDocker(repo_dir)
+		}
+            }
+        } finally{
+            echo "Docker Pipeline is Complete"
+            // Test jenkins need Plugins to send test results
+            // shareMethod.sendResult(false, false)
+        }
+    }
+}

--- a/jobs/ShareMethod.groovy
+++ b/jobs/ShareMethod.groovy
@@ -126,6 +126,23 @@ def buildandtestOVA(String repo_dir){
     }
 }
 
+def buildandtestDocker(String repo_dir){
+    // retry times for images build to avoid failing caused by network
+    int retry_times = 3
+
+    buildPackage(repo_dir)
+
+    stage("Docker Images Build"){
+        retry(retry_times){
+            buildDocker(repo_dir)
+        }
+    }
+
+    stage("Docker Post Test"){
+        testDocker(repo_dir)
+    }
+}
+
 def publishImages(String repo_dir){
     stage("Publish"){
         parallel 'Publish Debian':{

--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -10,10 +10,25 @@ echo $SUDO_PASSWORD |sudo -S service mongodb stop
 echo $SUDO_PASSWORD |sudo -S service rabbitmq-server stop
 
 rackhd_docker_images=`ls ${DOCKER_PATH}`
+# load docker images
+docker load -i $rackhd_docker_images | tee ${WORKSPACE}/docker_load_output
+
+if [ ${USE_PREBUILT_IMAGES} == true ] ; then
+    # This path is followed when using the prebuilt images to get image tag
+    #file=${WORKSPACE}/docker_load_output
+    while IFS=:  read -r load imagename tag 
+    do
+       echo $tag
+       break
+    done < "${WORKSPACE}/docker_load_output"
+    repo_list=$(echo "rackhd/files:${tag} rackhd/on-core:${tag} rackhd/on-syslog:${tag} rackhd/on-dhcp-proxy:${tag} \
+                          rackhd/on-tftp:${tag} rackhd/on-wss:${tag} rackhd/on-statsd:${tag} rackhd/on-tasks:${tag} rackhd/on-taskgraph:${tag} \
+                          rackhd/on-http:${tag} rackhd/ucs-service:${tag}")
+    echo $repo_list >> ${WORKSPACE}/build_record
+    DOCKER_RECORD_PATH=${WORKSPACE}/build_record
+fi
 build_record=`ls ${DOCKER_RECORD_PATH}`
 
-# load docker images
-docker load -i $rackhd_docker_images
 image_list=`head -n 1 $build_record`
 
 pushd $BUILD_CONFIG_DIR

--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -15,7 +15,6 @@ docker load -i $rackhd_docker_images | tee ${WORKSPACE}/docker_load_output
 
 if [ ${USE_PREBUILT_IMAGES} == true ] ; then
     # This path is followed when using the prebuilt images to get image tag
-    #file=${WORKSPACE}/docker_load_output
     while IFS=:  read -r load imagename tag 
     do
        echo $tag


### PR DESCRIPTION
RAC-5347 docker post test, following RAC-5026 OVA post test
This PR is addressing fillowing things
We started with creating a Post docker test in the sandbox. It has two option start container from prebuilt rackhd images or Build docker  images and start docker container, then run FIT tests
This master Pipeline runs only on test jenkins, updates in this PR allows to run master pipeline without any changes.