### PR TITLE
[W.I.P] [RAC-5547] All-in-Docker script for vRack/CI test Env (Pair with @Tian )

### DIFF
--- a/deployRackHD_from_src.sh
+++ b/deployRackHD_from_src.sh
@@ -1,0 +1,453 @@
+#!/bin/bash -e
+
+#############################################
+#
+# Global Variable
+############################################
+RACKHD_DOCKER_NAME="my/test"
+BASE_IMAGE_URL=http://rackhdci.lss.emc.com/job/Docker_Image_Build/lastSuccessfulBuild/artifact/rackhd_pipeline_docker.tar  # EMC internal Jenkins
+OPERATION=""
+#########################################
+#
+#  Usage
+#
+#########################################
+Usage(){
+    echo "function: this script is used to deploy rackhd within docker"
+    echo "usage: $0 [options] [arguments]"
+    echo "  options:"
+    echo "    -h     : give this help list"
+    echo "    cleanup: remove the running rackhd docker container and rackhd images"
+    echo "    deploy : build a image with rackhd and run it"
+    echo "    mandatory arguments:"
+    echo "      -w, --workspace: the directory of workspace( where the code will be cloned to and staging folder), it's required"
+    echo "      -p, --sudo_password: password of current user which has sudo privilege, it's required."
+    echo "    Optional Arguments:"
+    echo "      -s, --SRC_CODE_DIR: The directory of source code which contains all the repositories of RackHD"
+    echo "                       If it's not provided, the script will clone the latest source code under $WORKSPACE/build-deps"
+    echo "      -f, --MANIFEST_FILE: The path of manifest file"
+    echo "                       If it's not provided, the script will generate a new manifest with latest commit of repositories of RackHD"
+    echo "      -b, --ON_BUILD_CONFIG_DIR: The directory of repository on-build-config"
+    echo "                       If it's not provided, the script will clone the latest repository on-build-config under $WORKSPACE"
+    echo "      -i, --RACKHD_IMAGE_PATH: The path of base docker image of rackhd CI test (rackhd/pipeline)"
+    echo "                       If it's not provided, the script will download the image from jenkins artifacts"
+}
+
+
+##############################################
+#
+# Remove docker images after test
+#
+###########################################
+cleanUpDockerImages(){
+    set +e
+    local to_be_removed="$(echo $SUDO_PASSWORD |sudo -S docker images ${RACKHD_DOCKER_NAME} -q)  \
+                         $(echo $SUDO_PASSWORD |sudo -S docker images rackhd/pipeline -q)  \
+                         $(echo $SUDO_PASSWORD |sudo -S docker images -f "dangling=true" -q )"
+    # remove ${RACKHD_DOCKER_NAME} image,  rackhd/pipeline image and <none>:<none> images
+    if [ ! -z "${to_be_removed// }" ] ; then
+         echo $SUDO_PASSWORD |sudo -S docker rmi $to_be_removed
+    fi
+    set -e
+}
+
+##############################################
+#
+# Remove docker instance which are running
+#
+###########################################
+cleanUpDockerContainer(){
+    set +e
+    local docker_name_key=$1
+    local running_docker=$(echo $SUDO_PASSWORD |sudo -S docker ps -a |grep "$1" |awk '{print $1}')
+    if [ "$running_docker" != "" ]; then
+         echo $SUDO_PASSWORD |sudo -S docker stop $running_docker
+         echo $SUDO_PASSWORD |sudo -S docker rm   $running_docker
+    fi
+    set -e
+}
+
+######################################
+#
+# Clean Up runnning docker instance
+#
+#####################################
+cleanupDockers(){
+    echo "CleanUp Dockers ..."
+    set +e
+    cleanUpDockerContainer "${RACKHD_DOCKER_NAME}"
+    cleanUpDockerImages
+    set -e
+}
+
+
+#########################################
+#
+# Start Host services to avoid noise
+#
+#######################################
+startServices(){
+    echo "Start Services (mongo/rabbitmq)..."
+    set +e
+    mongo_path=$( which mongod )
+    rabbitmq_path=$( which rabbitmq-server )
+    if [ ! -z "$mongo_path" ]; then
+        echo $SUDO_PASSWORD |sudo -S service mongodb start
+    fi
+    if [ ! -z "$rabbitmq_path" ]; then
+        echo $SUDO_PASSWORD |sudo -S service rabbitmq-server start
+    fi
+    set -e
+}
+#########################################
+#
+# Stop Host services to avoid noise, there're mongo/rabbitmq inside docker , port confliction with OS's mongo/rabbitmq will occur.
+#
+#######################################
+stopServices(){
+    echo "Stop Services (mongo/rabbitmq)..."
+    set +e
+    netstat -ntlp |grep ":27017 "
+    mongo_port_in_use=$?
+    netstat -ntlp |grep ":5672 "
+    rabbitmq_port_in_use=$?
+    if [ "$mongo_port_in_use" == "0" ]; then
+        echo $SUDO_PASSWORD |sudo -S service mongodb stop
+    fi
+    if [ "$rabbitmq_port_in_use" == "0" ]; then
+        echo $SUDO_PASSWORD |sudo -S service rabbitmq-server stop
+    fi
+    set -e
+}
+
+############################################
+#
+# Clean Up if you want to stop RackHD docker and recover services
+#
+###########################################
+cleanUp(){
+    set +e
+    echo "*****************************************************************************************************"
+    echo "Start to clean up environment: stopping running containers, starting service mongodb and rabbitmq-server"
+    echo "*****************************************************************************************************"
+    cleanupDockers
+    startServices
+    netstat -ntlp
+    echo "*****************************************************************************************************"
+    echo "End to clean up environment: stopping running containers, starting service mongodb and rabbitmq-server"
+    echo "*****************************************************************************************************"
+    set -e
+}
+
+##############################################
+#
+# Back up exist dir or file
+#
+#############################################
+backupFile(){
+    
+    local new_name=$( basename $1 )_$(date "+%Y-%m-%d-%H-%M-%S")
+    if [ -d $1 ];then
+        echo "[Warning]: $1 already exists, it will be moved to $WORKSPACE/$new_name !"
+        mv $1 $WORKSPACE/$new_name
+    fi
+    if [ -f $1 ];then
+        echo "[Warning]: $1 already exists, it will be moved to $WORKSPACE/$new_name !"
+        mv $1 $WORKSPACE/$new_name
+    fi
+}
+
+##############################################
+#
+# Clean up previous dirty space before everyting starts
+# Check arguments and prepare depends repository and images
+#
+#############################################
+prepareEnv(){
+    echo "*****************************************************************************************************"
+    echo "Start to clean up environment: stopping running containers, service mongodb and rabbitmq-server"
+    echo "*****************************************************************************************************"
+    cleanupDockers
+    stopServices
+    #############################################
+    #
+    # Default Parameter Checking
+    #
+    #############################################
+    if [ ! -n "${WORKSPACE}" ]; then
+        echo "Arguments WORKSPACE is required"
+        exit 1
+    else
+        if [ ! -d "${WORKSPACE}" ]; then
+            mkdir -p ${WORKSPACE}
+        fi
+    fi
+    if [ ! -n "${ON_BUILD_CONFIG_DIR}" ]; then
+        pushd $WORKSPACE
+        backupFile on-build-config
+        git clone https://github.com/RackHD/on-build-config
+        ON_BUILD_CONFIG_DIR=$WORKSPACE/on-build-config
+        popd
+    fi
+    if [ ! -n "${RACKHD_IMAGE_PATH}" ]; then
+        pushd $WORKSPACE
+        # Auto Select the best available server to download
+        set +e 
+        ping -q -c 1 rackhdci.lss.emc.com > /dev/null
+        if [ "$?" != "0" ]; then
+           BASE_IMAGE_URL=http://147.178.202.18/job/Docker_Image_Build/lastSuccessfulBuild/artifact/rackhd_pipeline_docker.tar  # the cloud Jenkins mirror
+        fi
+        set -e
+        download_docker_file=$( echo ${BASE_IMAGE_URL##*/} )
+        backupFile $download_docker_file
+        wget $BASE_IMAGE_URL
+        RACKHD_IMAGE_PATH=$WORKSPACE/$download_docker_file
+        popd
+    fi
+    if [ ! -n "${SRC_CODE_DIR}" ]; then
+        if [ ! -n "${MANIFEST_FILE}" ]; then
+           # Checkout RackHD source code and build them
+           generateManifest # it will generate a manifest file and export the MANIFEST_FILE variable
+        fi
+        preparePackages $MANIFEST_FILE # it will clone and build RackHD code under ${WORKSPACE}/build-deps according to the new_manifest
+        SRC_CODE_DIR=${WORKSPACE}/build-deps
+    fi
+    echo "*****************************************************************************************************"
+    echo "End to clean up environment: stopping running containers, service mongodb and rabbitmq-server"
+    echo "*****************************************************************************************************"
+}
+
+##############################################
+#
+# Generate a manifest file according to the latest commit of repositories of RackHD
+#
+#############################################
+generateManifest(){
+    echo "*****************************************************************************************************"
+    echo "Start to generate a manifest with the latest commit of RackHD" 
+    echo "*****************************************************************************************************"
+    pushd $ON_BUILD_CONFIG_DIR
+    # Generate a manifest file
+    ./build-release-tools/HWIMO-BUILD build-release-tools/application/generate_manifest.py \
+    --branch master \
+    --date current \
+    --timezone -0500 \
+    --builddir $WORKSPACE/build-deps \
+    --dest-manifest new_manifest \
+    --force \
+    --jobs 8
+    # above script will generate a manifest file as $WORKSPACE/new_manifest
+    MANIFEST_FILE=$WORKSPACE/new_manifest
+    popd
+    echo "*****************************************************************************************************"
+    echo "End to generate manifest file"
+    echo "*****************************************************************************************************"
+}
+
+##############################################
+#
+# Check out repositories of RackHD, build them and download static files
+#
+#############################################
+preparePackages() {
+    echo "*****************************************************************************************************"
+    echo "Start to check out RackHD source code and run npm build"
+    echo "*****************************************************************************************************"
+    pushd $ON_BUILD_CONFIG_DIR
+    pwd
+    export SKIP_PREP_DEP=false
+    export MANIFEST_FILE=$MANIFEST_FILE
+    export WORKSPACE=$WORKSPACE
+    ln -s $ON_BUILD_CONFIG_DIR $WORKSPACE/build-config
+    bash jobs/FunctionTest/prepare_manifest.sh
+    popd
+    echo "*****************************************************************************************************"
+    echo "End to check out RackHD source code and run npm build"
+    echo "*****************************************************************************************************"
+}
+
+###################################
+#
+# Modify the RackHD default Config file
+#
+#################################
+setupRackHDConfig(){
+    echo "*****************************************************************************************************"
+    echo "Customize RackHD Config Files to adopt RackHD docker enviroment"
+    echo "*****************************************************************************************************"
+
+    RACKHD_DHCP_HOST_IP=$(ifconfig | awk '/inet addr/{print substr($2,6)}' |grep 172.31.128)
+    sed -i "s/172.31.128.1/${RACKHD_DHCP_HOST_IP}/g" ${ON_BUILD_CONFIG_DIR}/jobs/pr_gate/docker/monorail/config.json
+}
+
+
+###################################
+#
+# Build docker and run it
+#
+#################################
+dockerUp(){
+    echo "*****************************************************************************************************"
+    echo "Start to build and run RackHD CI docker"
+    echo "*****************************************************************************************************"
+    echo $SUDO_PASSWORD |sudo -S docker load -i $RACKHD_IMAGE_PATH
+    backupFile ${ON_BUILD_CONFIG_DIR}/jobs/pr_gate/docker/build-deps
+    mkdir ${ON_BUILD_CONFIG_DIR}/jobs/pr_gate/docker/build-deps
+    cp -r ${SRC_CODE_DIR}/* ${ON_BUILD_CONFIG_DIR}/jobs/pr_gate/docker/build-deps
+    pushd ${ON_BUILD_CONFIG_DIR}/jobs/pr_gate/docker
+    #cp -r ${WORKSPACE}/build-config/jobs/pr_gate/docker/* .
+    echo $SUDO_PASSWORD |sudo -S docker build -t my/test .
+    echo $SUDO_PASSWORD |sudo -S docker run --net=host -v /etc/localtime:/etc/localtime:ro -d -t my/test
+    popd
+    echo "*****************************************************************************************************"
+    echo "End to build and run RackHD CI docker"
+    echo "*****************************************************************************************************"
+}
+
+##############################################
+#
+# Check the API of RackHD is accessable
+#
+#############################################
+waitForAPI() {
+    echo "*****************************************************************************************************"
+    echo "Try to access the RackHD API"
+    echo "*****************************************************************************************************"
+    timeout=0
+    maxto=60
+    set +e
+    url=http://localhost:9090/api/2.0/nodes #9090 is the rackhd api port which docker uses
+    while [ ${timeout} != ${maxto} ]; do
+        wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue ${url}
+        if [ $? = 0 ]; then
+          break
+        fi
+        sleep 10
+        timeout=`expr ${timeout} + 1`
+    done
+    set -e
+    if [ ${timeout} == ${maxto} ]; then
+        echo "Timed out waiting for RackHD API service (duration=`expr $maxto \* 10`s)."
+        exit 1
+    fi
+    echo "*****************************************************************************************************"
+    echo "RackHD API is accessable"
+    echo "*****************************************************************************************************"
+}
+
+
+##############################################
+#
+# deploy RackHD 
+#
+#############################################
+deployRackHD(){
+    # Checkout tools: on-build-config and RackHD
+    prepareEnv
+    # Costumrize the config.json
+    setupRackHDConfig
+    # Build docker image and run it
+    dockerUp
+    # Check the RackHD API is accessable
+    waitForAPI   
+}
+
+
+##############################################
+#
+# Export log of RackHD from container
+#
+#############################################
+exportLogs(){
+    set +e
+    mkdir ${WORKSPACE}/build-log
+    containerId=$( docker ps|grep "${RACKHD_DOCKER_NAME}" | awk '{print $1}' )
+    echo $SUDO_PASSWORD |sudo -S docker cp $containerId:/root/.pm2/logs ${WORKSPACE}/build-log
+    echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER ${WORKSPACE}/build-log/logs
+    mv ${WORKSPACE}/build-log/logs/*.log ${WORKSPACE}/build-log
+}
+
+###################################################################
+#
+#  Parse and check Arguments
+#
+##################################################################
+parseArguments(){
+
+    while [ "$1" != "" ]; do
+        case $1 in
+            -w | --WORKSPACE )              shift
+                                            WORKSPACE=$1
+                                            ;;
+            -s | --SRC_CODE_DIR )           shift
+                                            SRC_CODE_DIR=$1
+                                            ;;
+            -f | --MANIFEST_FILE )          shift
+                                            MANIFEST_FILE=$1
+                                            ;;
+            -b | --ON_BUILD_CONFIG_DIR )       shift
+                                            ON_BUILD_CONFIG_DIR=$1
+                                            ;;
+            -i | --RACKHD_IMAGE_PATH )      shift
+                                            RACKHD_IMAGE_PATH=$1
+                                            ;;
+            -p | --SUDO_PASSWORD )          shift
+                                            SUDO_PASSWORD=$1
+                                            ;;
+            * )                             Usage
+                                            exit 1
+        esac
+        shift
+    done
+
+    if [ ! -n "${WORKSPACE}" ] && [ ${OPERATION,,} != "cleanup" ]; then  # ${str,,} is to_lowercase(). available for Bash 4.
+        echo "[Error]Arguments -w|--WORKSPACE is required!"
+        Usage
+        exit 1
+    fi
+
+    if [ ! -n "${SUDO_PASSWORD}" ]; then
+        echo "[Error]Arguments -p|--SUDO_PASSWORD is required"
+        Usage
+        exit 1
+    fi
+
+}
+
+
+########################################################
+#
+# Main
+#
+######################################################
+OPERATION=$1
+case "$1" in
+  cleanUp|cleanup)
+      shift
+      parseArguments $@
+      cleanUp
+  ;;
+
+  deploy)
+      shift
+      parseArguments $@
+      deployRackHD
+  ;;
+
+  exportLog)
+      shift
+      parseArguments $@
+      exportLogs
+  ;;
+
+  -h|--help|help)
+    Usage
+    exit 0
+  ;;
+
+  *)
+    Usage
+    exit 1
+  ;;
+
+esac

--- a/deployVNodes.sh
+++ b/deployVNodes.sh
@@ -1,0 +1,313 @@
+#!/bin/bash -e
+
+#####################################
+#
+#  Usage
+#
+####################################
+
+Usage()
+{
+    echo "Function: this script is used to deploy/cleanup InfraSIM dockers and setup pipework network "
+    echo "Usage: [OPERATION]|--help [OPTION]"
+    echo "  OPERATION:"
+    echo "    deploy : to deploy InfraSIM in dockers"
+    echo "    cleanup: to destroy the running InfraSIM dockers"
+    echo "  OPTION:"
+    echo "    -c, --VNODE_COUNT  : vNode count: how many infraSIM instance to be created(only required for deploy opertion, default value is 2)"
+    echo "    -p, --SUDO_PASSWORD : sudo password of current user with root privileged"
+}
+
+
+
+
+#############################################
+#
+# Global Variable
+############################################
+OV_BRIDGE=ovs-br0   # Open VSwitch Bridge Name in Host
+INFRASIM_DOCKER=infrasim/infrasim-compute
+INFRASIM_DOCKER_TAG=infrasim-compute_227db #lock down the version
+NODE_TYPE_ARRAY=(quanta_d51 quanta_t41 dell_r630 s2600kp dell_c6320 dell_r730 s2600tp)
+INFRSIM_RAM=2048
+INFRSIM_INSTANCE_NAME_PREFIX=idic
+
+
+##############################################
+#
+# Remove docker instance which are running
+#
+###########################################
+cleanUpDockerContainer(){
+    set +e
+    CONTAINERS=$(docker ps -a -q --filter ancestor=$INFRASIM_DOCKER:$INFRASIM_DOCKER_TAG --format="{{.ID}}")
+    if [ "$CONTAINERS" != "" ]; then
+        echo "Stop docker containers..."
+        docker stop $CONTAINERS
+        echo "Remove docker containers..."
+        docker rm $CONTAINERS
+    else
+        echo "No running infrasim/infrasim-compute containers. skip cleanup"
+    fi
+    set -e
+}
+
+
+##############################################
+#
+# Modify InfraSIM config file
+#
+###########################################
+prepare_pipework(){
+    if [ "$(which pipework)" == "" ]; then
+        pushd /tmp
+        rm pipework -rf
+        git config --global http.sslverify false
+        git clone https://github.com/jpetazzo/pipework.git
+        echo $SUDO_PASSWORD |sudo -S  scp $PWD/pipework/pipework /usr/local/bin/pipework
+        echo $SUDO_PASSWORD |sudo -S chmod +x /usr/local/bin/pipework
+        popd
+    else
+        echo "pipework is existing....skip prepare_pipework()"
+    fi
+}
+
+
+##############################################
+#
+# Modify InfraSIM config file
+#
+###########################################
+modifyInfrasimConfigFile(){
+     local vnode_id=$1
+     local vnode_docker_name=$2
+     local config_file=/root/.infrasim/.node_map/default.yml  #config file inside InfraSIM Docker
+
+     docker exec $vnode_docker_name  sed -i "s/type: dell_r730/type: ${NODE_TYPE_ARRAY[$((${vnode_id}-1))]}/"  $config_file
+     docker exec $vnode_docker_name  sed -i "s/network_mode: nat/network_mode: bridge/"  $config_file
+     docker exec $vnode_docker_name  sed -i "s/network_name: eth0/network_name: br0/"  $config_file
+     docker exec $vnode_docker_name  sed -i "s/mac:.*//"  $config_file
+     docker exec $vnode_docker_name  sed -i "s/size: 1024/size: ${INFRSIM_RAM}/g" $config_file
+}
+
+
+##############################################
+#
+# Helper Function: retrieve IP from a running Docker image
+#
+# $1: docker instance name
+# $2: the NIC name inside docker instance
+# $3: the name of ret value
+###########################################
+retrieveIPinsideDocker(){
+    local docker_name=$1    # e.x: idid1
+    local nic_interface=$2  # e.x: eth1
+
+    local ret_var=$3      # will use eval to set its value
+
+    local retry_counter=0
+    local retry_total=10
+    local my_ip=""
+    while [ ${retry_counter} != ${retry_total} ]; do
+        my_ip=$(docker exec $infrasim_docker_name ifconfig eth1 | awk '/inet addr/{print substr($2,6)}')
+        if [ "$my_ip" == "" ]; then
+            echo "retry to get docker image $infrasim_docker_name IP. maybe it is still under DHCP."
+            sleep 2;
+        else
+            break;
+        fi
+        retry_counter=$(( retry_counter + 1 ))
+    done
+    if [ "$my_ip" == "" ]; then
+        echo "No DHCP services, please check DHCP server."
+        return 1
+    else
+        eval $ret_var="'$my_ip'"   # return the parameter $3 to invoker
+        return 0
+    fi
+   
+}
+
+##############################################
+#
+# Set up Pipework
+#
+###########################################
+setupInfrasimNetwork(){
+
+    local vnode_docker_name=$1
+
+    echo "[Info] Use pipework to create eth1 inside $vnode_docker_name , and try DHCP to retrieve its IP"
+    echo $SUDO_PASSWORD |sudo -S  /bin/bash $(which pipework) ${OV_BRIDGE} -i eth1 $infrasim_docker_name dhclient
+
+    echo "[Info] Create br0 inside docker instance $vnode_docker_name"
+    # Create br0 inside infrasim docker
+    docker exec $infrasim_docker_name brctl addbr    br0
+    docker exec $infrasim_docker_name brctl addif    br0 eth1
+    docker exec $infrasim_docker_name brctl setfd    br0 0
+    docker exec $infrasim_docker_name brctl sethello br0 1
+    docker exec $infrasim_docker_name brctl stp      br0 no
+    sleep 2
+
+    # retry to obtain eth1's IP inside infrasim instance
+    local dhcp_ip=""
+    retrieveIPinsideDocker $infrasim_docker_name  "eth1"  dhcp_ip  # the 3rd parameter is the ret variable's name
+    if [ $? -ne 0 ]; then
+        echo "[Error] Timeout waiting for DHCP of Infrasim internal eth1 IP from $vnode_docker_name."
+        exit -1
+    fi
+    echo "[Info] Exchange the eth1 IP with br0 inside $vnode_docker_name"
+    docker exec $infrasim_docker_name ifconfig eth1 0
+    docker exec $infrasim_docker_name ifconfig eth1 promisc
+    docker exec $infrasim_docker_name ifconfig br0 $dhcp_ip
+
+}
+
+##############################################
+#
+# Pull Docker Image with retry (dockerhub pull are slow in APJ and may end up "docker: unauthorized: authentication required.")
+#
+###########################################
+dockerPullWithRetry(){
+    local retry_counter=0
+    local docker_image=$1
+    local retry_total=$2
+    if [ "$docker_image" == "" ]; then
+       echo "[Error] in dockerPullWithRetry(), missing argument docker_image"
+       exit -1
+    fi
+    if [ -z $retry_total ]; then
+       retry_total=3
+    fi
+    while [ ${retry_counter} != ${retry_total} ]; do
+            docker pull ${docker_image}
+            if [ $? -ne 0 ]; then
+            echo "retry to pull docker image $docker_image "
+        else
+            break;
+        fi
+        retry_counter=$(( retry_counter + 1 ))
+    done
+}
+
+
+####################################
+#
+# start infrasim docker, then create bridge inside it , bind with ovs-br0 using pipework.
+# then start infrasim app.
+#
+####################################
+startInfrasimNodes() {
+
+    # Prepare InfraSIM running
+    prepare_pipework
+    dockerPullWithRetry ${INFRASIM_DOCKER}:${INFRASIM_DOCKER_TAG}   3
+
+    local port_num=15901 # the Host VNC port base
+
+    local vnode_id
+    for vnode_id in $(seq 1 ${VNODE_COUNT})  ; do
+
+        local infrasim_docker_name=idic${vnode_id}
+
+        echo "[Info]: create docker instance : $infrasim_docker_name on port $port_num "
+
+        docker run --privileged -p ${port_num}:5901 -dit --name $infrasim_docker_name  ${INFRASIM_DOCKER}:${INFRASIM_DOCKER_TAG} /bin/bash
+
+
+        # modify the infrasim config file
+        modifyInfrasimConfigFile ${vnode_id} ${infrasim_docker_name}
+
+        # setup Pipework network and InfraSIM br0
+        setupInfrasimNetwork ${infrasim_docker_name}
+
+        # start InfraSIM
+        echo "[Info] Start InfraSIM node $vnode_docker_name"
+        docker exec $infrasim_docker_name infrasim node start
+       
+        port_num=$(( $port_num + 1 ))
+
+    done
+}
+################################
+#
+# Parse the options after deploy|clenup 
+#
+##############################
+
+parseOptions(){
+    while [ "$1" != "" ]; do
+        case $1 in
+             -c | --VNODE_COUNT )   shift
+                                    VNODE_COUNT=$1
+                                    ;;
+             -p | --SUDO_PASSWORD ) shift
+                                    SUDO_PASSWORD=$1
+                                    ;;
+             * )                    Usage
+                                    exit 1
+        esac
+        shift
+    done
+    if  [ ! -n "${VNODE_COUNT}" ];  then
+        VNODE_COUNT=2
+    fi
+
+    if  [ ! -n "${SUDO_PASSWORD}" ];  then
+        echo "[Error] SUDO_PASSWORD is mandatory"
+        Usage
+        exit 1
+    fi
+
+}
+
+################################
+#
+# Main Function
+#
+##############################
+main(){
+    local argc=("$@")
+    local argv=$#
+
+    if [ $argv  -eq 0 ];then
+        Usage
+        exit 1
+    fi
+    while [ "$1" != "" ]; do
+        case $1 in
+            ##########################
+            # deploy opertion: parse arguments
+            #########################
+            deploy)
+                parseOptions ${argc[@]:1} #elements from a[1]
+                startInfrasimNodes
+                break
+                ;;
+            ##########################
+            # cleanup opertion: parse arguments
+            #########################
+            cleanup|cleanUp)
+                parseOptions ${argc[@]:1} 
+                cleanUpDockerContainer
+                break
+                ;;
+            ##########################
+            # --help 
+            #########################
+            -h | --help )
+                Usage
+                exit
+                ;;
+            *)  Usage
+                exit 1
+         esac
+         shift
+   done
+
+
+
+}
+
+################################
+main $@

