### PR TITLE
BugFix: Stop service only when service is running

### DIFF
--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -6,7 +6,9 @@ set -e
 # otherwise mongo and rabbitmq service won't run normally
 # use host mongo and rabbitmq is a chioce but the coverage may be decreased.
 # services will be restart in cleanup.sh, which script will always be executed.
-echo $SUDO_PASSWORD |sudo -S service mongodb stop
+if [ "$(service mongodb status|grep  start )" != "" ]; then
+    echo $SUDO_PASSWORD |sudo -S service mongodb stop # "service mongodb stop" will return non 0 if service already stop,  while rabbitmq is fine
+fi
 echo $SUDO_PASSWORD |sudo -S service rabbitmq-server stop
 
 rackhd_docker_images=`ls ${DOCKER_PATH}`


### PR DESCRIPTION
Background Issue:

when if service was stopped and not installed. this script will fail when it tries to stop service again:
error message like below ( if mongo was stopped):
```
+ sudo -S service mongodb stop
sudo: unable to resolve host vmslave
[sudo] password for ****: stop: Unknown instance: 
```

example failure case:

http://10.6x.59.xxx:8080/blue/organizations/jenkins/Master-CI-RAC-4783/detail/Master-CI-RAC-4783/499/pipeline/408


Testing for this PR:
http://10.6x.59.xxx:8080/job/Master-CI-RAC-4783/511/