### PR TITLE
if default gateway exists, change it

### DIFF
--- a/jobs/build_ova/ansible/main.yml
+++ b/jobs/build_ova/ansible/main.yml
@@ -6,6 +6,16 @@
         ip route add default via {{ ova_gateway }} dev {{ ova_net_interface }}
       tags:
         - config-gateway
+      ignore_errors: yes
+      register: gateway
+
+    - name: Enable external network through gateway
+      become: yes
+      shell: |
+        ip route change default via {{ ova_gateway }} dev {{ ova_net_interface }}
+      tags:
+        - config-gateway
+      when: gateway.rc != 0
 
     - name: Copy rackhd config for test
       become: yes

--- a/jobs/build_ova/prepare_ova_post_test.sh
+++ b/jobs/build_ova/prepare_ova_post_test.sh
@@ -77,19 +77,7 @@ configOVA() {
     echo "ova-post-test ansible_host=$OVA_INTERNAL_IP ansible_user=$OVA_USER ansible_ssh_pass=$OVA_PASSWORD ansible_become_pass=$OVA_PASSWORD" > hosts
     cp -f ${WORKSPACE}/build-config/vagrant/config/mongo/config.json .
     if [ -z "${External_vSwitch}" ]; then
-      set +e
-      rc=1
-      n=0
-      until [ $rc -eq 0 ]; do
-        ansible-playbook -i hosts main.yml --extra-vars "ova_gateway=$OVA_GATEWAY ova_net_interface=$OVA_NET_INTERFACE" --tags "config-gateway"
-        rc=$?
-        #n=$[$n+1]
-        if [ $n -ge 10 ];then
-          break;
-        fi
-        sleep 2
-      done
-      set -e
+      ansible-playbook -i hosts main.yml --extra-vars "ova_gateway=$OVA_GATEWAY ova_net_interface=$OVA_NET_INTERFACE" --tags "config-gateway"
     fi
     ansible-playbook -i hosts main.yml --tags "before-test"
   popd


### PR DESCRIPTION
a newly deployed new ova sometimes will have a default gateway, so if add default gateway again
```
TASK [Enable external network through gateway] *********************************
fatal: [ova-post-test]: FAILED! => {"changed": true, "cmd": "ip route add default via 172.31.128.250 dev eth1", "delta": "0:00:00.002923", "end": "2017-07-04 04:34:49.500372", "failed": true, "rc": 2, "start": "2017-07-04 04:34:49.497449", "stderr": "RTNETLINK answers: File exists", "stderr_lines": ["RTNETLINK answers: File exists"], "stdout": "", "stdout_lines": []}
	to retry, use: --limit @/home/****/workspace/MasterCI/build-config/jobs/build_ova/ansible/main.retry
```
such error will occur.

so this pr will try to change the gateway if it already exists.

however, why the newly deployed ova sometimes has a default eth1 gateway but sometimes not is still a mistery.

@panpan0000 @PengTian0 