--- a/deployVRack.sh
+++ b/deployVRack.sh
@@ -1,0 +1,244 @@
+#!/bin/bash -e
+
+#############################################
+#
+# Usage
+#
+# ############################################
+Usage(){
+    echo "*****************************************************************************"
+    echo " Function: help to deploy RackHD/InfraSIM as a virtual Rack, then run FIT."
+    echo ""
+    echo ""
+    echo " Prerequisite:"
+    echo "      - docker installed."
+    echo "      - open vswitch installed."
+    echo "      - a NIC with IP 172.31.128.x(typically eth1)"
+    echo ""
+    echo ""
+    echo " Usage: $0 [option] [arguments]"
+    echo "  option:"
+    echo "    deploy : create a vRack: deploy RackHD and InfraSIM in docker "
+    echo "    test   : when if vRack has been deployed. run FIT test"
+    echo "    cleanUp: remove the docker images and restore network setting"
+    echo "    help   : give this help list"
+    echo ""
+    echo "   Mandatory arguments:"
+    echo "      -w, --WORKSPACE: the directory of workspace( where the code will be cloned to and staging folder), it's required"
+    echo "      -p, --SUDO_PASSWORD: password of current user which has sudo privilege, it's required."
+    echo ""
+    echo "    Optional Arguments:"
+    echo "        -g, --TEST_GROUP:  the test cases group name to be run in FIT"
+    echo "        -c, --VNODE_COUNT: the number of InfraSIM vNode to be deployed"
+    echo "*****************************************************************************"
+}
+
+
+#############################################
+#
+# Global Variable
+############################################
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+DEPLOY_RACKHD_ARGS=()
+FIT_ARGS=()
+OPERTATION=""
+
+####################################
+# helpful fucntion: compare two version string
+###################################
+version_gt(){
+     test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+}
+
+####################################
+# check prerequisite
+###################################
+check_prerequisite(){
+    local result=true;
+    local docker_version=$(docker -v| grep -Po '(Docker version )\d*.\d*.\d*[-ce]*' | awk '{print $NF}')
+    local open_vswitch_version=$( ovs-vsctl --version |grep '(Open vSwitch) .*'|awk '{print $NF}' )
+    # docker -v will show "Docker version 17.03.1-ce, build c6d412e"
+
+    if [ "$docker_version" == "" ]; then
+         echo "[Error] Docker is not Installed!"
+         result=false
+    fi
+
+    if [ "$open_vswitch_version" == "" ]; then
+         echo "[Error] Open VSwitch is not Installed!"
+         result=false
+    fi
+
+    local verified_docker_version=17.03.1-ce
+    if  $(version_gt  $verified_docker_version $docker_version)  ; then
+        echo "[Warning] Installed docker version($docker_version) is lower than verifed docker version $verified_docker_version"
+    fi
+
+    local verified_open_vswitch_version=2.0.2
+    if  $(version_gt  $verified_open_vswitch_version $open_vswitch_version)  ; then
+        echo "[Warning] Installed Open VSwitch version($open_vswitch_version) is lower than verifed Open VSwitch version $verified_open_vswitch_version"
+    fi
+
+    if [ "$result" == "true" ]; then
+         return 0
+    else
+         return 1
+    fi
+
+}
+
+####################################
+# Clean Up and Restore
+###################################
+cleanUp(){
+        ${SCRIPTPATH}/deployVNodes.sh           cleanUp -p $SUDO_PASSWORD
+        ${SCRIPTPATH}/deployRackHD_from_src.sh  cleanUp -p $SUDO_PASSWORD
+        ${SCRIPTPATH}/deployVSwitch.sh          cleanUp -p $SUDO_PASSWORD
+
+}
+
+
+
+####################################
+#
+# deploy RackHD and virtual Nodes
+#
+###################################
+deploy(){
+
+    check_prerequisite
+    
+    ${SCRIPTPATH}/deployVSwitch.sh          deploy -p $SUDO_PASSWORD
+
+    ${SCRIPTPATH}/deployRackHD_from_src.sh  deploy -p $SUDO_PASSWORD -w $WORKSPACE "$DEPLOY_RACKHD_ARGS"
+
+    ${SCRIPTPATH}/deployVNodes.sh           deploy -p $SUDO_PASSWORD -c ${VNODE_COUNT}
+}
+
+####################################
+#
+# run FIT test
+#
+###################################
+runTests(){
+    ${SCRIPTPATH}/runFIT.sh -w $WORKSPACE -p $SUDO_PASSWORD -g "$TEST_GROUP" $FIT_ARGS
+}
+
+###################################################################
+#
+#  Parse and check Arguments
+#
+##################################################################
+parseArguments(){
+    while [ "$1" != "" ]; do
+        case $1 in
+            -w | --WORKSPACE )              shift
+                                            WORKSPACE=$1
+                                            ;;
+            -p | --SUDO_PASSWORD )          shift
+                                            SUDO_PASSWORD=$1
+                                            ;;
+            -g | --TEST_GROUP )             shift
+                                            TEST_GROUP="$1"
+                                            ;;
+            -c | --VNODE_COUNT )            shift
+                                            VNODE_COUNT=$1
+                                            ;;
+            * )                             echo "[Error] Unknown argument $1"
+                                            Usage
+                                            exit 1
+        esac
+        shift
+    done
+
+    if [ ! -n "${WORKSPACE}" ] && [ ${OPERATION,,} != "cleanup" ]; then  # ${str,,} is to_lowercase(). available for Bash 4.
+        echo "[Error]Arguments -w|--WORKSPACE is required!"
+        Usage
+        exit 1
+    fi
+
+    if [ ! -n "${SUDO_PASSWORD}" ]; then
+        echo "[Error]Arguments -p|--SUDO_PASSWORD is required"
+        Usage
+        exit 1
+    fi
+
+    if [ ! -n "${ON_BUILD_CONFIG_DIR}" ]; then
+        if [ -d $WORKSPACE/on-build-config ]; then
+            ON_BUILD_CONFIG_DIR=$WORKSPACE/on-build-config
+            DEPLOY_RACKHD_ARGS+=" -b $ON_BUILD_CONFIG_DIR"
+            FIT_ARGS+=" -b $ON_BUILD_CONFIG_DIR"
+        fi
+    fi
+
+    if [ ! -n "${RACKHD_DIR}" ]; then
+        if [ -d $WORKSPACE/RackHD ]; then
+            RACKHD_DIR=$WORKSPACE/RackHD
+            FIT_ARGS+=" -r ${RACKHD_DIR}"
+        fi
+    fi
+
+    if [ ! -n "${RACKHD_IMAGE_PATH}" ]; then
+        if [ -f $WORKSPACE/rackhd_pipeline_docker.tar ]; then
+            RACKHD_IMAGE_PATH=$WORKSPACE/rackhd_pipeline_docker.tar
+            DEPLOY_RACKHD_ARGS+=" -i ${RACKHD_IMAGE_PATH}"
+        fi
+    fi
+
+    if [ ! -n "${SRC_CODE_DIR}" ]; then
+        if [ -d $WORKSPACE/build-deps ]; then
+            SRC_CODE_DIR=${WORKSPACE}/build-deps
+            DEPLOY_RACKHD_ARGS+=" -s ${SRC_CODE_DIR}"
+        fi
+    fi
+
+    if  [ ! -n "${VNODE_COUNT}" ];  then
+        VNODE_COUNT=2
+    fi
+
+    if [ ! -n "$TEST_GROUP" ]; then
+        TEST_GROUP=("-test tests -group smoke")
+    fi
+}
+
+########################################################
+#
+# Main
+#
+#
+####################################################
+OPERATION=$1
+case "$1" in
+  cleanUp|cleanup)
+      shift
+      parseArguments $@
+      cleanUp
+  ;;
+
+  deploy)
+      shift
+      parseArguments $@
+      deploy
+  ;;
+
+  test)
+      shift
+      parseArguments $@
+      runTests
+  ;;
+
+  -h|--help|help)
+    Usage
+    exit 0
+  ;;
+
+  *)
+    echo  "[Error] Unknown operation $1"
+    Usage
+    exit 1
+  ;;
+
+esac
+
+

