### PR TITLE
RAC-5280 - improvement of SprintRelease pipeline  to skip all tests

### DIFF
--- a/jobs/FunctionTest/SourceBasedTest.groovy
+++ b/jobs/FunctionTest/SourceBasedTest.groovy
@@ -7,6 +7,11 @@ def generateTestBranches(function_test){
         def ALL_TESTS = function_test.getAllTests()
         def used_resources = function_test.getUsedResources()
         def TESTS = "${env.TESTS}"
+        if(TESTS == "null" || TESTS == "" || TESTS == null){
+           print "no test need to run"
+           return 
+            }
+
         def test_stack = "-stack docker_local_run"
         List tests_group = Arrays.asList(TESTS.split(','))
         for(int i=0; i<tests_group.size(); i++){

--- a/jobs/FunctionTest/SourceBasedTest.groovy
+++ b/jobs/FunctionTest/SourceBasedTest.groovy
@@ -8,9 +8,10 @@ def generateTestBranches(function_test){
         def used_resources = function_test.getUsedResources()
         def TESTS = "${env.TESTS}"
         if(TESTS == "null" || TESTS == "" || TESTS == null){
-           print "no test need to run"
-           return 
-            }
+            print "no test need to run"
+            return 
+            
+        }
 
         def test_stack = "-stack docker_local_run"
         List tests_group = Arrays.asList(TESTS.split(','))


### PR DESCRIPTION
Background: 
MasterCI/SprintRelease pipeline code doesn't allow we skip function-tests ,ERROR like : 
Caught: java.lang.NullPointerException: Cannot get property 'label' on null object

Details : 
changed in file named SourceBasedTest.groovy , added judgement of TESTS .if no test ,will skip run test step. 

TestDone : http://10.62.59.175:8080/job/masterRC5280/51/

Reviewer : 
@panpan0000 @changev @PengTian0 @linlynn @anhou 