### PR TITLE
bugfix: failed to archive ova post smoke test log when test failed

### DIFF
--- a/test.sh.in
+++ b/test.sh.in
@@ -329,12 +329,10 @@ exportLog(){
     nodesOn &
 
     # signal handler
-    trap fetchOVALog SIGINT SIGTERM SIGKILL EXIT
+    trap "deactivate && fetchOVALog" SIGINT SIGTERM SIGKILL EXIT
 
     # Run tests
     runTests
-    # exit venv
-    deactivate
 
     # Clean Up below
 


### PR DESCRIPTION
venv contains its own ansible.

When test failed, the the trag fetchOVA log is trigger but deactive won't be executed.
So ansible scripts in fetchOVA will fail.

@panpan0000 @PengTian0 