### PR TITLE
[RAC-5468]modify Jenkins's dockerhub credential ID.

### DIFF
--- a/jobs/BuildBaseImage/Jenkinsfile
+++ b/jobs/BuildBaseImage/Jenkinsfile
@@ -21,7 +21,7 @@ node{
                     usernamePassword(credentialsId: 'ff7ab8d2-e678-41ef-a46b-dd0e780030e1',
                                      passwordVariable: 'SUDO_PASSWORD',
                                      usernameVariable: 'SUDO_USER'),
-                    usernamePassword(credentialsId: 'da1e60c6-f23a-429d-b0f5-19e3b287f5dc',
+                    usernamePassword(credentialsId: 'rackhd-ci-docker-hub',
                          passwordVariable: 'DOCKERHUB_PASS',
                          usernameVariable: 'DOCKERHUB_USER')
                 ]){

--- a/jobs/release/release_docker.groovy
+++ b/jobs/release/release_docker.groovy
@@ -6,7 +6,7 @@ node(build_docker_node){
         unstash env.DOCKER_STASH_NAME
     }
     withCredentials([
-        usernamePassword(credentialsId: 'da1e60c6-f23a-429d-b0f5-19e3b287f5dc', 
+        usernamePassword(credentialsId: 'rackhd-ci-docker-hub', 
                          passwordVariable: 'DOCKERHUB_PASS', 
                          usernameVariable: 'DOCKERHUB_USER')]) {
         timeout(120){


### PR DESCRIPTION
According to @PengTian0 's suggestion, it is ineffective to modify the dockerhub password only, because it can update the docker image as long as it uses the credential ID.
In order to rule out this possibility, I modified the credential ID with a humanized name, so we can see if it is the Jenkins job's cause.
After the PR is merged, I will remove the old dockerhub credential ID, which will not affect the current Jenkins jobs.
@PengTian0 @panpan0000 @changev @anhou 