### PR TITLE
Refine Manifest: checkoutTargetRepo()

### DIFF
--- a/src/pipeline/rackhd/source_code/FunctionTest.groovy
+++ b/src/pipeline/rackhd/source_code/FunctionTest.groovy
@@ -44,7 +44,7 @@ def runTest(String stack_type, String test_name, ArrayList<String> used_resource
                 String library_dir = "$WORKSPACE/on-build-config"
                 String rackhd_dir = "$WORKSPACE/RackHD"
                 share_method.checkoutOnBuildConfig(library_dir)
-                manifest.checkoutTargetRepo(library_dir, manifest_path, "RackHD", rackhd_dir)
+                manifest.checkoutTargetRepo( manifest_path, "RackHD", rackhd_dir, library_dir)
                 boolean ignore_failure = false
                 String target_dir = test_target + "/" + test_name + "[$NODE_NAME]"
                 try{

--- a/src/pipeline/rackhd/source_code/UnitTest.groovy
+++ b/src/pipeline/rackhd/source_code/UnitTest.groovy
@@ -56,7 +56,7 @@ def runTest(String repo_name, Map manifest_dict, ArrayList<String> used_resource
                 share_method.checkoutOnBuildConfig(library_dir)
                 String manifest_path = manifest.unstashManifest(manifest_dict, "$WORKSPACE")
                 String repo_dir = "$WORKSPACE/$repo_name"
-                manifest.checkoutTargetRepo(library_dir, manifest_path, repo_name, repo_dir)
+                manifest.checkoutTargetRepo( manifest_path, repo_name, repo_dir, library_dir)
                 if(with_sudo){
                     testWithSudo(repo_name, repo_dir)
                 } else {


### PR DESCRIPTION
1. for checkoutTargetRepo()  the parameter ```target_dir``` should be the same level like on-http, instead of upper folder.
2. update the invoking of Manifest class about the interface changes

Unit-tested: http://10.62.**.**5:8080/job/test_manifest/92

Reviewer:
@PengTian0 