### PR TITLE
RAC-5612 add test type in test name for distinction

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -18,7 +18,7 @@ def getUsedResources(){
     return used_resources
 }
 
-def functionTest(String test_name, String TEST_GROUP, Boolean RUN_FIT_TEST, Boolean RUN_CIT_TEST, String test_stack, String extra_hw){
+def functionTest(String test_name, String test_type, String TEST_GROUP, Boolean RUN_FIT_TEST, Boolean RUN_CIT_TEST, String test_stack, String extra_hw){
     withEnv([
         "API_PACKAGE_LIST=on-http-api2.0 on-http-redfish-1.0",
         "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
@@ -61,6 +61,7 @@ def functionTest(String test_name, String TEST_GROUP, Boolean RUN_FIT_TEST, Bool
                     '''
                 }
             } finally{
+                test_name = "$test_type $test_name"
                 def result = "FAILURE"
                 def artifact_dir = test_name.replaceAll(' ', '-') + "[$NODE_NAME]"
                 try{
@@ -148,7 +149,7 @@ def functionTest(String test_name, String TEST_GROUP, Boolean RUN_FIT_TEST, Bool
     }
 }
 
-def archiveArtifactsToTarget(target, TESTS){
+def archiveArtifactsToTarget(target, TESTS, test_type){
     // The function will archive artifacts to the target
     // 1. Create a directory with name target and go to it
     // 2. Unstash files according to the member variable: TESTS, for example: CIT.FIT
@@ -160,7 +161,7 @@ def archiveArtifactsToTarget(target, TESTS){
             for(int i=0;i<tests.size();i++){
                 try{
                     test = tests[i]
-                    def test_name = "$test"
+                    def test_name = "$test_type $test"
                     unstash "$test_name"
                 } catch(error){
                     echo "[WARNING]Caught error during archive artifact of function test: ${error}"

--- a/jobs/FunctionTest/SourceBasedTest.groovy
+++ b/jobs/FunctionTest/SourceBasedTest.groovy
@@ -1,3 +1,7 @@
+import groovy.transform.Field;
+
+@Field def TEST_TYPE = "manifest"
+
 def generateTestBranches(function_test){
     def test_branches = [:]
     node{
@@ -36,7 +40,7 @@ def generateTestBranches(function_test){
                                 "TFTP_STATIC_FILES=${env.TFTP_STATIC_FILES}",
                                 "stash_manifest_name=${env.stash_manifest_name}",
                                 "stash_manifest_path=${env.stash_manifest_path}",
-                                "TEST_TYPE=manifest"])
+                                "TEST_TYPE=${TEST_TYPE}"])
                             {
                                 withCredentials([
                                     usernamePassword(credentialsId: 'ESXI_CREDS',
@@ -85,7 +89,7 @@ def generateTestBranches(function_test){
                                 projectName: 'Docker_Image_Build',
                                 target: "$WORKSPACE"]);
     
-                                function_test.functionTest(test_name,test_group, run_fit_test, run_cit_test, test_stack, extra_hw)
+                                function_test.functionTest(test_name, TEST_TYPE, test_group, run_fit_test, run_cit_test, test_stack, extra_hw)
                                 }
                             }
                         }
@@ -112,7 +116,7 @@ def runTests(function_test){
 
 def archiveArtifacts(function_test){
     def TESTS = "${env.TESTS}"
-    function_test.archiveArtifactsToTarget("FunctionTest", TESTS)
+    function_test.archiveArtifactsToTarget("FunctionTest", TESTS, TEST_TYPE)
 }
 
 return this

--- a/jobs/build_docker/docker_post_test.groovy
+++ b/jobs/build_docker/docker_post_test.groovy
@@ -1,3 +1,7 @@
+import groovy.transform.Field;
+
+@Field def TEST_TYPE = "docker"
+
 def generateTestBranches(function_test){
     def test_branches = [:]
     node{
@@ -29,7 +33,7 @@ def generateTestBranches(function_test){
                                 "DOCKER_RACKHD_IP=${env.DOCKER_RACKHD_IP}",
                                 "SKIP_PREP_DEP=false",
                                 "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
-                                "TEST_TYPE=docker"])
+                                "TEST_TYPE=${TEST_TYPE}"])
                             {
                                 withCredentials([
                                     usernamePassword(credentialsId: 'ESXI_CREDS',
@@ -77,7 +81,7 @@ def generateTestBranches(function_test){
                                         error("Preparation of docker post test failed.")
                                     }
                                     // Start to run test
-                                    function_test.functionTest(test_name, test_group, run_fit_test, run_cit_test, docker_test_stack, extra_hw)
+                                    function_test.functionTest(test_name, TEST_TYPE, test_group, run_fit_test, run_cit_test, docker_test_stack, extra_hw)
                                 }
                             }
                         }
@@ -104,7 +108,7 @@ def runTests(function_test){
 
 def archiveArtifacts(function_test){
     def DOCKER_TESTS = "${env.DOCKER_POST_TESTS}"
-    function_test.archiveArtifactsToTarget("DOCKER_POST_SMOKE_TEST", DOCKER_TESTS)
+    function_test.archiveArtifactsToTarget("DOCKER_POST_SMOKE_TEST", DOCKER_TESTS, TEST_TYPE)
 }
 
 return this

--- a/jobs/build_ova/ova_post_test.groovy
+++ b/jobs/build_ova/ova_post_test.groovy
@@ -1,3 +1,7 @@
+import groovy.transform.Field;
+
+@Field def TEST_TYPE = "ova"
+
 def generateTestBranches(function_test){
     def test_branches = [:]
     node{
@@ -34,7 +38,7 @@ def generateTestBranches(function_test){
                                 "SKIP_PREP_DEP=false",
                                 "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
                                 "OVA_NET_INTERFACE=${env.OVA_NET_INTERFACE}",
-                                "TEST_TYPE=ova"])
+                                "TEST_TYPE=${TEST_TYPE}"])
                             {
                                 withCredentials([
                                     usernamePassword(credentialsId: 'OVA_CREDS',
@@ -80,7 +84,7 @@ def generateTestBranches(function_test){
                                         echo "Caught: ${error}"
                                         error("Preparation of ova post test failed.")
                                     }
-                                    function_test.functionTest(test_name,test_group, run_fit_test, run_cit_test, ova_test_stack, extra_hw)
+                                    function_test.functionTest(test_name, TEST_TYPE, test_group, run_fit_test, run_cit_test, ova_test_stack, extra_hw)
                                 }
                             }
                         }
@@ -107,7 +111,7 @@ def runTests(function_test){
 
 def archiveArtifacts(function_test){
     def OVA_TESTS = "${env.OVA_POST_TESTS}"
-    function_test.archiveArtifactsToTarget("OVA_POST_TEST", OVA_TESTS)
+    function_test.archiveArtifactsToTarget("OVA_POST_TEST", OVA_TESTS, TEST_TYPE)
 }
 
 return this


### PR DESCRIPTION
http://rackhdci.lss.emc.com/blue/organizations/jenkins/MasterCI/detail/MasterCI/269/artifacts
docker/ova post test log are all logs from previous function stage.
The root cause is
#FunctionTest.groovy
```
...
stash name: "$test_name", includes: "$artifact_dir/., $artifact_dir/*/.*"
....
def archiveArtifactsToTarget(target, TESTS)
{ ... unstash "$test_name" ... }
```
test name is FIT, OS-INSTALL-UBUTNU-14.04 etc.
so the stash run 3 times and all stash the same name.
then the later 2 stash lost efficacy.


==========================================================


Recent changes lead this issue
the var of test_name used to be DOCKER_FIT/OVA_FIT.
so no problem before.