### PR TITLE
RAC-5276: jump_version.py fail

### DIFF
--- a/build-release-tools/lib/gitbits.py
+++ b/build-release-tools/lib/gitbits.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import tempfile
 from urlparse import urlparse
+from github import Github
 from common import *
 
 class GitBit(object):
@@ -26,6 +27,16 @@ class GitBit(object):
         (username, password) = credential.split(':', 2)
         return username, password
 
+    @staticmethod
+    def __get_email_of_github(username, password):
+        try:
+            g = Github(username, password)
+            for email in g.get_user().get_emails():
+                email_address = email["email"]
+                return email_address
+            return None
+        except Exception,e:
+            raise ValueError("Username or Password for github is wrong. Failed to get the email")
 
     def __init__(self, verbose=False):
         """
@@ -79,7 +90,8 @@ class GitBit(object):
                                        "password": password,
                                        "url": full_url,
                                       })
-            self.set_identity(username=username)
+            email = self.__get_email_of_github(username,password)
+            self.set_identity(username=username, email=email)
             return True
         else:
             return False


### PR DESCRIPTION
Fix: jump_version.py failed to run on vmslave26
Root Cause:
The script run git command without email address.
Git will try to auto-detect email address if email address is not given.
On vmslave01, git got email address jenkins@vmslave01.veyder.emc.com
However, on vmslave26, git failed to get a valid email address. It got jenkins@vmslave26.(none) because the /etc/hosts is wrong configured.

PR:
It will get the email address according to the provided git credential.

@panpan0000 @changev @anhou @iceiilin 