### PR TITLE
[RAC-4849] Add version/commit in docker info & Add commit/version checking in docker-post-test

### DIFF
--- a/build-release-tools/application/docker_version_check.py
+++ b/build-release-tools/application/docker_version_check.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+###############################
+# parse a manifest file to get the commit for each repo.
+# parse commitstring.txt in docker image for each repo image.
+# Check consistency of two commit hash.
+###############################
+
+import json
+import sys
+import os
+import argparse
+import common
+from manifest import Manifest
+
+def parse_args(args):
+    """
+    Parse script arguments.
+    :return: Parsed args for assignment
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--manifest-file',
+                        required=True,
+                        help="The file path of manifest",
+                        action='store')
+
+    parser.add_argument('--parameters-file',
+                        help="The repo commit id infomation in docker images",
+                        required=True,
+                        action='store')
+
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+def get_repo_commit(manifest_file):
+    """
+    build {repository:commit-id} dictionary, return the dict.
+    """
+    manifest = Manifest(manifest_file)
+    manifest.validate_manifest()
+    repo_commit_dict = {}
+    for repo in manifest.repositories:
+        repo_name = common.strip_suffix(os.path.basename(repo["repository"]), ".git")
+        commit_id = repo["commit-id"]
+        repo_commit_dict[repo_name] = commit_id
+    print "[DEBUG] manifest repo_commit dict:", repo_commit_dict
+    return repo_commit_dict
+
+def check_commit_version(repo_commit_dict, docker_repo_commit_file):
+    """
+    check the commit hashcode between manifest and docker build.
+    """
+    version_correct = True
+    f = open(docker_repo_commit_file)
+    for line in f:
+        print "[DEBUG] get docker repo commit info:(%s)" %line
+        line_list = line.strip().split(':')
+        hashcode = repo_commit_dict.get(line_list[0])
+        if not hashcode.startswith(line_list[1]) :
+            print "[ERROR] mismatch: repo:%s, manifest commit:%s, docker build commit:%s" % (line_list[0], hashcode, line_list[1])
+            version_correct = False
+    f.close()   
+    return version_correct
+
+
+
+def main():
+    args = parse_args(sys.argv[1:])
+    print "[DEBUG] args manifest_file:%s, docker_repo_commit_file:%s" % (args.manifest_file, args.parameters_file)
+    repo_commit_dict = get_repo_commit(args.manifest_file)
+    version_correct = check_commit_version(repo_commit_dict, args.parameters_file)
+    print "[INFO] docker commit version check for each repo is correct:", version_correct
+    if not version_correct :
+        print "[ERROR] mismatch: docker commit version and manifest "
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()
+

--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -65,7 +65,8 @@ doBuild() {
         fi
         pushd $repo
             # Add version/commit in commitstring.txt for docker image build.
-            git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
+            commitstring_file="commitstring.txt"
+            git log -n 1 --pretty=format:%h.%ai.%s > ${commitstring_file}
             
             PKG_TAG=""
             if [ "$BUILD_NIGHTLY" == true ]; then
@@ -78,6 +79,7 @@ doBuild() {
             repos_tags=$repos_tags"rackhd/"$repo$TAG" "
             cp Dockerfile ../Dockerfile.bak
             if [ "$repo" == "on-imagebuilder" ]; then
+                    cp ${commitstring_file} ./common/
                     docker build -t rackhd/files$TAG .
                     repos_tags="rackhd/files"$TAG" "
             elif [ "$repo" != "on-core" ];then

--- a/build-release-tools/docker_build.sh
+++ b/build-release-tools/docker_build.sh
@@ -64,6 +64,9 @@ doBuild() {
             exit 1
         fi
         pushd $repo
+            # Add version/commit in commitstring.txt for docker image build.
+            git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
+            
             PKG_TAG=""
             if [ "$BUILD_NIGHTLY" == true ]; then
                 TAG=:nightly

--- a/jobs/build_docker/docker_post_test.groovy
+++ b/jobs/build_docker/docker_post_test.groovy
@@ -77,7 +77,7 @@ def generateTestBranches(function_test){
                                         env.MANIFEST_FILE="$stash_manifest_path"
 
                                         env.DOCKER_REPO_HASHCODE_FILE = env.RackHD_DIR + "/docker/docker_repo_hashcode.txt"
-                                        sh "/bin/bash ./build-config/jobs/build_docker/get_docker_commit_version.sh"
+                                        sh "/bin/bash ./build-config/jobs/build_docker/get_docker_commit_version.sh ${DOCKER_RECORD_PATH} ${DOCKER_REPO_HASHCODE_FILE}"
                                         sh '''#!/bin/bash
                                         ./build-config/build-release-tools/HWIMO-BUILD ./build-config/build-release-tools/application/docker_version_check.py \
                                         --manifest-file $MANIFEST_FILE \

--- a/jobs/build_docker/get_docker_commit_version.sh
+++ b/jobs/build_docker/get_docker_commit_version.sh
@@ -1,33 +1,45 @@
 #!/bin/bash 
 set -e
 
-build_record=`ls ${DOCKER_RECORD_PATH}`
-docker_repo_commit_file="${DOCKER_REPO_HASHCODE_FILE}"
+# get each repo's docker image commit hashcode, save to file: ${docker_repo_commit_file}. 
+# each docker image check its basic images's commit hashcode.
+# 
+# dependency graph:
+# on-syslog,on-dhcp,on-tftp,on-wss,on-statsd,on-tasks  ------> on-core
+# on-taskgraph,on-http ------> on-tasks
+
+
+build_record=`ls $1`
+image_list=`head -n 1 $build_record`
+docker_repo_commit_file="$2"
 commit_string_file=commitstring.txt
 
+# global var
 on_core_hash=
 on_tasks_hash=
+hashcode=
 
-# docker images
-image_list=`head -n 1 $build_record`
-
-running_container="$(docker ps -q | wc -l)"
-echo "[DEBUG] all running_container count:${running_container}"
-
-time=1
-MAX_TRY=10
-while [ ${running_container} -lt 9 ] && [ ${time} -le ${MAX_TRY} ]; do
-    sleep 10
+# basic check, clean env
+prepare_check_test(){
     running_container="$(docker ps -q | wc -l)"
-    echo "[DEBUG] [${time}*10s] all running_container count:${running_container}"
-    time=`expr ${time} + 1`
-done
+    echo "[DEBUG] all running_container count:${running_container}"
 
-if [ ${running_container} -lt 9 ]; then
-    echo "[ERROR] not all containers is running, only ${running_container}, need 9."
-    exit 1
-fi
+    time=1
+    MAX_TRY=10
+    while [ ${running_container} -lt 9 ] && [ ${time} -le ${MAX_TRY} ]; do
+        sleep 10
+        running_container="$(docker ps -q | wc -l)"
+        echo "[DEBUG] [${time}*10s] all running_container count:${running_container}"
+        time=`expr ${time} + 1`
+    done
 
+    if [ ${running_container} -lt 9 ]; then
+        echo "[ERROR] not all containers is running, only ${running_container}, need 9."
+        exit 1
+    fi
+    rm -rf ${docker_repo_commit_file}
+}
+    
 # clean up docker env: clean_docker_env ${repo_tag}
 clean_docker_env(){
     container_id="$(docker ps -a -q --filter ancestor=$1 --format="{{.ID}}")"
@@ -65,8 +77,43 @@ is_tasks_correct(){
     fi
 }
 
-#get docker commit hashcode, store in file:docker_repo_hashcode.txt
-rm -rf ${docker_repo_commit_file}
+# get hashcode: get_repo_hashcode "${commitstring}" ${repo}
+get_repo_hashcode(){
+    commitstring=$1
+    repo=$2
+    hashcode="${commitstring:0:7}"
+    echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+    echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+}
+
+# check on core hashcode: 
+# call 1: check_on_core_hashcode "${commitstring}" ${repo} ${repo_tag} "run"
+# call 2: check_on_core_hashcode "${commitstring}" ${repo} ${container_id} "exec"
+check_on_core_hashcode(){
+    commitstring=$1
+    repo=$2
+    item=$3
+    cmd=$4
+    on_core_commitstring="$(docker ${cmd}  ${item}  cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
+    on_core_hashcode="${on_core_commitstring:0:7}"
+    is_core_correct ${on_core_hashcode}
+}
+
+# check on tasks hashcode: 
+# call 1: check_on_tasks_hashcode "${commitstring}" ${repo} ${repo_tag} "run"
+# call 2: check_on_tasks_hashcode "${commitstring}" ${repo} ${container_id} "exec"
+check_on_tasks_hashcode(){
+    commitstring=$1
+    repo=$2
+    item=$3
+    cmd=$4
+    on_tasks_commitstring="$(docker ${cmd}  ${item}  cat /RackHD/${repo}/node_modules/on-tasks/${commit_string_file})"
+    on_tasks_hashcode="${on_tasks_commitstring:0:7}"
+    is_tasks_correct ${on_tasks_hashcode}
+}
+
+# get docker commit hashcode, store in file:docker_repo_hashcode.txt
+prepare_check_test
 for repo_tag in $image_list; do
     repo_tmp="${repo_tag%:*}" 
     repo="${repo_tmp##'rackhd/'}"
@@ -79,45 +126,31 @@ for repo_tag in $image_list; do
         container_id="$(docker ps -q --filter ancestor=${repo_tag} --format="{{.ID}}")"
         echo "[DEBUG] repo_tag:${repo_tag}, running container_id:${container_id}"
         commitstring="$(docker exec  ${container_id}  cat /RackHD/downloads/common/${commit_string_file})"
-        hashcode="${commitstring:0:7}"
-        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
-        echo "on-imagebuilder:${hashcode}" >> ${docker_repo_commit_file}
+        get_repo_hashcode "${commitstring}" "on-imagebuilder"
         ;;
 
     "on-wss" | "on-statsd")
         commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/${commit_string_file})"
-        hashcode="${commitstring:0:7}"
-        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
-        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
-
-        on_core_commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
-        on_core_hashcode="${on_core_commitstring:0:7}"
-        is_core_correct ${on_core_hashcode}
-        # clean up env
+        get_repo_hashcode "${commitstring}" ${repo}
+        
+        check_on_core_hashcode "${commitstring}" ${repo} ${repo_tag} "run"
         clean_docker_env ${repo_tag}
         ;;
 
     "on-core")
         commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/${commit_string_file})"
-        hashcode="${commitstring:0:7}"
-        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
-        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+        get_repo_hashcode "${commitstring}" ${repo}
         is_core_correct ${hashcode}
-        # clean up env
+
         clean_docker_env ${repo_tag}
         ;;
 
     "on-tasks")
         commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/${commit_string_file})"
-        hashcode="${commitstring:0:7}"
-        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
-        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+        get_repo_hashcode "${commitstring}" ${repo}
         is_tasks_correct ${hashcode}
 
-        on_core_commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
-        hashcode="${on_core_commitstring:0:7}"
-        is_core_correct ${hashcode}
-        # clean up env
+        check_on_core_hashcode "${commitstring}" ${repo} ${repo_tag} "run"
         clean_docker_env ${repo_tag}
         ;;
 
@@ -125,32 +158,19 @@ for repo_tag in $image_list; do
         container_id="$(docker ps -q --filter ancestor=${repo_tag} --format="{{.ID}}")"
         echo "[DEBUG] repo_tag:${repo_tag}, running container_id:${container_id}"
         commitstring="$(docker exec  ${container_id}  cat /RackHD/${repo}/${commit_string_file})"
-        hashcode="${commitstring:0:7}"
-        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
-        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+        get_repo_hashcode "${commitstring}" ${repo}
 
-        on_core_commitstring="$(docker exec $container_id cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
-        hashcode="${on_core_commitstring:0:7}"
-        is_core_correct ${hashcode}
-
-        on_tasks_commitstring="$(docker exec $container_id cat /RackHD/${repo}/node_modules/on-tasks/${commit_string_file})"
-        hashcode="${on_tasks_commitstring:0:7}"
-        is_tasks_correct ${hashcode}
+        check_on_core_hashcode "${commitstring}" ${repo} ${container_id} "exec"
+        check_on_tasks_hashcode "${commitstring}" ${repo} ${container_id} "exec"
         ;;
 
     "on-syslog" | "on-dhcp-proxy" | "on-tftp")
         container_id="$(docker ps -q --filter ancestor=${repo_tag} --format="{{.ID}}")"
         echo "[DEBUG] repo_tag:${repo_tag}, running container_id:${container_id}"
         commitstring="$(docker exec  ${container_id}  cat /RackHD/${repo}/${commit_string_file})"
-        hashcode="${commitstring:0:7}"
-        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
-        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+        get_repo_hashcode "${commitstring}" ${repo}
 
-        on_core_commitstring="$(docker exec $container_id cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
-        hashcode="${on_core_commitstring:0:7}"
-        is_core_correct ${hashcode}
+        check_on_core_hashcode "${commitstring}" ${repo} ${container_id} "exec"
         ;;
     esac
 done
-
-

--- a/jobs/build_docker/get_docker_commit_version.sh
+++ b/jobs/build_docker/get_docker_commit_version.sh
@@ -1,0 +1,156 @@
+#!/bin/bash 
+set -e
+
+build_record=`ls ${DOCKER_RECORD_PATH}`
+docker_repo_commit_file="${DOCKER_REPO_HASHCODE_FILE}"
+commit_string_file=commitstring.txt
+
+on_core_hash=
+on_tasks_hash=
+
+# docker images
+image_list=`head -n 1 $build_record`
+
+running_container="$(docker ps -q | wc -l)"
+echo "[DEBUG] all running_container count:${running_container}"
+
+time=1
+MAX_TRY=10
+while [ ${running_container} -lt 9 ] && [ ${time} -le ${MAX_TRY} ]; do
+    sleep 10
+    running_container="$(docker ps -q | wc -l)"
+    echo "[DEBUG] [${time}*10s] all running_container count:${running_container}"
+    time=`expr ${time} + 1`
+done
+
+if [ ${running_container} -lt 9 ]; then
+    echo "[ERROR] not all containers is running, only ${running_container}, need 9."
+    exit 1
+fi
+
+# clean up docker env: clean_docker_env ${repo_tag}
+clean_docker_env(){
+    container_id="$(docker ps -a -q --filter ancestor=$1 --format="{{.ID}}")"
+    for container in ${container_id}; do
+        echo "[DEBUG] docker rm container:${container}"
+        docker rm ${container}
+    done    
+}
+
+# is_core_correct ${hashcode}
+is_core_correct(){
+    if [ -z "${on_core_hash}" ]; then 
+        echo "on-core hashcode is empty. set value." 
+        on_core_hash="$1"
+    else
+        echo "on-core hashcode is not empty. compare value."  
+        if [ "${on_core_hash}" != "$1" ]; then
+            echo "[ERROR] on-core hashcode is not coincident. ${on_core_hash}:$1"
+            exit 1
+        fi
+    fi
+}
+
+# is_tasks_correct ${hashcode}
+is_tasks_correct(){
+    if [ -z "${on_tasks_hash}" ]; then 
+        echo "on-tasks hashcode is empty. set value." 
+        on_tasks_hash="$1"
+    else
+        echo "on-tasks hashcode is not empty. compare value."  
+        if [ "${on_tasks_hash}" != "$1" ]; then
+            echo "[ERROR] on-tasks hashcode is not coincident. ${on_tasks_hash}:$1"
+            exit 1
+        fi
+    fi
+}
+
+#get docker commit hashcode, store in file:docker_repo_hashcode.txt
+rm -rf ${docker_repo_commit_file}
+for repo_tag in $image_list; do
+    repo_tmp="${repo_tag%:*}" 
+    repo="${repo_tmp##'rackhd/'}"
+    echo "[Debug] rep_tag:${repo_tag}, repo:${repo}"
+    case "${repo}" in
+    "ucs-service")
+        ;;
+
+    "files")
+        container_id="$(docker ps -q --filter ancestor=${repo_tag} --format="{{.ID}}")"
+        echo "[DEBUG] repo_tag:${repo_tag}, running container_id:${container_id}"
+        commitstring="$(docker exec  ${container_id}  cat /RackHD/downloads/common/${commit_string_file})"
+        hashcode="${commitstring:0:7}"
+        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+        echo "on-imagebuilder:${hashcode}" >> ${docker_repo_commit_file}
+        ;;
+
+    "on-wss" | "on-statsd")
+        commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/${commit_string_file})"
+        hashcode="${commitstring:0:7}"
+        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+
+        on_core_commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
+        on_core_hashcode="${on_core_commitstring:0:7}"
+        is_core_correct ${on_core_hashcode}
+        # clean up env
+        clean_docker_env ${repo_tag}
+        ;;
+
+    "on-core")
+        commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/${commit_string_file})"
+        hashcode="${commitstring:0:7}"
+        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+        is_core_correct ${hashcode}
+        # clean up env
+        clean_docker_env ${repo_tag}
+        ;;
+
+    "on-tasks")
+        commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/${commit_string_file})"
+        hashcode="${commitstring:0:7}"
+        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+        is_tasks_correct ${hashcode}
+
+        on_core_commitstring="$(docker run  ${repo_tag}  cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
+        hashcode="${on_core_commitstring:0:7}"
+        is_core_correct ${hashcode}
+        # clean up env
+        clean_docker_env ${repo_tag}
+        ;;
+
+    "on-http" | "on-taskgraph")
+        container_id="$(docker ps -q --filter ancestor=${repo_tag} --format="{{.ID}}")"
+        echo "[DEBUG] repo_tag:${repo_tag}, running container_id:${container_id}"
+        commitstring="$(docker exec  ${container_id}  cat /RackHD/${repo}/${commit_string_file})"
+        hashcode="${commitstring:0:7}"
+        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+
+        on_core_commitstring="$(docker exec $container_id cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
+        hashcode="${on_core_commitstring:0:7}"
+        is_core_correct ${hashcode}
+
+        on_tasks_commitstring="$(docker exec $container_id cat /RackHD/${repo}/node_modules/on-tasks/${commit_string_file})"
+        hashcode="${on_tasks_commitstring:0:7}"
+        is_tasks_correct ${hashcode}
+        ;;
+
+    "on-syslog" | "on-dhcp-proxy" | "on-tftp")
+        container_id="$(docker ps -q --filter ancestor=${repo_tag} --format="{{.ID}}")"
+        echo "[DEBUG] repo_tag:${repo_tag}, running container_id:${container_id}"
+        commitstring="$(docker exec  ${container_id}  cat /RackHD/${repo}/${commit_string_file})"
+        hashcode="${commitstring:0:7}"
+        echo "[DEBUG]repo:${repo}, commitstring:${commitstring}, hashcode:${hashcode}"
+        echo "${repo}:${hashcode}" >> ${docker_repo_commit_file}
+
+        on_core_commitstring="$(docker exec $container_id cat /RackHD/${repo}/node_modules/on-core/${commit_string_file})"
+        hashcode="${on_core_commitstring:0:7}"
+        is_core_correct ${hashcode}
+        ;;
+    esac
+done
+
+


### PR DESCRIPTION

Once user download a set of docker images, how can they trace back base on which commit did the docker image was built?
So I added some code commit info into docker image when it was built.