### PR TITLE
Install fuseiso for image service FIT

### DIFF
--- a/vmslave-config/ansible/roles/install-package-for-ci/tasks/main.yml
+++ b/vmslave-config/ansible/roles/install-package-for-ci/tasks/main.yml
@@ -5,6 +5,7 @@
     - openjdk-7-jdk
     - maven
     - socat
+    - fuseiso
 
 - name: Check if ovftool is installed
   shell: |


### PR DESCRIPTION
The cases of image service in FIT need to use the tool fuseiso.
The PR is used to install fuseiso on Jenkins slaves which are used to run FIT.

@panpan0000 @nortonluo @changev @anhou @iceiilin 