### PR TITLE
[SkipCI]in Docker Post Test, download then extract the deb , then pass to docker

### DIFF
--- a/jobs/build_docker/build_docker.sh
+++ b/jobs/build_docker/build_docker.sh
@@ -17,38 +17,47 @@ on_imagebuilder_version=$( ./build-config/build-release-tools/HWIMO-BUILD ./buil
 --repo-dir ./$CLONE_DIR/on-imagebuilder \
 --is-official-release $IS_OFFICIAL_RELEASE )
 
-
-echo $SUDO_PASSWORD |sudo -S rm -rf /etc/apt/sources.list.d/rackhd.source.list
-echo "deb https://dl.bintray.com/$CI_BINTRAY_SUBJECT/debian trusty main" | sudo tee -a /etc/apt/sources.list.d/rackhd.source.list
-echo $SUDO_PASSWORD |sudo -S apt-get update
-
-
 #build static files
 pushd ./$CLONE_DIR/on-imagebuilder
 
 # Download the staging on-imagebuilder.deb
 echo "[Info] Downloading on-imagebuilder deb , version = $on_imagebuilder_version ..."
-apt-get download on-imagebuilder=$on_imagebuilder_version
+BINTRAY_DL_URL=https://dl.bintray.com/rackhd/debian
+BINTRAY_DEB_LIST_FNAME=debian_list.html
+local_deb_fname=local-on-imaegbuilder-${on_imagebuilder_version}.deb
+rm  $BINTRAY_DEB_LIST_FNAME  -f
+
+#Get all the debian package lis on Bintray
+wget -c -t 5 -nv $BINTRAY_DL_URL  -O $BINTRAY_DEB_LIST_FNAME
+
+# find out the deb package name , it should be on-imagebuilder_$VERSION_all.deb
+deb_name=$(cat $BINTRAY_DEB_LIST_FNAME  |grep -o href=.*\"|sed 's/href=//' | sed 's/"//g'|grep  "on-imagebuilder.*${on_imagebuilder_version}.*.deb$")
+
+#Download the deb package to local folder
+wget -c -t 5 -nv ${BINTRAY_DL_URL}/${deb_name} -O ${local_deb_fname}
 
 # Extact the deb content into a folder
 if [ "$(which dpkg-deb)" == "" ]; then
      echo $SUDO_PASSWORD |sudo -S apt-get install -y dpkg
-fi
-local STAGE_FOLDER=deb_content
+ fi
+
+STAGE_FOLDER=deb_content
 mkdir -p $STAGE_FOLDER
-dpkg-deb -x on-imagebuilder*${on_imagebuilder_version}*.deb  $STAGE_FOLDER
-local common_path=${STAGE_FOLDER}/var/renasar/on-http/static/http/common
-local pxe_path=${STAGE_FOLDER}/var/renasar/on-tftp/static/tftp/
 
+#using dpkg-deb -x to extract the deb file
+dpkg-deb -x $local_deb_fname  $STAGE_FOLDER
+common_path=${STAGE_FOLDER}/var/renasar/on-http/static/http/common
+pxe_path=${STAGE_FOLDER}/var/renasar/on-tftp/static/tftp/
 
-
+#create $CLONE_DIR/on-imagebuilder/common & $CLONE_DIR/on-imagebuilder/pxe
+#put the microkernel static files into them, so that they can be consumed in later docker-build step
 rm -rf common pxe
 mkdir common
 mkdir pxe
 cp $common_path/* common/
 cp $pxe_path/* pxe/
-sudo chown -R $USER:$USER common
-sudo chown -R $USER:$USER pxe
+echo $SUDO_PASSWORD |sudo -S  chown -R $USER:$USER common
+echo $SUDO_PASSWORD |sudo -S  chown -R $USER:$USER pxe
 popd
 
 


### PR DESCRIPTION
Background:

It's a cookie job.

in CI pipeline docker build, it will use the micro-kernel static files from on-imagebuild.deb in previous "package build" pipeline stage .

**previous implementation:**
using host to ```apt-get install on-imagebuilder```, then copy the files from host to docker working directory, hen ```apt-get remove on-imagebuilder.```

**It's not good to using host OS as a debian exchanging station.** by the way, with this change, the vmslave docker build vmslave can be run parallel with multiple build

**My change:**
so I changed it to ```wget download``` and ```dpkg-deb -x```

**Testing**
http://10.6*.59.***:8080/job/MasterCI_Peter_PR_258/

**Reviewer**
@PengTian0 
@changev 