### PR TITLE
RAC-5619: add SOL/VNC into Docker Post Test

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -356,6 +356,7 @@ if [ "$RUN_FIT_TEST" == true ] ; then
     # Prepare RackHD
     # Forward local host port to ova
     portForwarding localhost
+    trap exportLog SIGINT SIGTERM SIGKILL EXIT
 
     # We setup the virtual-environment here, since once we
     # call "nodesOn", it's a race to get to the first test
@@ -366,8 +367,9 @@ if [ "$RUN_FIT_TEST" == true ] ; then
     setupVirtualEnv
     waitForAPI
     nodesOn &
-    # Doesn't support ova smoke test now
-    # generateSolLog
+
+    generateSolLog
+    vnc_record_start
     # Run tests
     runTests
     # exit venv


### PR DESCRIPTION
Background:
in CI pipeline, SOL/VNC logs were not available in post-test stage.
this PR will add the logs .

Test:
![image](https://user-images.githubusercontent.com/14049268/28198895-eee5236e-6893-11e7-9d4a-1570aa77b9b7.png)

http://10.**.59.1**:8080/job/MasterCI_VNC/


OVA-Post-Test enhancement will come soon,
