### PR TITLE
[RAC-5468]add docker logout for release_docker.sh

### DIFF
--- a/jobs/release/release_docker.sh
+++ b/jobs/release/release_docker.sh
@@ -66,4 +66,7 @@ clean_up rackhd
 echo "clean up /var/lib/docker/volumes"
 docker volume ls -qf dangling=true | xargs -r docker volume rm
 
+docker logout
+echo "docker logout."
+
 exit 0 # this is a workaround. to avoid the cleanup failure makes whole workflow fail.don't worry, the set -e will ensure failure captured for necessary steps(those lines before set +e)


### PR DESCRIPTION
 At publishing docker images stage in the Jenkins job, there is "login" only, but not "logout". It's not reasonable. 