### PR TITLE
RAC-5421 Remove CIT/FIT references from test files

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -2,11 +2,10 @@ import groovy.transform.Field;
 
 // The default test config: ALL_TESTS (a global variable)
 @Field def ALL_TESTS = [:]
-ALL_TESTS["FIT"]=["TEST_GROUP":"-test tests -group smoke","RUN_FIT_TEST":true,"RUN_CIT_TEST":false,"label":"smoke_test", "EXTRA_HW":""]
-ALL_TESTS["CIT"]=["TEST_GROUP":"smoke-tests","RUN_FIT_TEST":false,"RUN_CIT_TEST":true,"label":"smoke_test", "EXTRA_HW":""]
-ALL_TESTS["Install Ubuntu 14.04"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_ubuntu14.04_minimum.json","RUN_FIT_TEST":true,"RUN_CIT_TEST":false,"label":"os_install", "EXTRA_HW":""]
-ALL_TESTS["Install ESXI 6.0"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_esxi_bootstrap.py -extra install_esxi6.0_minimum.json","RUN_FIT_TEST":true,"RUN_CIT_TEST":false,"label":"os_install", "EXTRA_HW":""]
-ALL_TESTS["Install Centos 6.5"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_centos65_minimum.json","RUN_FIT_TEST":true,"RUN_CIT_TEST":false,"label":"os_install", "EXTRA_HW":""]
+ALL_TESTS["FIT"]=["TEST_GROUP":"-test tests -group smoke","label":"smoke_test", "EXTRA_HW":""]
+ALL_TESTS["Install Ubuntu 14.04"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_ubuntu14.04_minimum.json","label":"os_install", "EXTRA_HW":""]
+ALL_TESTS["Install ESXI 6.0"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_esxi_bootstrap.py -extra install_esxi6.0_minimum.json","label":"os_install", "EXTRA_HW":""]
+ALL_TESTS["Install Centos 6.5"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_centos65_minimum.json","label":"os_install", "EXTRA_HW":""]
 
 @Field ArrayList<String> used_resources = []
 
@@ -18,13 +17,11 @@ def getUsedResources(){
     return used_resources
 }
 
-def functionTest(String test_name, String test_type, String TEST_GROUP, Boolean RUN_FIT_TEST, Boolean RUN_CIT_TEST, String test_stack, String extra_hw){
+def functionTest(String test_name, String test_type, String TEST_GROUP, String test_stack, String extra_hw){
     withEnv([
         "API_PACKAGE_LIST=on-http-api2.0 on-http-redfish-1.0",
         "USE_VCOMPUTE=${env.USE_VCOMPUTE}",
         "TEST_GROUP=$TEST_GROUP",
-        "RUN_CIT_TEST=$RUN_CIT_TEST",
-        "RUN_FIT_TEST=$RUN_FIT_TEST",
         "NODE_NAME=${env.NODE_NAME}",
         "TEST_STACK=$test_stack",
         "EXTRA_HW=$extra_hw",

--- a/jobs/FunctionTest/SourceBasedTest.groovy
+++ b/jobs/FunctionTest/SourceBasedTest.groovy
@@ -23,8 +23,6 @@ def generateTestBranches(function_test){
             def test_name = tests_group[i]
             def label_name=ALL_TESTS[test_name]["label"]
             def test_group = ALL_TESTS[test_name]["TEST_GROUP"]
-            def run_fit_test = ALL_TESTS[test_name]["RUN_FIT_TEST"]
-            def run_cit_test = ALL_TESTS[test_name]["RUN_CIT_TEST"]
             def extra_hw = ALL_TESTS[test_name]["EXTRA_HW"]
             test_branches["manifest $test_name"] = {
                 String node_name = ""
@@ -89,7 +87,7 @@ def generateTestBranches(function_test){
                                 projectName: 'Docker_Image_Build',
                                 target: "$WORKSPACE"]);
     
-                                function_test.functionTest(test_name, TEST_TYPE, test_group, run_fit_test, run_cit_test, test_stack, extra_hw)
+                                function_test.functionTest(test_name, TEST_TYPE, test_group, test_stack, extra_hw)
                                 }
                             }
                         }

--- a/jobs/build_docker/docker_post_test.groovy
+++ b/jobs/build_docker/docker_post_test.groovy
@@ -18,8 +18,6 @@ def generateTestBranches(function_test){
             def test_name = docker_tests_group[i]
             def label_name=ALL_TESTS[test_name]["label"]
             def test_group = ALL_TESTS[test_name]["TEST_GROUP"]
-            def run_fit_test = ALL_TESTS[test_name]["RUN_FIT_TEST"]
-            def run_cit_test = ALL_TESTS[test_name]["RUN_CIT_TEST"]
             def extra_hw = ALL_TESTS[test_name]["EXTRA_HW"]
             test_branches["docker $test_name"] = {
                 String node_name = ""
@@ -96,7 +94,7 @@ def generateTestBranches(function_test){
                                         error("Preparation of docker post test failed.")
                                     }
                                     // Start to run test
-                                    function_test.functionTest(test_name, TEST_TYPE, test_group, run_fit_test, run_cit_test, docker_test_stack, extra_hw)
+                                    function_test.functionTest(test_name, TEST_TYPE, test_group, docker_test_stack, extra_hw)
                                 }
                             }
                         }

--- a/jobs/build_ova/ova_post_test.groovy
+++ b/jobs/build_ova/ova_post_test.groovy
@@ -19,8 +19,6 @@ def generateTestBranches(function_test){
             def test_name = ova_tests_group[i]
             def label_name=ALL_TESTS[test_name]["label"]
             def test_group = ALL_TESTS[test_name]["TEST_GROUP"]
-            def run_fit_test = ALL_TESTS[test_name]["RUN_FIT_TEST"]
-            def run_cit_test = ALL_TESTS[test_name]["RUN_CIT_TEST"]
             def extra_hw = ALL_TESTS[test_name]["EXTRA_HW"]
             test_branches["ova $test_name"] = {
                 String node_name = ""
@@ -89,7 +87,7 @@ def generateTestBranches(function_test){
                                         echo "Caught: ${error}"
                                         error("Preparation of ova post test failed.")
                                     }
-                                    function_test.functionTest(test_name, TEST_TYPE, test_group, run_fit_test, run_cit_test, ova_test_stack, extra_hw)
+                                    function_test.functionTest(test_name, TEST_TYPE, test_group, ova_test_stack, extra_hw)
                                 }
                             }
                         }

--- a/test.sh.in
+++ b/test.sh.in
@@ -1,6 +1,5 @@
 #!/bin/bash -ex
 export VCOMPUTE=("${NODE_NAME}-Rinjin1","${NODE_NAME}-Rinjin2","${NODE_NAME}-Quanta")
-RUN_FIT_TEST="${RUN_FIT_TEST}"
 MODIFY_API_PACKAGE="${MODIFY_API_PACKAGE}"
 source ${WORKSPACE}/build-config/shareMethod.sh
 
@@ -170,9 +169,7 @@ runTests() {
   if [ ! -z "$1" ];then
       args+="$1"
   fi
-  if [ "$RUN_FIT_TEST" == true ] ; then
-      fitSmokeTest "${args}"
-  fi
+  fitSmokeTest "${args}"
   set -e
 }
 
@@ -251,15 +248,14 @@ setupTestsConfig(){
       wget --tries=3 $RACKHD_CONFIG_FILE_URL -O ${WORKSPACE}/build-config/jobs/pr_gate/docker/monorail/config.json
     fi
     sed -i "s/172.31.128.1/${RACKHD_DHCP_HOST_IP}/g" ${WORKSPACE}/build-config/jobs/pr_gate/docker/monorail/config.json
-    if [ "$RUN_FIT_TEST" == true ] ; then
-        pushd ${WORKSPACE}/RackHD/test/config
-        sed -i "s/\"username\": \"vagrant\"/\"username\": \"${SUDO_USER}\"/g" credentials_default.json
-        sed -i "s/\"password\": \"vagrant\"/\"password\": \"$SUDO_PASSWORD\"/g" credentials_default.json
-        popd
-        pushd ${WORKSPACE}/RackHD
-        find ./ -type f -exec sed -i -e "s/172.31.128.1/${RACKHD_DHCP_HOST_IP}/g" {} \;
-        popd
-    fi
+
+    pushd ${WORKSPACE}/RackHD/test/config
+    sed -i "s/\"username\": \"vagrant\"/\"username\": \"${SUDO_USER}\"/g" credentials_default.json
+    sed -i "s/\"password\": \"vagrant\"/\"password\": \"$SUDO_PASSWORD\"/g" credentials_default.json
+    popd
+    pushd ${WORKSPACE}/RackHD
+    find ./ -type f -exec sed -i -e "s/172.31.128.1/${RACKHD_DHCP_HOST_IP}/g" {} \;
+    popd
 }
 
 collectTestReport()
@@ -313,7 +309,6 @@ exportLog(){
 #  OVA POST SMOKE TEST RELATED END   #
 ######################################
 
-if [ "$RUN_FIT_TEST" == true ] ; then
   if [ "$TEST_TYPE" == "ova" ]; then
     # based on the assumption that in the same folder, the VMs has been exist normally. so don't destroy VM here.
     
@@ -396,4 +391,3 @@ if [ "$RUN_FIT_TEST" == true ] ; then
     runTests " --sm-amqp-use-user guest"
   fi
 
-fi


### PR DESCRIPTION
This PR clears out old CIT/FIT logic from on-build-config. This is in preparation for the PR gate optimization.

@jimturnquist @hohene