### PR TITLE
RAC-5619: add SOL/VNC into OVA Post Test

### DIFF
--- a/generate-sol-log.sh.in
+++ b/generate-sol-log.sh.in
@@ -13,7 +13,14 @@ bmc_account_list="${BMC_ACCOUNT_LIST}"
 handled_ip_list=""
 vnode_num=0
 timeout=0
-maxto=20
+maxto=40
+
+target_folder=${WORKSPACE}/build-log/
+
+if [ ! -z $1 ]; then
+    target_folder=$1
+fi
+
 while [ ${timeout} != ${maxto} ]; do
     ip_list=`arp | awk '{print $1}' | xargs`
     echo "IP LIST: $ip_list"
@@ -31,9 +38,9 @@ while [ ${timeout} != ${maxto} ]; do
                                     tr 'A-Z' 'a-z' |
                                     while IFS= read -r line; do 
                                         echo "$(date +%FT%H:%M:%SZ) $line"; 
-                                    done > ${WORKSPACE}/build-log/${vnode_num}.sol.log.raw'
+                                    done > ${target_folder}/${vnode_num}.sol.log.raw'
                         #dump cmd to cmd.sh, replace vars with actual value.
-                        echo -e "bmc_ip=$ip\nbmc_user=${bmc%:*}\nbmc_password=${bmc#*:}\nvnode_num=${vnode_num}"|\
+                        echo -e "bmc_ip=$ip\nbmc_user=${bmc%:*}\nbmc_password=${bmc#*:}\nvnode_num=${vnode_num}\ntarget_folder=${target_folder}"|\
                         sed 's/[\%]/\\&/g;s/\([^=]*\)=\(.*\)/s%${\1}%\2%/' > sed.script
                         echo $cmd | sed -f sed.script > cmd.sh
                         chmod oug+x cmd.sh

--- a/jobs/build_ova/ansible/main.yml
+++ b/jobs/build_ova/ansible/main.yml
@@ -1,4 +1,5 @@
 - hosts: ova-post-test
+
   tasks:
     - name: Enable external network through gateway
       become: yes
@@ -17,13 +18,22 @@
         - config-gateway
       when: gateway.rc != 0
 
+    - name: Add DNS Server IP if it's specified in Jenkins build param
+      become: yes
+      shell: bash -c " echo \"nameserver {{ dns_server_ip }}\" >> /etc/resolv.conf  "
+      tags:
+        - config-gateway
+      when: dns_server_ip != ""
+
     - name: Sync ova time
       become: yes
       shell: |
-        timedatectl set-timezone America/New_York
-        ntpdate {{ ova_gateway }}
+         timedatectl set-timezone America/New_York
+         ntpdate {{ ova_gateway }}
       tags:
         - before-test
+
+
 
     - name: Copy rackhd config for test
       become: yes
@@ -54,6 +64,106 @@
       tags:
         - before-test
       
