### PR TITLE
RAC-5474: To address issue when publish vagrant

### DIFF
--- a/build-release-tools/requirements.txt
+++ b/build-release-tools/requirements.txt
@@ -9,3 +9,4 @@ pyparsing
 JIRA
 python-jenkins
 configparser
+pyOpenSSL


### PR DESCRIPTION
**Motivation**
https://rackhd.atlassian.net/browse/RAC-5474
(1) to resolve ERROR: 
```[Errno 8] _ssl.c:510: EOF occurred in violation of protocol```

(2) to depress Warning:
```python2.7/site-packages/urllib3/util/ssl_.py:335: SNIMissingWarning: An
HTTPS request has been made, but the SNI (Subject Name Indication)
extension to TLS is not available on this platform. This may cause the
server to present an incorrect TLS certificate, which can cause
validation failures. You can upgrade to a newer version of Python to
solve this. For more information, see
https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  SNIMissingWarning
```


**Reference**
https://stackoverflow.com/questions/29099404/ssl-insecureplatform-error-when-using-requests-package

although they suggest to install 3 packages: pyOpenSSL , cryptography, idna , but my experience shows only ```pyOpenSSL``` is enough..


**Test Done**
Command Line:
```
jenkins@vmslave06:~/workspace/MasterCI@2$ ./on-build-config/build-release-tools/HWIMO-BUILD on-build-config/build-release-tools/application/release_to_atlas.py --build-directory ./VAGRANT/build/packer --atlas-url https://app.vagrantup.com/api/v1 --atlas-creds ****:****** --atlas-name rackhd --is-release false
```
Output is:
```
-------------------------------
https://app.vagrantup.com/api/v1/box/rackhd/rackhd/version/0.06.29
Box version 0.06.29 already exists.
-------------------------------
https://app.vagrantup.com/api/v1/box/rackhd/rackhd/version/0.06.29
Box version 0.06.29 already exists.
virtualbox provider of version 0.06.29 already exists!
Upload box /home/jenkins/workspace/MasterCI@2/VAGRANT/build/packer/rackhd-ubuntu-14.04-2.11.0-20170628UTC.box to version/0.06.29/provider/virtualbox successfully!
Release version 0.06.29 successfully!
```

**Why it can fix the problem**

Yes, the stackoverflow link above is to depress the ```SNIMissingWarning```, instead of to resolve the ```[Errno 8] _ssl.c:510: EOF occurred in violation of protocol```
But the trutttttttttttttttttth is with this change, the SSL EOF problem has gone!
So don't ask me why... I don't know either !! T_T