--- a/deployVSwitch.sh
+++ b/deployVSwitch.sh
@@ -1,0 +1,123 @@
+#!/bin/bash -e
+#############################################
+#
+# Global Variable
+############################################
+OV_BRIDGE=ovs-br0
+
+#############################################
+#
+# Usage
+############################################
+Usage(){
+    set +x
+    echo "Function: This script is used to create a virtual switch $OV_BRIDGE with open-vswitch.
+                    It requires there is a NIC with IP 172.31.128.x
+                    The script will move the IP of the NIC to $OV_BRIDGE and set the IP of the NIC as 0"
+    echo "Usage: $0 [OPTIONS] [ARGUMENTS]"
+    echo "  OPTIONS:"
+    echo "    --help : give this help list"
+    echo "    cleanUp: remove the virtual switch $OV_BRIDGE created by the script"
+    echo "    deploy : create a virtual switch $OV_BRIDGE 
+                       set its IP as the original IP of the NIC whose IP is 172.31.128.x"
+    echo "  ARGUMENTS:"
+    echo "    -p     : the password of current user with root privilege"
+    set -x
+}
+
+#######################################
+#
+# Set up Network in Host( Open vSwitch Bridge)
+#
+#####################################
+setup_host_network(){
+   local RACKHD_DHCP_HOST_IP=$(ifconfig | awk '/inet addr/{print substr($2,6)}' |grep 172.31.128)
+   if [ "$RACKHD_DHCP_HOST_IP" == "" ]; then
+         echo "[Error] There should be a NIC with 172.31.128.xxx IP in your OS."
+         exit -2
+   fi
+   local RACKHD_DHCP_NIC=$( ifconfig | awk '/172.31.128/ {print $1}' RS="\n\n" )
+   echo "Debug: RackHD DHCP NIC is $RACKHD_DHCP_NIC, IP was $RACKHD_DHCP_HOST_IP."
+   echo $SUDO_PASSWORD |sudo -S ovs-vsctl add-br ${OV_BRIDGE}
+   echo $SUDO_PASSWORD |sudo -S ovs-vsctl add-port ${OV_BRIDGE} $RACKHD_DHCP_NIC
+   echo $SUDO_PASSWORD |sudo -S ovs-vsctl set Bridge ${OV_BRIDGE} other_config:stp-forward-delay=0
+   echo $SUDO_PASSWORD |sudo -S ovs-vsctl set Bridge ${OV_BRIDGE} other_config:stp-hello-time=1
+   echo $SUDO_PASSWORD |sudo -S ovs-vsctl set Bridge ${OV_BRIDGE} stp_enable=no
+   echo $SUDO_PASSWORD |sudo -S ip link set dev ${OV_BRIDGE} up
+   echo $SUDO_PASSWORD |sudo -S ifconfig $RACKHD_DHCP_NIC 0
+   echo $SUDO_PASSWORD |sudo -S ifconfig $RACKHD_DHCP_NIC promisc
+   echo $SUDO_PASSWORD |sudo -S ifconfig  ${OV_BRIDGE} $RACKHD_DHCP_HOST_IP
+}
+
+#######################################
+#
+# Delete bridge and restore IP
+#
+#####################################
+restore_host_network(){
+    echo "Restore NIC configurations and delete old open vswitch bridge..."
+    set +e
+    # delete the bridge created by open vswitch
+    local bridges=$( echo $SUDO_PASSWORD |sudo -S  ovs-vsctl list-br| grep $OV_BRIDGE )
+    if [ "$bridges" != "" ];  then
+         local DHCP_NIC=$( echo $SUDO_PASSWORD |sudo -S  ovs-vsctl list-ports ${bridges} | head -n1 )
+         local original_ip=$(ifconfig ${bridges} | awk '/inet addr/{print substr($2,6)}')
+         echo $SUDO_PASSWORD |sudo -S ovs-vsctl del-br $bridges
+         echo $SUDO_PASSWORD |sudo -S ifconfig $DHCP_NIC $original_ip
+         echo $SUDO_PASSWORD |sudo -S ifconfig $DHCP_NIC -promisc
+    fi
+    set -e
+}
+
+#######################################
+#
+# Parse and check arguments
+#
+#####################################
+parseArguments(){
+    while [ "$1" != "" ]; do
+        case $1 in
+            -p | --SUDO_PASSWORD )          shift
+                                            SUDO_PASSWORD=$1
+                                            ;;
+            * )                             Usage
+                                            exit 1
+        esac
+        shift
+    done
+    if [ ! -n "$SUDO_PASSWORD" ]; then
+        echo "The argument -p is required"
+        exit 1
+    fi
+}
+
+#####################################
+#
+# Main
+#
+###################################
+case "$1" in
+  cleanUp)
+      shift
+      parseArguments $@
+      restore_host_network
+  ;;
+
+  deploy)
+      shift
+      parseArguments $@
+      setup_host_network 
+  ;;
+
+  -h | --help)
+      Usage
+      exit 0
+  ;;
+
+  *)
+      Usage
+      exit 1
+  ;;
+
+esac
+

