### PR TITLE
RAC-4719 sync ova time with vmslave and modify sol log format

### DIFF
--- a/generate-sol-log.sh.in
+++ b/generate-sol-log.sh.in
@@ -30,7 +30,7 @@ while [ ${timeout} != ${maxto} ]; do
                         cmd='ipmitool -I lanplus -H ${bmc_ip} -U ${bmc_user} -P ${bmc_password} sol activate |
                                     tr 'A-Z' 'a-z' |
                                     while IFS= read -r line; do 
-                                        echo "$(date) $line"; 
+                                        echo "$(date +%FT%H:%M:%SZ) $line"; 
                                     done > ${WORKSPACE}/build-log/${vnode_num}.sol.log.raw'
                         #dump cmd to cmd.sh, replace vars with actual value.
                         echo -e "bmc_ip=$ip\nbmc_user=${bmc%:*}\nbmc_password=${bmc#*:}\nvnode_num=${vnode_num}"|\

--- a/jobs/build_ova/ansible/main.yml
+++ b/jobs/build_ova/ansible/main.yml
@@ -17,6 +17,14 @@
         - config-gateway
       when: gateway.rc != 0
 
+    - name: Sync ova time
+      become: yes
+      shell: |
+        timedatectl set-timezone America/New_York
+        ntpdate {{ ova_gateway }}
+      tags:
+        - before-test
+
     - name: Copy rackhd config for test
       become: yes
       copy:

--- a/jobs/build_ova/prepare_ova_post_test.sh
+++ b/jobs/build_ova/prepare_ova_post_test.sh
@@ -79,7 +79,7 @@ configOVA() {
     if [ -z "${External_vSwitch}" ]; then
       ansible-playbook -i hosts main.yml --extra-vars "ova_gateway=$OVA_GATEWAY ova_net_interface=$OVA_NET_INTERFACE" --tags "config-gateway"
     fi
-    ansible-playbook -i hosts main.yml --tags "before-test"
+    ansible-playbook -i hosts main.yml --tags "before-test" --extra-vars "ova_gateway=$OVA_GATEWAY"
   popd
 }
 


### PR DESCRIPTION
Background:
1. OVA has different time with vmslaves, so the console log of jenkins has different time stamp with ova rackhd log. this is badfor debug.
2. make sol log time stamp format more readable(same with rackhd)
@PengTian0 @panpan0000 
