### PR TITLE
RAC-5474: Migrate ATLAS to Vagrant Cloud - app.vagrantup.com

### DIFF
--- a/jobs/release/release_vagrant.sh
+++ b/jobs/release/release_vagrant.sh
@@ -4,7 +4,7 @@ echo "upload vagrant to atlas"
 
 ./on-build-config/build-release-tools/HWIMO-BUILD on-build-config/build-release-tools/application/release_to_atlas.py \
 --build-directory ./VAGRANT/build/packer \
---atlas-url https://atlas.hashicorp.com/api/v1 \
+--atlas-url https://app.vagrantup.com/api/v1  \
 --atlas-creds ${ATLAS_CREDS} \
 --atlas-name rackhd \
 --is-release $IS_OFFICIAL_RELEASE 


### PR DESCRIPTION
**Why**
Hmm.... https://github.com/RackHD/on-build-config/pull/242 is not enough..
seems Hashipcorp shutoff  the original restful URL: ```https://atlas.hashicorp.com/api/v1```  during last weekend.
```
"errors":["Vagrant Cloud has been moved to app.vagrantup.com","Please upgrade to the latest Vagrant version at","","  https://www.vagrantup.com/downloads.html","","or, override the Vagrant server address with","","  export VAGRANT_SERVER_URL=https://app.vagrantup.com","","For more information, visit","","  https://www.vagrantup.com/docs/vagrant-cloud/vagrant-cloud-migration.html",""]} 
```
so we will have to migrate it to latest ```https://app.vagrantup.com/api/v1```

**Test**
by command line on vmslave 06
```
jenkins@vmslave06:~/workspace/MasterCI@2$ ./on-build-config/build-release-tools/HWIMO-BUILD on-build-config/build-release-tools/application/release_to_atlas.py --build-directory ./VAGRANT/build/packer --atlas-url https://aoo.vagrantup.com/api/v1 --atlas-creds $ATLAS_CRED --atlas-name rackhd --is-release False
```
Output:
```
Box version 0.07.02 doesn't' exist, will be created soon.
https://app.vagrantup.com/api/v1/box/rackhd/rackhd/versions
Create box version 0.07.02 successfully.
Box version 0.07.02 already exists.
virtualbox provider of version 0.07.02 doesn't' exist, will be created soon
Create box provider virtualbox of version 0.07.02 successfully.
Upload box /home/jenkins/workspace/MasterCI@2/VAGRANT/build/packer/rackhd-ubuntu-14.04-2.12.0-20170701UTC.box to version/0.07.02/provider/virtualbox successfully!
Release version 0.07.02 successfully!

```

And there it is
![image](https://user-images.githubusercontent.com/14049268/27775070-a4723a2c-5fd0-11e7-8abc-ca17ea68098c.png)
