### PR TITLE
RAC-4023: Using DEBIAN_REPOSITORY parameter to pass in the deb repo to packer ansible

### DIFF
--- a/jobs/build_ova/build_ova.sh
+++ b/jobs/build_ova/build_ova.sh
@@ -22,10 +22,6 @@ if   ! check_empty_variable "STAGE_REPO_NAME" ||  ! check_empty_variable "DEB_DI
 fi
 
 
-pushd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
-sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
-sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
-popd
 
 echo "kill previous running packer instances"
 
@@ -39,11 +35,10 @@ echo "Start to packer build .."
 
 export PACKER_CACHE_DIR=$HOME/.packer_cache
 #export vars to build ova
-if [ "${IS_OFFICIAL_RELEASE}" == true ]; then
-    export ANSIBLE_PLAYBOOK=rackhd_release
-else
-    export ANSIBLE_PLAYBOOK=rackhd_ci_builds
-fi
+
+export ANSIBLE_PLAYBOOK=rackhd_package #build image from deb package
+# Using Artifactory as the debian repository instead of Bintray
+export DEBIAN_REPOSITORY="deb ${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}"
 
 if [ "$BUILD_TYPE" == "vmware" ] &&  [ -f output-vmware-iso/*.vmx ]; then
      echo "Build from template cache"
@@ -54,6 +49,7 @@ else
 fi
 
 export RACKHD_VERSION=$RACKHD_VERSION
+
 #export end
 
 ./HWIMO-BUILD

--- a/jobs/build_vagrant/build_vagrant.sh
+++ b/jobs/build_vagrant/build_vagrant.sh
@@ -42,10 +42,6 @@ if   ! check_empty_variable "STAGE_REPO_NAME" ||  ! check_empty_variable "DEB_DI
 fi
 
 
-pushd $WORKSPACE/build/packer/ansible/roles/rackhd-builds/tasks
-sed -i "s#https://dl.bintray.com/rackhd/debian trusty release#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
-sed -i "s#https://dl.bintray.com/rackhd/debian trusty main#${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}#" main.yml
-popd
 
 cleanup # clean up previous dirty env
 
@@ -62,11 +58,11 @@ fi
 
 export PACKER_CACHE_DIR=$HOME/.packer_cache
 
-if [ "${IS_OFFICIAL_RELEASE}" == "true" ]; then
-    export ANSIBLE_PLAYBOOK=rackhd_release
-else
-    export ANSIBLE_PLAYBOOK=rackhd_ci_builds
-fi
+export ANSIBLE_PLAYBOOK=rackhd_package #build image from deb package
+
+# Using Artifactory as the debian repository instead of Bintray
+export DEBIAN_REPOSITORY="deb ${ARTIFACTORY_URL}/${STAGE_REPO_NAME} ${DEB_DISTRIBUTION} ${DEB_COMPONENT}"
+
 export UPLOAD_BOX_TO_ATLAS=false
 export RACKHD_VERSION=$RACKHD_VERSION
 #export end


### PR DESCRIPTION
Jenkins: depends on https://github.com/RackHD/RackHD/pull/875

background:

previously, we use IS_OFFICIAL_RELEASE as an interface to talk with packer scripts, and use duplicated rackhd_release.yml and rackhd_ci_build.yml.and in CI script, we will have to use ```sed``` to replace the bintray source to artifactory source.


Now , we directly make the debian source as a configuable parameter of the packer ansibles.  and in ci script. we just pass in the deb source as the param. (```DEBIAN_REPOSITORY```)


FAQ:
removing the "IS_OFFICIAL_RELEASE" ? I don't want to bother the effort. because @PengTian0  and @changev  will re-write the build_ova.sh build_vagrant.sh and replace those old scripts very soon.


testing:
done by unit-test like 
```IS_OFFICIAL_RELEASE=false OS_VER=ubuntu-14.04 ARTIFACTORY_URL=http://afeossand1.cec.lab.emc.com/artifactory/rackhd-staging STAGE_REPO_NAME=rackhd-staging BUILD_TYPE=virtualbox DEB_COMPONENT=staging DEB_DISTRIBUTION=trusty WORKSPACE=/tmp ./on-build-config/jobs/build_vagrant/build_vagrant.sh```




![image](https://user-images.githubusercontent.com/14049268/29812940-f1819a60-8cda-11e7-831e-775a7c3528f3.png)