+
+    - name: Copy SOL generating script
+      become: yes
+      copy:
+        src: ../../../generate-sol-log.sh
+        dest: /var/log/rackhd/generate-sol-log.sh
+      tags:
+        - before-test
+
+    - name: Copy VNC recording script
+      become: yes
+      copy:
+        src: ../../../vnc_record.sh
+        dest: /var/log/rackhd/vnc_record.sh
+      tags:
+        - before-test
+
+
+    - name: Start SOL Log collecting
+      become: yes
+      shell: |
+        cd /var/log/rackhd
+        nohup bash generate-sol-log.sh /var/log/rackhd  > sol_script.log &
+      tags:
+        - before-test
+
+
+    - name: get BUILD_ID from ENV
+      set_fact: BUILD_ID="{{ lookup('env','BUILD_ID') }}"
+      tags:
+        - before-test
+
+
+    - name: Start VNC Recording
+      become: yes
+      shell: |
+        cd /var/log/rackhd
+        export fname_prefix="vNode"
+        if [ "{{BUILD_ID}}" != "" ]; then
+             export fname_prefix=${fname_prefix}_b{{BUILD_ID}}
+        fi
+        nohup bash vnc_record.sh /var/log/rackhd $fname_prefix > vnc_record.log   &
+      tags:
+        - before-test
+
+
+#######################
+
+
+    - name: Stop VNC Record, sleep 2 sec to ensure FLV finishes the disk I/O before VM destroyed
+      become: yes
+      shell: |
+          kill -TERM $(ps -lef|grep flvrec.py|grep -v grep| awk '{print $4}')
+          sleep 2
+          pkill --full --exact "bash vnc_record.sh /var/log/rackhd vNode"
+      ignore_errors: yes
+      tags:
+        - after-test
+
+    - name: Kill screen which used by SOL collector
+      become: yes
+      shell: |
+          kill -KILL $(ps -lef|grep -i screen |grep -v grep| awk '{print $4}')
+          pkill --full --exact "bash generate-sol-log.sh /var/log/rackhd"
+      ignore_errors: yes
+      tags:
+        - after-test
+
+    - name: List remote sol.log.raw files
+      command: "/bin/sh -c 'ls /var/log/rackhd/*sol.log.raw'"
+      register: sol_logs
+      ignore_errors: yes
+      tags:
+        - after-test
+
+
+    - name: List remote flv files
+      command: "/bin/sh -c 'ls /var/log/rackhd/*.flv'"
+      register: flvfiles
+      ignore_errors: yes
+      tags:
+        - after-test
+
+
+    - name: Gather SOL and VNC log
+      become: yes
+      fetch:
+          src: "{{ item }}"
+          dest: ./
+          flat: yes
+      with_items:
+        - /var/log/rackhd/sol_script.log
+        - /var/log/rackhd/vnc_record.log
+        - "{{ flvfiles.stdout_lines }}"
+        - "{{ sol_logs.stdout_lines }}"
+      ignore_errors: yes
+      tags:
+        - after-test
+
+
     - name: Gather rackhd log
       become: yes
       fetch:

