### PR TITLE
 RAC-5570:change access of folder mount #265

### DIFF
--- a/jobs/build_docker/prepare_docker_post_test.sh
+++ b/jobs/build_docker/prepare_docker_post_test.sh
@@ -61,3 +61,26 @@ set -e
 
 docker-compose -f docker-compose-mini.yml up > $WORKSPACE/build-log/vagrant.log &
 popd
+
+#Folder named "common" is the deepest folder in mount folder which is used to share files on docker
+#Check the "common"folder is used to make sure all folder is created (all mount opreation is done),then change the authority
+#The foler tree is defined in RackHD/docker/docker-compose*.yml , refer to the mount command in this file
+mountpath="$WORKSPACE/RackHD/docker/files/mount/common"
+retrytimes=5
+#Check the folder is exist or not 5 times, if not, break. 
+while [ ! -d "$mountpath" ]
+do
+    echo "mount is not finished"
+    retrytimes=$(($retrytimes-1))
+    echo "retry : $retrytimes times"
+    sleep 10
+    if [ $retrytimes -eq 0 ]; then
+        break
+    fi
+done
+
+if [ -d "$mountpath" ]; then
+#After 5 times check ,if mount is still not finished, it may failed. no need to change the permissions 
+    echo "change the permissions  of RackHD"
+    echo $SUDO_PASSWORD |sudo -S chown -R $USER:$USER $WORKSPACE/RackHD
+fi


### PR DESCRIPTION
Background :
RAC-5770,[Cookie]Master CI #263: dirty vmslave25 workspace( should chown of folder after docker up)

Error like :
remote file operation failed: /home/jenkins/workspace/MasterCI at hudson.remoting.Channel@3fb3c78:vmslave25: java.io.IOException: Unable to delete '/home/jenkins/workspace/MasterCI/RackHD/docker/files/mount/monorail.ipxe.debug'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
Details :
add access change of folder mount in "prepare_docker_post_test.sh"
test done : http://10.62.59.175:8080/job/RAC5770/70/console

reviewer : @panpan0000 @changev @PengTian0 @iceiilin