### PR TITLE
[RAC-5280] Skip Archive when no Function Test need run

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -155,6 +155,10 @@ def archiveArtifactsToTarget(target, TESTS, test_type){
     // 2. Unstash files according to the member variable: TESTS, for example: CIT.FIT
     //    The function functionTest() will stash log files after run test specified in the TESTS
     // 3. Archive the directory target
+     if(TESTS == "null" || TESTS == "" || TESTS == null){
+        print "No function test run, skip archiveArtifacts"
+        return
+    }
     List tests = Arrays.asList(TESTS.split(','))
     if(tests.size() > 0){
         dir("$target"){


### PR DESCRIPTION
background : 
this is a bug of story RAC-5280 . when we skip the Function test .Archive  function test  is still running on in finally stock .it will makes jenkins job become red .error shows like : 
[WARNING]Caught error during archive artifact of function test: hudson.AbortException: No such saved stash ‘manifest null’
ERROR: No artifacts found that match the file pattern "FunctionTest/*.*, FunctionTest/**/*.*". Configuration error?

details : 
Add judgement before archiveArtifacts in FunctionTest.grooy.

testDone : http://10.62.59.175:8080/job/masterRC5280/67/

reviewer : @changev @panpan0000 @PengTian0 