--- a/jobs/build_ova/ova_post_test.groovy
+++ b/jobs/build_ova/ova_post_test.groovy
@@ -38,6 +38,8 @@ def generateTestBranches(function_test){
                                 "SKIP_PREP_DEP=false",
                                 "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
                                 "OVA_NET_INTERFACE=${env.OVA_NET_INTERFACE}",
+                                "DNS_SERVER_IP=${env.DNS_SERVER_IP}",
+                                "BUILD_ID=${env.BUILD_ID}", //Jenkins Build-in Env
                                 "TEST_TYPE=${TEST_TYPE}"])
                             {
                                 withCredentials([
@@ -50,6 +52,9 @@ def generateTestBranches(function_test){
                                     usernamePassword(credentialsId: 'ff7ab8d2-e678-41ef-a46b-dd0e780030e1',
                                                     passwordVariable: 'SUDO_PASSWORD',
                                                     usernameVariable: 'SUDO_USER'),
+                                     usernamePassword(credentialsId: 'BMC_VNODE_CREDS',
+                                                    passwordVariable: 'BMC_VNODE_PASSWORD',
+                                                    usernameVariable: 'BMC_VNODE_USER'),
                                     string(credentialsId: 'vCenter_IP', variable: 'VCENTER_IP'),
                                     string(credentialsId: 'Deployed_OVA_INTERNAL_IP', variable: 'OVA_INTERNAL_IP')
                                 ])

--- a/jobs/build_ova/prepare_ova_post_test.sh
+++ b/jobs/build_ova/prepare_ova_post_test.sh
@@ -73,12 +73,19 @@ waitForAPI() {
 }
 
 configOVA() {
+  # run build-config script, to generate  vnc_record.sh and generate_sol_log.sh
+  # Workaround, it's duplicated with what's run in FunctionTest.functionTest()
+  pushd ${WORKSPACE}/build-config
+  ./build-config
+  popd
+
   # config the OVA for post test
   pushd ${WORKSPACE}/build-config/jobs/build_ova/ansible
     echo "ova-post-test ansible_host=$OVA_INTERNAL_IP ansible_user=$OVA_USER ansible_ssh_pass=$OVA_PASSWORD ansible_become_pass=$OVA_PASSWORD" > hosts
     cp -f ${WORKSPACE}/build-config/vagrant/config/mongo/config.json .
+
     if [ -z "${External_vSwitch}" ]; then
-      ansible-playbook -i hosts main.yml --extra-vars "ova_gateway=$OVA_GATEWAY ova_net_interface=$OVA_NET_INTERFACE" --tags "config-gateway"
+      ansible-playbook -i hosts main.yml --extra-vars "ova_gateway=$OVA_GATEWAY ova_net_interface=$OVA_NET_INTERFACE dns_server_ip=$DNS_SERVER_IP"  --tags "config-gateway"
     fi
     ansible-playbook -i hosts main.yml --tags "before-test" --extra-vars "ova_gateway=$OVA_GATEWAY"
   popd

--- a/test.sh.in
+++ b/test.sh.in
@@ -122,7 +122,7 @@ vnc_record_stop(){
 
 generateSolLog(){
   pushd ${WORKSPACE}/build-config
-  bash generate-sol-log.sh > ${WORKSPACE}/sol.log &
+  bash generate-sol-log.sh > ${WORKSPACE}/sol_script.log &
 }
 
 generateSolLogStop(){
@@ -225,7 +225,7 @@ fetchOVALog(){
       echo "ova-post-test ansible_host=$OVA_INTERNAL_IP ansible_user=$OVA_USER ansible_ssh_pass=$OVA_PASSWORD ansible_become_pass=$OVA_PASSWORD" > hosts
       ansible-playbook -i hosts main.yml --tags "after-test"
       mkdir -p ${WORKSPACE}/build-log
-      for log in `ls *.log | xargs` ; do
+      for log in `ls *.log *.flv *sol.log.raw | xargs` ; do
         cp $log ${WORKSPACE}/build-log
       done
     popd
@@ -332,16 +332,14 @@ if [ "$RUN_FIT_TEST" == true ] ; then
     setupVirtualEnv
     waitForAPI
     nodesOn &
-    # Doesn't support ova smoke test now
-    # generateSolLog
+
+    # signal handler
+    trap fetchOVALog SIGINT SIGTERM SIGKILL EXIT
+
     # Run tests
     runTests
     # exit venv
     deactivate
-
-    # Remedial work
-    # Specific remedial work
-    fetchOVALog
 
     # Clean Up below
 

--- a/vnc_record.sh.in
+++ b/vnc_record.sh.in
@@ -30,10 +30,16 @@ pip install vnc2flv
 FLVREC=flvrec.py
 
 #Using cutomized flvrec.py, which can do multiple retry when vNode power cycled (adding '-R' option)
+
 pushd $save_path
-wget https://raw.githubusercontent.com/panpan0000/vnc2flv/master/tools/flvrec.py
+echo "Download Customized flvrec.py.. "
+curl --insecure https://raw.githubusercontent.com/panpan0000/vnc2flv/master/tools/flvrec.py > ./flvrec.py
+#wget --no-check-certificate https://raw.githubusercontent.com/panpan0000/vnc2flv/master/tools/flvrec.py # FIXME: the wget always fail without any output when run under ansible for OVA
 chmod +x flvrec.py
 popd
+
+
+
 
 while [ ${timeout} -ne ${maxto} ]; do
     ip_list=`arp | awk '{print $1}' | xargs`


### PR DESCRIPTION
Background:
in this PR, OVA-Post-Test  is added with VNC record/SOL logs.
NOTE: [flvrec.py](https://github.com/panpan0000/vnc2flv/blob/master/tools/flvrec.py) is updated to support this.

Test Done:
http://10.**.**.**5:8080/job/MasterCI_VNC_OVA_TEST/35/artifact/OVA_POST_TEST/
![image](https://user-images.githubusercontent.com/14049268/28359764-eb14aa32-6ca5-11e7-8662-14d44e52e5d6.png)



Details in code:

- ```jobs/build_ova/ansible/main.yml```
     -- ```dns_server_ip``` : it's for Jenkins Sandbox , which OVA need DNS to be able to connect to internet, to download flvrec.py from github.
    -- ```BUILD_ID```: fetch Jenkins BUILD_ID env variable, and attach to video record file name.
    --``` nohup bash vnc_record.sh &```: if without nohup, the background script will exist once ansible exist.
- ```jobs/build_ova/ova_post_test.groovy```
    --  typically, ```./build-config``` is invoked in ```FunctionTest.groovy```, but at this moment, we need vnc_record.sh being generated. so ```BMC_VNODE_CREDS``` and ```build-config``` is required earlier than before 


- ```test.sh.in```
    -- previously, once FIT fail, the ```fetchOVAlog``` will never be invoked .  so I used signal handler(```trap```) to ensure it's run.
   



