### PR TITLE
rac-5423- Add OS_INSTALL tag with new parallel bootstrap test.

### DIFF
--- a/jobs/FunctionTest/FunctionTest.groovy
+++ b/jobs/FunctionTest/FunctionTest.groovy
@@ -3,7 +3,9 @@ import groovy.transform.Field;
 // The default test config: ALL_TESTS (a global variable)
 @Field def ALL_TESTS = [:]
 ALL_TESTS["FIT"]=["TEST_GROUP":"-test tests -group smoke","label":"smoke_test", "EXTRA_HW":""]
-ALL_TESTS["Install Ubuntu 14.04"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_ubuntu14.04_minimum.json","label":"os_install", "EXTRA_HW":""]
+ALL_TESTS["OS_INSTALL"]=["TEST_GROUP":"-test tests/bootstrap/pr_gate_os_install.py","label":"os_install", "EXTRA_HW":""]
+ALL_TESTS["Install Ubuntu 14.04"]=["TEST_GROUP":"-test tests/bootstrap/pr_gate_os_install.py","label":"os_install", "EXTRA_HW":""]
+// ALL_TESTS["Install Ubuntu 14.04"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_ubuntu14.04_minimum.json","label":"os_install", "EXTRA_HW":""]
 ALL_TESTS["Install ESXI 6.0"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_esxi_bootstrap.py -extra install_esxi6.0_minimum.json","label":"os_install", "EXTRA_HW":""]
 ALL_TESTS["Install Centos 6.5"]=["TEST_GROUP":"-test tests/bootstrap/test_api20_linux_bootstrap.py -extra install_centos65_minimum.json","label":"os_install", "EXTRA_HW":""]
 


### PR DESCRIPTION
use the pr_gate_os_install.py test for performing os-install.
The script will run three os-install tests to three virtual nodes that were set up in the pipelines.
Setting the 'ubuntu' os-install test to call this script temporarily to check pipelines.