### PR TITLE
restore apiServerPort back to 9080 to use on-http southbound interface

### DIFF
--- a/jobs/pr_gate/docker/monorail/config.json
+++ b/jobs/pr_gate/docker/monorail/config.json
@@ -2,7 +2,7 @@
     "CIDRNet": "172.31.128.0/22",
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "broadcastaddr": "172.31.131.255",
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",

--- a/vagrant/config/mongo/config.json
+++ b/vagrant/config/mongo/config.json
@@ -2,7 +2,7 @@
     "CIDRNet": "172.31.128.0/22",
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "broadcastaddr": "172.31.131.255",
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",

--- a/vagrant/config/mongo/monorail.json
+++ b/vagrant/config/mongo/monorail.json
@@ -2,7 +2,7 @@
     "CIDRNet": "172.31.128.0/22",
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "broadcastaddr": "172.31.131.255",
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",
@@ -33,7 +33,7 @@
             "port": 9080,
             "httpsEnabled": false,
             "proxiesEnabled": true,
-            "authEnabled": false
+            "authEnabled": false,
             "routers": "southbound-api-router"
         }
     ],

--- a/vagrant/config/postgresql/config.json
+++ b/vagrant/config/postgresql/config.json
@@ -2,7 +2,7 @@
     "CIDRNet": "172.31.128.0/22",
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "broadcastaddr": "172.31.131.255",
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",
@@ -33,7 +33,7 @@
             "port": 9080,
             "httpsEnabled": false,
             "proxiesEnabled": true,
-            "authEnabled": false
+            "authEnabled": false,
             "routers": "southbound-api-router"
         }
     ],

--- a/vagrant/config/postgresql/monorail.json
+++ b/vagrant/config/postgresql/monorail.json
@@ -2,7 +2,7 @@
     "CIDRNet": "172.31.128.0/22",
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "broadcastaddr": "172.31.131.255",
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",
@@ -33,7 +33,7 @@
             "port": 9080,
             "httpsEnabled": false,
             "proxiesEnabled": true,
-            "authEnabled": false
+            "authEnabled": false,
             "routers": "southbound-api-router"
         }
     ],


### PR DESCRIPTION
This PR will switch the apiiServerPort back to 9080, which is the southbound port for on-http. 
@RackHD/committers 