### PR TITLE
[RAC-5256]Deploy vNode failure should be captured in test scripts 

### DIFF
--- a/deployment/timeout_cmd.exp
+++ b/deployment/timeout_cmd.exp
@@ -1,0 +1,14 @@
+#!/usr/bin/expect
+set timeout [lindex $argv 0]
+set cmd [lindex $argv 1] 
+eval spawn -noecho $cmd
+puts "$cmd"
+expect { 
+         timeout { exit 1 }
+         eof
+        }
+lassign [wait] pid spawnid os_error_flag value
+exit $value
+
+expect eof
+

--- a/shareMethod.sh
+++ b/shareMethod.sh
@@ -22,24 +22,17 @@ execWithTimeout() {
     fi
     echo "execWithTimeout() retry count is $retry"
     echo "execWithTimeout() timeout is set to $timeout"
+    dir=${WORKSPACE}/build-config/deployment
+    local time_cmd="${dir}/timeout_cmd.exp"
+    if [ ! -x ${time_cmd} ]; then
+        chmod a+x ${time_cmd}
+        echo "chmod +x ${time_cmd}"
+    fi
+
     i=1
     while [[ $i -le $retry ]]
     do
-        cat <<EOF > ./timeout_cmd.exp
-#!/usr/bin/expect
-set timeout $timeout
-spawn -noecho $cmd
-expect { 
-         timeout { exit 1 }
-         eof
-       }
-lassign [wait] pid spawnid os_error_flag value
-exit \$value
-expect eof
-EOF
-
-        chmod a+x ./timeout_cmd.exp
-        ./timeout_cmd.exp
+        ${time_cmd} "${timeout}" "${cmd}"
         result=$?
         echo "execWithTimeout() exit code $result"
         if [ $result = 0 ] ; then

--- a/shareMethod.sh
+++ b/shareMethod.sh
@@ -9,9 +9,9 @@ execWithTimeout() {
         echo "execWithTimeout() Command not specified"
         exit 2
     fi
-    local cmd="/bin/sh -c \"$1\""
+    export cmd="/bin/sh -c \"$1\""
     #timeout default to 90 seconds
-    local timeout=90
+    export timeout=90
     local retry=3
     local result=0
     if [ ! -z "${2}" ]; then
@@ -25,7 +25,16 @@ execWithTimeout() {
     i=1
     while [[ $i -le $retry ]]
     do
-        expect -c "set timeout $timeout; spawn -noecho $cmd; expect timeout { exit 1 } eof { exit 0 }"
+        expect << 'EOF'
+            set timeout $env(timeout)
+            eval spawn -noecho $env(cmd)
+            expect {
+                timeout { exit 1 }
+                eof
+            }
+            lassign [wait] pid spawnid os_error_flag value
+            exit $value
+EOF
         result=$?
         echo "execWithTimeout() exit code $result"
         if [ $result = 0 ] ; then
@@ -36,6 +45,9 @@ execWithTimeout() {
     if [ $result = 1 ] ; then
         echo "execWithTimeout() command timed out $retry times after $timeout seconds"
         exit 1
+    elif [ $result != 0 ]; then
+        echo "execWithTimeout() exit final code $result"
+        exit $result
     fi
     set -e
 }

--- a/test.sh.in
+++ b/test.sh.in
@@ -93,9 +93,9 @@ nodesCreate() {
   if [ "${USE_VCOMPUTE}" != "false" ]; then
     for i in {1..2}
     do
-      execWithTimeout "ovftool --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE}  --name='${NODE_NAME}-Rinjin${i}' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vRinjin-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+      execWithTimeout "ovftool --overwrite --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE}  --name='${NODE_NAME}-Rinjin${i}' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vRinjin-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
     done
-    execWithTimeout "ovftool  --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE} --name='${NODE_NAME}-Quanta' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vQuanta-T41-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
+    execWithTimeout "ovftool --overwrite --noSSLVerify --diskMode=${DISKMODE} --datastore=${DATASTORE} --name='${NODE_NAME}-Quanta' --net:'${NIC}=${NODE_NAME}-switch' '${HOME}/isofarm/OVA/vQuanta-T41-Haswell.ova'   vi://${ESXI_USER}:${ESXI_PASS}@${ESXI_HOST}"
   else
     nodesOff
   fi


### PR DESCRIPTION
## 1. Backgroud
There should be 3 vNodes deployed.
But there are only 2 vNodes deployed and the shell step didn't exit with error code.

`Error: Duplicate name 'vmslave16-Rinjin1' on target. Use --overwrite option to delete it.
Completed with errors`

Why do the jenkins can not capture the ERROR ? 

## 2.  Analysis
The key cause is the command: "expect" in the method `execWithTimeout() ` of `shareMethod.sh`.
`expect -c 'set timeout 90; spawn -noecho /bin/sh -c "ovftool --noSSLVerify --diskMode= --datastore=Isilon-Cluster-NFS  --name='\''vmslave16-Rinjin1'\'' --net:'\''Mgmt - longej=vmslave16-switch'\'' '\''/home/****/isofarm/OVA/vRinjin-Haswell.ova'\''   vi://****:****@10.240.19.230"; expect timeout { exit 1 } eof { exit 0 }'`

- if `ovftool` executes timeout, return 1.
- if `ovftool` occurrs other error, such as "Duplicate name 'vmslave16-Rinjin1' on target.", the command expect returns 0. Therefore the Jenkins can not capture this error.(That is unexpected.)

Generally, the normal behavior of `execWithTimeout()` is
- if `ovftool` executes timeout, return 1.
- else return  what the `ovftool` returns.

@PengTian0 @PengTian0 @anhou @iceiilin @changev 