### PR TITLE
Fix: set build status to falure if it's not success

### DIFF
--- a/jobs/write_back_github/write_back_github.groovy
+++ b/jobs/write_back_github/write_back_github.groovy
@@ -10,7 +10,16 @@ node{
         unstash "${env.stash_manifest_name}"
         withCredentials([string(credentialsId: 'JENKINSRHD_GITHUB_TOKEN', 
                                 variable: 'GITHUB_TOKEN')]) {
-            if ("${currentBuild.result}" == "null"){
+            // if previous steps all pass,  $currentBuild.result will be set to "SUCCESS" explictly in pipeline groovy code
+            // if Junit plugin found test case error in previous step,  the plugin will set $currentBuild.result  to "Unstable"
+            // if previous steps abort with error, the $currentBuild.result will not get chance to be set . so value is "null" here
+            // ------
+            //Jenkins currentBuild.result| github commit status(https://developer.github.com/v3/repos/statuses/ )
+            // null                      | failure
+            // failure                   | failure
+            // unstable                  | failure
+            // success                   | success
+            if ("${currentBuild.result}" != "SUCCESS"){
                 currentBuild.result = "FAILURE"
             }
             env.status = "${currentBuild.result}"


### PR DESCRIPTION
Set build status to falure if it's not success.
Otherwise, the result may be unstable and the script commit_status_setter.py will fail:
```
github.GithubException.GithubException: 422 {u'documentation_url': u'https://developer.github.com/v3/repos/statuses/#create-a-status', u'message': u'Validation Failed', u'errors': [{u'field': u'state', u'message': u'state is not included in the list', u'code': u'custom', u'resource': u'Status'}]}

```

@changev @panpan0000 @anhou @iceiilin 