### PR TITLE
RAC-4091 Add autoCreateObm:true to all instances of config.json

### DIFF
--- a/jobs/pr_gate/docker/monorail/config.json
+++ b/jobs/pr_gate/docker/monorail/config.json
@@ -51,6 +51,7 @@
     "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
     "authTokenSecret": "RackHDRocks!",
     "authTokenExpireIn": 86400,
+    "autoCreateObm": "true",
     "mongo": "mongodb://localhost/pxe",
     "sharedKey": "qxfO2D3tIJsZACu7UA6Fbw0avowo8r79ALzn+WeuC8M=",
     "statsd": "127.0.0.1:8125",

--- a/vagrant/config/mongo/config.json
+++ b/vagrant/config/mongo/config.json
@@ -51,6 +51,7 @@
     "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
     "authTokenSecret": "RackHDRocks!",
     "authTokenExpireIn": 86400,
+    "autoCreateObm": "true",
     "mongo": "mongodb://localhost/pxe",
     "sharedKey": "qxfO2D3tIJsZACu7UA6Fbw0avowo8r79ALzn+WeuC8M=",
     "statsd": "127.0.0.1:8125",

--- a/vagrant/config/mongo/monorail.json
+++ b/vagrant/config/mongo/monorail.json
@@ -51,6 +51,7 @@
     "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
     "authTokenSecret": "RackHDRocks!",
     "authTokenExpireIn": 86400,
+    "autoCreateObm": "true",
     "mongo": "mongodb://localhost/pxe",
     "sharedKey": "qxfO2D3tIJsZACu7UA6Fbw0avowo8r79ALzn+WeuC8M=",
     "statsd": "127.0.0.1:8125",


### PR DESCRIPTION
Add autoCreateObm:true to config.json to utilize the modern OBM generation routine.

After this is merged, then the 'apply OBM settings' routine will be removed from stack init.

Paired with Beena

@jimturnquist @patelb10 @hohene