--- a/runFIT.sh
+++ b/runFIT.sh
@@ -1,0 +1,292 @@
+#!/bin/bash -e
+#############################################
+#
+# Global Variable
+############################################
+RACKHD_DOCKER_NAME=my/test
+
+#############################################
+#
+# Usage
+############################################
+Usage(){
+    set +x
+    echo "Function: This script is used to set up environment for FIT and run FIT."
+    echo "Usage: $0 [OPTIONS]"
+    echo "  OPTIONS:"
+    echo "    Mandatory options:"
+    echo "      -w, --WORKSPACE: The directory of workspace( where the code will be cloned to and staging folder), it's required"
+    echo "      -p, --SUDO_PASSWORD: password of current user which has sudo privilege, it's required."
+    echo "    Optional options:"
+    echo "      -b, --ON_BUILD_CONFIG_DIR: The directory of repository on-build-config"
+    echo "                       If it's not provided, the script will clone the latest repository on-build-config under $WORKSPACE"
+    echo "      -r, --RACKHD_DIR: The directory of repository RackHD"
+    echo "                       If it's not provided, the script will clone the latest repository RackHD under $WORKSPACE"
+    set -x
+}
+
+#############################################
+#
+#  Start to take the vnc record of nodes 
+#
+############################################
+vnc_record_start(){
+    mkdir -p ${WORKSPACE}/build-log
+    pushd ${ON_BUILD_CONFIG_DIR}
+    export fname_prefix="vNode"
+    if [ ! -z $BUILD_ID ]; then
+        export fname_prefix=${fname_prefix}_b${BUILD_ID}
+    fi
+    bash vnc_record.sh ${WORKSPACE}/build-log $fname_prefix &
+    popd
+}
+
+#############################################
+#
+#  Stop to take the vnc record of nodes
+#
+############################################
+vnc_record_stop(){
+    #sleep 2 sec to ensure FLV finishes the disk I/O before VM destroyed
+    set +e
+    pkill -f flvrec.py
+    sleep 2
+    set -e
+}
+
+#############################################
+#
+#  Start to export the sol log of nodes
+#
+############################################
+exportSolLogStart(){
+    pushd ${ON_BUILD_CONFIG_DIR}
+    bash generate-sol-log.sh > ${WORKSPACE}/sol.log &
+    popd
+}
+
+#############################################
+#
+#  Stop to export the sol log of nodes
+#
+############################################
+exportSolLogStop(){
+    set +e
+    pkill -f SCREEN
+}
+
+#############################################
+#
+#  Start to export the syslog of RackHD container
+#
+############################################
+exportSysLog(){
+    set +e
+    containerId=$( docker ps|grep "${RACKHD_DOCKER_NAME}" | awk '{print $1}' )
+    echo $SUDO_PASSWORD |sudo -S docker exec -it $containerId dmesg > ${WORKSPACE}/build-log/dmesg.log
+}
+
+#############################################
+#
+#  Start to export the mongo of RackHD container
+#
+############################################
+exportMongoLog(){
+    set +e
+    containerId=$( docker ps|grep "${RACKHD_DOCKER_NAME}" | awk '{print $1}' )
+    echo $SUDO_PASSWORD |sudo -S docker cp $containerId:/var/log/mongodb ${WORKSPACE}/build-log
+    echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER ${WORKSPACE}/build-log/mongodb
+}
+
+#############################################
+#
+# Stop to take the vnc record of nodes
+# Stop to export the sol log of nodes
+# Export the syslog and mongodb from RackHD container 
+#
+############################################
+cleanUp(){
+    vnc_record_stop
+    exportSolLogStop
+    exportSysLog
+    exportMongoLog
+}
+
+#############################################
+#
+#  Create the virtual env for FIT  
+#
+############################################
+setupVirtualEnv(){
+    pushd ${RACKHD_DIR}/test
+    rm -rf .venv/on-build-config
+    ./mkenv.sh on-build-config
+    source myenv_on-build-config
+    popd
+}
+
+####################################
+#
+# 1. Modify FIT config files , to  using actual DHCP Host IP instead of 172.31.128.1
+#
+##################################
+setupTestsConfig(){
+    echo "SetupTestsConfig ...replace the 172.31.128.1 IP in test configs with actual DHCP port IP"
+    RACKHD_DHCP_HOST_IP=$(ifconfig | awk '/inet addr/{print substr($2,6)}' |grep 172.31.128)
+    if [ "$RACKHD_DHCP_HOST_IP" == "" ]; then
+         echo "[Error] There should be a NIC with 172.31.128.xxx IP in your OS."
+         exit -2
+    fi
+    pushd ${RACKHD_DIR}/test/config
+    sed -i "s/\"username\": \"vagrant\"/\"username\": \"${USER}\"/g" credentials_default.json
+    sed -i "s/\"password\": \"vagrant\"/\"password\": \"$SUDO_PASSWORD\"/g" credentials_default.json
+    popd
+    pushd ${RACKHD_DIR}/test
+    find ./ -type f -exec sed -i -e "s/172.31.128.1/${RACKHD_DHCP_HOST_IP}/g" {} \;
+    popd
+}
+
+####################################
+#
+# Collect the test report
+#
+##################################
+collectTestReport()
+{
+    mkdir -p ${WORKSPACE}/xunit-reports
+    cp ${RACKHD_DIR}/test/*.xml ${WORKSPACE}/xunit-reports
+}
+
+
+####################################
+#
+# Start to run FIT tests
+#
+##################################
+runFIT() {
+    set +e
+    netstat -ntlp
+    echo "########### Run FIT Stack Init #############"
+    pushd ${RACKHD_DIR}/test
+    #TODO Parameterize FIT args
+    tstack="-stack docker_local_run"
+    args=()
+    if [ ! -z "$1" ];then
+        args+="$1"
+    fi
+    python run_tests.py -test deploy/rackhd_stack_init.py ${tstack} ${args} -xunit
+    if [ $? -ne 0 ]; then
+        echo "Test FIT failed running deploy/rackhd_stack_init.py"
+        collectTestReport
+        exit 1
+    fi
+    echo "########### Run FIT Smoke Test #############"
+    python run_tests.py ${TEST_GROUP} ${tstack} ${args} -v 4 -xunit
+    if [ $? -ne 0 ]; then
+        echo "Test FIT failed running smoke test"
+        collectTestReport
+        exit 1
+    fi
+    collectTestReport
+    popd
+    set -e
+}
+
+
+##############################################
+#
+# Set up test environment and run test
+#
+#############################################
+runTests(){
+    OVERALL_STATUS="FAILURE_EXIT"
+    trap "cleanUp $OVERALL_STATUS" SIGINT SIGTERM SIGKILL EXIT
+    setupTestsConfig
+    setupVirtualEnv
+    exportSolLogStart
+    vnc_record_start
+    runFIT " --sm-amqp-use-user guest"
+    OVERALL_STATUS="SUCCESSFUL_EXIT"
+}
+
+##############################################
+#
+# Back up exist dir or file
+#
+#############################################
+backupFile(){
+    if [ -d $1 ];then
+        mv $1 $1-bk
+    fi
+    if [ -f $1 ];then
+        mv $1 $1.bk
+    fi
+}
+
+#######################################
+#
+# Main
+#
+#####################################
+main(){
+    while [ "$1" != "" ]; do
+        case $1 in
+            -w | --WORKSPACE )              shift
+                                            WORKSPACE=$1
+                                            ;;
+            -b | --ON_BUILD_CONFIG_DIR )    shift
+                                            ON_BUILD_CONFIG_DIR=$1
+                                            ;;
+            -r | --RACKHD_DIR )             shift
+                                            RACKHD_DIR=$1
+                                            ;;
+            -p | --SUDO_PASSWORD )          shift
+                                            SUDO_PASSWORD=$1
+                                            ;;
+            -g | --TEST_GROUP )             shift
+                                            TEST_GROUP=$1
+                                            ;;
+            * )                             echo "[Error]$0: Unkown Argument: $1"
+                                            Usage
+                                            exit 1
+        esac
+        shift
+    done
+    if [ ! -n "$WORKSPACE" ]; then
+        echo "The argument -w|--WORKSPACE is required"
+        exit 1
+    else
+        if [ ! -d "${WORKSPACE}" ]; then
+            mkdir -p ${WORKSPACE}
+        fi
+    fi
+
+    if [ ! -n "$SUDO_PASSWORD" ]; then
+        echo "The argument -p|--SUDO_PASSWORD is required"
+        exit 1
+    fi
+
+    if [ ! -n "$ON_BUILD_CONFIG_DIR" ]; then
+        pushd $WORKSPACE
+        backupFile on-build-config
+        git clone https://github.com/RackHD/on-build-config
+        ON_BUILD_CONFIG_DIR=$WORKSPACE/on-build-config
+        popd
+    fi
+
+    if [ ! -n "$RACKHD_DIR" ]; then
+        pushd $WORKSPACE
+        backupFile RackHD
+        git clone https://github.com/RackHD/RackHD
+        RACKHD_DIR=$WORKSPACE/RackHD
+        popd
+
+    fi
+    if [ ! -n "$TEST_GROUP" ]; then
+        TEST_GROUP="-test tests -group smoke"
+    fi
+
+    runTests   
+}
+
+main "$@"


### PR DESCRIPTION
Don't Merge.
-----------------------
(Pair Programming with @PengTian0 )
---------------------

Background:
make CI portable. able to run outside Jenkins and don't rely on ESXi/VMWare.
it can run on a single host(VM/Physical Machine) OS.
RackHD is in docker, InfraSIM is in docker (if more than 1 InfraSIM, there will be multiple infrasim docker instance). pipework/open vswitch is used to setup the network.
this RackHD can also talk with external world to scale out ( like talking with a redfish/ucs simulator from eth1)

Implementation:
- deployVRack.sh:  an easy use script to do works of below: A turn-key script .
- deployRackHD_from_src.sh:  deploy RackHD in docker (build from source code)
- deployVNodes.sh : deploy InfraSIM nodes in docker
- deployVSwitch.sh:  setup open vswitch to bind eth1 with ovs-br0
- runFIT.sh : run FIT

![image](https://user-images.githubusercontent.com/14049268/27947464-78f5a608-6328-11e7-823c-339a3b8354ba.png)

Usage:

on a Ubuntu:
```./deployvRack.sh  deploy -w /tmp -p $PWD```
then RackHD API can be accessable from ```curl localhost:9090/api/2.0/``` with all nodes discovered.
```./deployvRack.sh   test  -w /tmp -p $PWD```
then FIT will run.
```./deployvRack.sh   cleanUp -p $PWD```
then all things being removed and restored.





Why don't merge:
a lot of duplication in the scripts with current code.
so it's plan to remove duplication code and refactor the test.sh.in and prepare_xx_post.test with this new solution.