### PR TITLE
Skip-CI: remove on-build-config from PR Gate Manifest

### DIFF
--- a/build-release-tools/lib/manifest-pr-gate.json
+++ b/build-release-tools/lib/manifest-pr-gate.json
@@ -47,12 +47,6 @@
             "branch": "", 
             "commit-id": "",
             "repository": "https://github.com/RackHD/RackHD.git"
-        }, 
-        {
-            "branch": "", 
-            "commit-id": "",
-            "repository": "https://github.com/RackHD/on-build-config.git"
-        }
-
+        } 
     ]
 }


### PR DESCRIPTION
prepare for the migration to EOS Github.

@PengTian0 @changev 